### PR TITLE
fixed #213

### DIFF
--- a/web-app/js/portal/details/AnimationControlsPanel.js
+++ b/web-app/js/portal/details/AnimationControlsPanel.js
@@ -658,8 +658,6 @@ Portal.details.AnimationControlsPanel = Ext.extend(Ext.Panel, {
 	},
 
 	_loadAnimation : function(ctx, dimSplit, startIndex, endIndex) {
-		console.log("Loading animation");
-
 		ctx.originalLayer.chosenTimes = dimSplit[startIndex] + "/"
 				+ dimSplit[endIndex];
 


### PR DESCRIPTION
processDates function took too long to process as it might have had close to 20,000 items sometimes.

The solution was to run this function in an async closure in a chunked way, letting the browser take control every 1024 items (can be easily changed). The result is slightly slower processing time, but also getting rid of the annoying popup saying a js script took too long to run
