### PR TITLE
Fix a bug that prevents basic authentication working.

### DIFF
--- a/src/test/javascript/portal/prototypes/OpenLayersSpec.js
+++ b/src/test/javascript/portal/prototypes/OpenLayersSpec.js
@@ -53,4 +53,24 @@ describe("OpenLayers.Layer.WMS", function() {
             expect(openLayer._is130()).toBeTruthy();
         });
     });
+    
+    describe("proxy", function() {
+        it("appends an ampersand to url when uri includes a question mark", function() {
+        	openLayer.server= {username: "user", password: "pass", uri:"http://geoserver.uni.edu.au/geoserver/wms?namespace=org"};
+            openLayer.proxy("proxy?url=");
+            expect (openLayer.url).toEqual("proxy?url=http://geoserver.uni.edu.au/geoserver/wms?namespace=org&");
+            expect (openLayer.localProxy).toEqual("proxy?url=");
+        });
+    });
+    
+    describe("proxy", function() {
+        it("appends a question mark to url when uri doesn't include one", function() {
+        	openLayer.server= {username: "user", password: "pass", uri:"http://geoserver.uni.edu.au/geoserver/wms"};
+            openLayer.proxy("proxy?url=");
+            expect (openLayer.url).toEqual("proxy?url=http://geoserver.uni.edu.au/geoserver/wms?");
+            expect (openLayer.localProxy).toEqual("proxy?url=");
+        });
+    });
+
+
 });

--- a/web-app/js/portal/prototypes/OpenLayers.js
+++ b/web-app/js/portal/prototypes/OpenLayers.js
@@ -101,7 +101,8 @@ OpenLayers.Layer.WMS.prototype.getMetadataUrl = function () {
 
 OpenLayers.Layer.WMS.prototype.proxy = function (proxy) {
     if (this.server.username && this.server.password && !this.localProxy) {
-        this.server.uri = proxy + this.server.uri + "?";
+    	var separator = (this.server.uri.indexOf("\?") !== -1) ? "&" : "?";
+        this.server.uri = proxy + this.server.uri + separator;   
         this.url = this.server.uri;
         this.localProxy = proxy;
     }


### PR DESCRIPTION
This bug was causing a second ? in the url - where there should have been an ampersand.  Occurs, for example, on servers that include a namespace.  Needs to be merged into the current prod portals as well as 1-2-3
