### PR TITLE
Issue #278.

### DIFF
--- a/web-app/js/portal/search/SearchForm.js
+++ b/web-app/js/portal/search/SearchForm.js
@@ -81,11 +81,9 @@ Portal.search.SearchForm = Ext.extend(Ext.FormPanel, {
     this.enableBubble('contentchange');
 
     this.mon(this.searchButton, 'click', this.onSearch, this);
-    this.mon(this.searchFiltersPanel, 'contentchange', this.refreshDisplay, this);
     
     this.mon(this.searchController, 'newsearch', this.handleNewSearch, this);
-    
-    this.on('activate', this.refreshDisplay, this);    
+ 
   },
 
   setExtent: function(bounds) {
@@ -98,14 +96,6 @@ Portal.search.SearchForm = Ext.extend(Ext.FormPanel, {
     }      
   },
   
-  refreshDisplay: function() {
-
-    this.doLayout();
-//  this.syncSize();
-    // let parent components know that the size of this component may have changed!
-    this.fireEvent('contentchange');
-  },
-
   afterRender: function() {
     Portal.search.SearchForm.superclass.afterRender.call(this);
 

--- a/web-app/js/portal/search/SearchTabPanel.js
+++ b/web-app/js/portal/search/SearchTabPanel.js
@@ -129,21 +129,6 @@ Portal.search.SearchTabPanel = Ext.extend(Ext.Panel, {
 			showlayer: this.onShowLayer
 		});
 
-		// set size of search form based on its content when its content is created and/or
-		// changed or the region containing the search is resized
-		// Ext isn't good at handling panels resizing based on content and scroll bars
-
-		this.mon(this.searchContainer, {
-			scope: this,
-			resize: this.setSearchContainerHeight
-		});
-
-		this.mon(this.searchForm, {
-			scope: this,
-			contentchange: this.setSearchContainerHeight,
-			afterrender: this.setSearchContainerHeight
-		});
-
 		this.mon(this.searchController, 'newsearch', this.handleNewSearch, this);
 	},
 
@@ -169,16 +154,6 @@ Portal.search.SearchTabPanel = Ext.extend(Ext.Panel, {
 	  this._changingBounds = true;
 	  this.minimap.setBounds(bounds);
 	  delete this._changingBounds;
-	},
-
-	setSearchContainerHeight: function() {
-		// wait a bit for new sizes to be reflected (there's no consistent
-		// resize event on elements across browsers or provided by Ext!)
-		this.setSearchContainerHeightDeferred.defer(50, this);
-	},
-
-	setSearchContainerHeightDeferred: function() {
-		this.searchPanel.doLayout();
 	},
 
 	resultsGridBbarBeforeChange: function(bbar, params) {

--- a/web-app/js/portal/search/field/MultiSelectCombo.js
+++ b/web-app/js/portal/search/field/MultiSelectCombo.js
@@ -56,7 +56,6 @@ Portal.search.field.MultiSelectCombo = Ext.extend(Ext.ux.form.SuperBoxSelect, {
       	  additem: this.onItemChange,
       	  removeitem: this.onItemChange,
       	  clear: this.onItemChange,
-      	  resize: this.handleResize
       });
       
       this.addEvents('contentchange');
@@ -94,14 +93,7 @@ Portal.search.field.MultiSelectCombo = Ext.extend(Ext.ux.form.SuperBoxSelect, {
    	this.fireEvent('contentchange');
    },
    
-   handleResize: function() {
-     // A resize may result in selected items being wrapped 
-     // increasing the size of the component!
-     // Handle this by signaling that parent containers should adjust for 
-     // a change in content after this sequence of resize events has finished
-     this.fireEvent.defer(50,this,['contentchange']);
-   },
-   
+  
    proxyBeforeLoad: function(proxy, params) {
   	
    	var protocolString = "";


### PR DESCRIPTION
This issue occurs in Chrome. doLayout was getting called repeatedly, sometimes with a 50ms delay. Removing the extra doLayouts fixes the issue. It seems to re-size just fine without them.
