### PR TITLE
#186 - DateTime attributes not available to add as filters after WFS har...

### DIFF
--- a/test/unit/au/org/emii/portal/FilterTypeTests.groovy
+++ b/test/unit/au/org/emii/portal/FilterTypeTests.groovy
@@ -24,11 +24,6 @@ class FilterTypeTests extends GrailsUnitTestCase {
 		super.tearDown()
 	}
 
-	void testDateTimeString() {
-		
-		assertEquals FilterType.Date, typeFromString( "DateTime" )
-	}
-
 	void testTypeFromString() {
 
 		FilterType.stringTypeMapping = [ "monkey": FilterType.Number ]
@@ -38,5 +33,4 @@ class FilterTypeTests extends GrailsUnitTestCase {
 		assertEquals FilterType.Number, typeFromString( "MONKEY" )
 		assertEquals null, typeFromString( "orangutan" )
 	}
-	
 }


### PR DESCRIPTION
...vest.

Wasn't added as there was no associated filter type for this type of attribute. 

Use a Date filter for DateTime attributes.
