### PR TITLE
If a data collection covers the whole world the micro map in the search

### DIFF
--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -173,11 +173,11 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         };
 
         function _centerLonLat(map, bounds) {
-        	var centerLonLat = bounds.getCenterLonLat();
-        	if (map.getZoomForExtent(bounds) == 0) {
-         		centerLonLat.lon = LONGITUDE_OF_AUSTRALIA;
-        	}
-        	return centerLonLat;
+            var centerLonLat = bounds.getCenterLonLat();
+            if (map.getZoomForExtent(bounds) == 0) {
+                centerLonLat.lon = LONGITUDE_OF_AUSTRALIA;
+            }
+            return centerLonLat;
         };
   
         var componentId = Ext.id();
@@ -198,10 +198,10 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
             map.render("fsSearchMap" + values.uuid);
          
             if (metadataExtent.getBounds()) {
-            	map.setCenter(
-            		    _centerLonLat(map, metadataExtent.getBounds()),
-            		    _zoomLevel(map, metadataExtent.getBounds())
-            		);
+                map.setCenter(
+                    _centerLonLat(map, metadataExtent.getBounds()),
+                    _zoomLevel(map, metadataExtent.getBounds())
+                );
             }
             else {
                 map.zoomToExtent( new  OpenLayers.Bounds.fromString(Portal.app.config.defaultDatelineZoomBbox));


### PR DESCRIPTION
results will only show a portion of the world because the zoom level is
set to 1 in these cases.  This change positions the micro-map for
whole-of-world views so that it at least shows Australia and the
surrounding areas.
