### PR TITLE
Upgraded to jasmine-maven 1.3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,7 +364,7 @@
 			<plugin>
 				<groupId>com.github.searls</groupId>
 				<artifactId>jasmine-maven-plugin</artifactId>
-				<version>1.0.2-beta-5</version>
+				<version>1.3.1.2</version>
 				<executions>
 					<execution>
 						<goals>
@@ -374,7 +374,6 @@
 				</executions>
 				<configuration>
 					<jsSrcDir>${project.basedir}/web-app/js</jsSrcDir>
-					<browserVersion>INTERNET_EXPLORER_8</browserVersion>
 					<sourceIncludes>
 						<include>jquery/jquery-1.4.1.min.js</include>
 						<include>jquery/jquery-autocomplete1.1.js</include>


### PR DESCRIPTION
This is an upgrade to the lastest jasmine-maven plugin, which happily fixes the travis build.
