### PR TITLE
Fix for #175

### DIFF
--- a/web-app/js/portal/ui/MapPanel.js
+++ b/web-app/js/portal/ui/MapPanel.js
@@ -153,9 +153,21 @@ Portal.ui.MapPanel = Ext.extend(Portal.common.MapPanel, {
     },
 
     _closeFeatureInfoPopup:function () {
-        if (this.featureInfoPopup) {
-            this.featureInfoPopup.close();
+        /**
+         * https://github.com/aodn/aodn-portal/issues/175
+         *
+         * This appears to have existed forever in IE, it basically comes down to Shadow.realign in Ext where the
+         * height value is determined as -1 which is invalid. At no point do we set the height to -1 so I assume that
+         * IE does this when the FeatureInfoPopup is hidden from view or something else crazy. I _hope_ that the popup
+         * is still destroyed effectively, it all seems to still work. I'm happy for someone else to find a better
+         * solution, I take no pride in this fix whatsoever.
+         */
+        try {
+            if (this.featureInfoPopup) {
+                this.featureInfoPopup.close();
+            }
         }
+        catch (e) {}
     },
 
     _findFeatureInfo:function (event) {


### PR DESCRIPTION
Doesn't feel like the tidiest solution, for some reason on the call to the feature info popup close
the Shadow.js code gets -1 as a value for the adjusts height in the popup which is an invalid value.
I couldn't trace where that value has come from as we certainly don't set it, catching the exception
appears to allow everything to work, am more than happy for someone to improve this solution!
