### PR TITLE
Try/catch block didn't fix the NoSuchFieldException

### DIFF
--- a/grails-app/domain/au/org/emii/portal/Menu.groovy
+++ b/grails-app/domain/au/org/emii/portal/Menu.groovy
@@ -157,17 +157,11 @@ class Menu {
 	}
 
 	def _cache(theCache, displayableMenu) {
-        //NoSuchFieldException getting thrown is a known problem with grails 1.3.7
-        //it's caused by the use of a grails hack which trys to access no existent String properties
-        //There for disable the hack beforehand and reenable after.
-        //see http://stackoverflow.com/questions/14510805/grails-1-3-7-java-7-compatibility
-        //and http://grails.org/doc/1.1.1/api/org/codehaus/groovy/grails/web/util/StringCharArrayAccessor.html
-        System.setProperty("stringchararrayaccessor.disabled", "true")
 
-        theCache.add(displayableMenu, JSON.use(JsonMarshallingRegistrar.MENU_PRESENTER_MARSHALLING_CONFIG) {
-            displayableMenu as JSON
-        }.toString())
-
-        System.setProperty("stringchararrayaccessor.disabled", "false")
+        StringCharArrayFixer.run {
+            theCache.add(displayableMenu, JSON.use(JsonMarshallingRegistrar.MENU_PRESENTER_MARSHALLING_CONFIG) {
+                displayableMenu as JSON
+            }.toString())
+        }
 	}
 }

--- a/src/groovy/au/org/emii/portal/StringCharArrayFixer.groovy
+++ b/src/groovy/au/org/emii/portal/StringCharArrayFixer.groovy
@@ -1,0 +1,27 @@
+
+/*
+ * Copyright 2013 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+
+package au.org.emii.portal
+
+class StringCharArrayFixer {
+
+    static void run(toExecute) {
+
+        // NoSuchFieldException getting thrown is a known problem with grails 1.3.7
+        // it's caused by the use of a grails hack which trys to access no existent String properties
+        // Therefore disable the hack beforehand and reenable after.
+        // see http://stackoverflow.com/questions/14510805/grails-1-3-7-java-7-compatibility
+        // and http://grails.org/doc/1.1.1/api/org/codehaus/groovy/grails/web/util/StringCharArrayAccessor.html
+
+        System.setProperty("stringchararrayaccessor.disabled", "true")
+
+        toExecute()
+
+        System.setProperty("stringchararrayaccessor.disabled", "false")
+    }
+}


### PR DESCRIPTION
 because it was already being caught further down stack and having a stacktrace printed.  Instead disable the Grails feature/hack which is causing the problem.  (although reenable it after, because it presumably increases the efficiency of string operations in cases where this problem isn't occurring)
