### PR TITLE
Added try/catch block for annoying/meaningless exception thrown by grail...

### DIFF
--- a/grails-app/domain/au/org/emii/portal/Menu.groovy
+++ b/grails-app/domain/au/org/emii/portal/Menu.groovy
@@ -142,8 +142,15 @@ class Menu {
 	}
 
 	def _cache(theCache, displayableMenu) {
-		theCache.add(displayableMenu, JSON.use(JsonMarshallingRegistrar.MENU_PRESENTER_MARSHALLING_CONFIG) {
-			displayableMenu as JSON
-		}.toString())
+        try {
+            theCache.add(displayableMenu, JSON.use(JsonMarshallingRegistrar.MENU_PRESENTER_MARSHALLING_CONFIG) {
+                displayableMenu as JSON
+            }.toString())
+        }
+        catch(java.lang.NoSuchFieldException e){
+            //NoSuchFieldException getting thrown is a known problem with grails 1.3.7
+            //try/catch block added so we don't have meaningless exceptions in our logs
+            //see http://stackoverflow.com/questions/14510805/grails-1-3-7-java-7-compatibility
+        }
 	}
 }


### PR DESCRIPTION
Currently we get a stacktrace thrown at us in the catalina logs whenever we run up a portal:
 "Unable to use direct char[] access of java.lang.String
 java.lang.NoSuchFieldException: count "

 This is a known grails issue, that doesn't affect any functionality, see here:

http://stackoverflow.com/questions/14510805/grails-1-3-7-jav…

 I''ve wacked a try/empy catch around the code which causes this so our logs are a bit cleaner (with a comment explaining why we resorted to this bad practice)
