### PR TITLE
Indicating that exception is being explicitly ignored

### DIFF
--- a/web-app/js/portal/ui/MapPanel.js
+++ b/web-app/js/portal/ui/MapPanel.js
@@ -153,21 +153,24 @@ Portal.ui.MapPanel = Ext.extend(Portal.common.MapPanel, {
     },
 
     _closeFeatureInfoPopup:function () {
-        /**
-         * https://github.com/aodn/aodn-portal/issues/175
-         *
-         * This appears to have existed forever in IE, it basically comes down to Shadow.realign in Ext where the
-         * height value is determined as -1 which is invalid. At no point do we set the height to -1 so I assume that
-         * IE does this when the FeatureInfoPopup is hidden from view or something else crazy. I _hope_ that the popup
-         * is still destroyed effectively, it all seems to still work. I'm happy for someone else to find a better
-         * solution, I take no pride in this fix whatsoever.
-         */
         try {
             if (this.featureInfoPopup) {
                 this.featureInfoPopup.close();
             }
         }
-        catch (e) {}
+        catch (e) {
+            /**
+             * Explicitly ignoring exception
+             *
+             * https://github.com/aodn/aodn-portal/issues/175
+             *
+             * This appears to have existed forever in IE, it basically comes down to Shadow.realign in Ext where the
+             * height value is determined as -1 which is invalid. At no point do we set the height to -1 so I assume that
+             * IE does this when the FeatureInfoPopup is hidden from view or something else crazy. I _hope_ that the popup
+             * is still destroyed effectively, it all seems to still work. I'm happy for someone else to find a better
+             * solution, I take no pride in this fix whatsoever.
+             */
+        }
     },
 
     _findFeatureInfo:function (event) {


### PR DESCRIPTION
As per feedback here
[32c6dfc](https://github.com/aodn/aodn-portal/commit/32c6dfcb35cdac63683b8f2cc754bd53302f167e#commitcomment-3355522)
the comment has been moved to indicate that the exception is intentionally being ignored.
