### PR TITLE
moved all labels to lang/en.js

### DIFF
--- a/web-app/js/portal/cart/DownloadPanel.js
+++ b/web-app/js/portal/cart/DownloadPanel.js
@@ -11,7 +11,7 @@ Portal.cart.DownloadPanel = Ext.extend(Ext.Panel, {
     initComponent: function(cfg) {
 
         var config = Ext.apply({
-            title: 'Data Download Tools',
+            title: OpenLayers.i18n('dataDownloadTools'),
             headerCfg: {
                 cls: 'x-panel-header p-header-space'
             },

--- a/web-app/js/portal/details/AnimationControlsPanel.js
+++ b/web-app/js/portal/details/AnimationControlsPanel.js
@@ -69,7 +69,7 @@ Portal.details.AnimationControlsPanel = Ext.extend(Ext.Panel, {
         });
 
         this.label = new Ext.form.Label({
-            html : "<h4>Select Time Period</h4>"
+            html : "<h4>" + OpenLayers.i18n('selectTimePeriod') + "</h4>"
         });
 
         this.stepSlider = new Portal.visualise.animations.AnimationStepSlider({

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -37,12 +37,35 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     polygonHelp: 'Click to add points. Double click to close polygon.',
     geoSelectionPanelHelp: "Choose a method of defining a bounding area.",
 
-    //DownloadCartPanel.js
+    // DownloadCartPanel.js
     okdownload: 'Download All',
     clearcart: "Clear Cart",
     downloadCartUndo: "Undo Last Remove",
     emptyCartText: "No data collections have been added.",
     unavailableDataLink: "Sorry this data is currently unavailable",
+
+    // DownloadPanel.js
+    dataDownloadTools: 'Data Download Tools',
+
+    // map.js
+    imageScaledDown: 'This image has been scaled down.',
+
+    // DateSelectionPanel.js
+    min: 'Min',
+    max: 'Max',
+
+    // FacetedSearchResultsDataView.js
+    platform: 'Platform',
+    organisation: 'Organisation',
+    dateRange: 'Date Range',
+    parameters: 'Parameters',
+
+    // LayerGridPanel.js
+    dragLayersOrServers: 'Drag layers or Servers to the menu tree',
+
+    // MapOptions
+    panControl: 'Pan Control',
+    zoomAndCentre: 'Zoom and centre [shift + mouse drag]',
 
     // Animation Panel
     stop: 'Stop',
@@ -57,13 +80,10 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     slowDown: "Halves animation speed",
     clearButton_tip: "Stops animation and remove all animated data collections from the map",
     pauseButton_tip: "Pauses animation and can explore individual time step using the slider above",
+    selectTimePeriod: 'Select Time Period',
 
     // Map.js
     controlButton_4AnimationControlsPanel: 'Animation Options',
-
-    // MapOptionsPanel.js
-    mapOptionsResetButton: 'This will remove all data collections from the portal, reset the map location and zoom level',
-    mapOptionsRemoveLayersButton: "Remove all data collections from the map and download pages",
 
     // Search results
     descHeading: 'Description',
@@ -136,7 +156,7 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     loadingMessage: 'Loading ...',
     noMetadataMessage: 'No information available at this time.',
 
-    //snapshots
+    // Snapshots
     saveMapButton: 'Save Map',
     saveMapButtonTip: 'Save the current state of the map',
     saveSnapshotDialogTitle: 'Save Map',
@@ -150,6 +170,8 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     shareSnapshot: 'Share',
     shareMapDialogTitle: 'Share Map',
     shareSnapshotTip: 'Share a saved map',
+    savedMap: 'Saved Map',
+    mapUnavailable: 'The map you are attempting to view is not available.',
 
     // Faceted layer search
     searchTabTitle: 'Search',
@@ -174,6 +196,8 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     clearAllButtonLabel: 'Clear all',
     removeAllControlLabel: 'Remove all data collections',
     resetMapControlLabel: 'Reset map',
+    mapOptionsResetButton: 'This will remove all data collections from the portal, reset the map location and zoom level',
+    mapOptionsRemoveLayersButton: "Remove all data collections from the map and download pages",
 
     //FilterPanel.js
     filterPanelTitle: 'Subset',
@@ -210,6 +234,9 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     noDataCollectionSelected: 'No data collection selected.',
     featureInformationFoundForDataCollection: "Feature information found for ${dataCollectionNumber} data collection(s)",
     noFeatureInformationFoundForDataCollection: "No feature information found for ${dataCollectionNumber} queryable data collection(s)",
+    searchingForFeatures: 'Searching for Features at your click point',
+    depth: 'Depth',
+    elevation: 'Elevation',
 
     // ActiveLayersTreeNodeUI.js
     removeDataCollection: 'Remove data collection',

--- a/web-app/js/portal/mainMap/map.js
+++ b/web-app/js/portal/mainMap/map.js
@@ -99,12 +99,11 @@ function imgSizer(){
             }, 'slow').width(new_height);
 
             $(this).hover(function(){
-                $(this).attr("title", "This image has been scaled down.");
-                //$(this).css("cursor","pointer");
+                $(this).attr("title", OpenLayers.i18n('imageScaledDown'));
             });
 
-        } //ends if statement
-    }); //ends each function
+        }
+    });
 }
 
 

--- a/web-app/js/portal/search/DateSelectionPanel.js
+++ b/web-app/js/portal/search/DateSelectionPanel.js
@@ -56,8 +56,8 @@ Portal.search.DateSelectionPanel = Ext.extend(Ext.Panel, {
         this.searcher.removeFilters("extFrom");
         this.searcher.removeFilters("extTo");
 
-        var titleFrom = "Min";
-        var titleTo = "Max";
+        var titleFrom = OpenLayers.i18n('min');
+        var titleTo   = OpenLayers.i18n('max');
 
         if (range.fromDate !== "")
         {

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -80,7 +80,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
     _getOrganisationAsHtml: function(template, organisation) {
         if (organisation) {
             return template.apply({
-                "label": "Organisation",
+                "label": OpenLayers.i18n('organisation'),
                 "value": organisation
             });
         }
@@ -91,7 +91,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
     _getPlatformAsHtml: function(template, platform) {
         if (platform) {
             return template.apply({
-                "label": "Platform",
+                "label": OpenLayers.i18n('platform'),
                 "value": platform
             });
         }
@@ -102,7 +102,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
     _getTemporalExtentAsHtml: function(template, temporalExtent) {
         if (temporalExtent.begin && temporalExtent.end) {
             return template.apply({
-                "label": "Date Range",
+                "label": OpenLayers.i18n('dateRange'),
                 "value": moment(temporalExtent.begin).format("YYYY-MM-DD Z")
                          + " - " + moment(temporalExtent.end).format("YYYY-MM-DD Z")
             });
@@ -114,7 +114,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
     _getParametersAsHtml: function(template, parameters) {
         if (parameters.size > 0) {
             return template.apply({
-                "label": "Parameters",
+                "label": OpenLayers.i18n('parameters'),
                 "value": parameters.join(" - ")
             });
         }

--- a/web-app/js/portal/search/RefineSearchPanel.js
+++ b/web-app/js/portal/search/RefineSearchPanel.js
@@ -168,6 +168,3 @@ Portal.search.RefineSearchPanel = Ext.extend(Ext.Panel, {
 
 Ext.reg('portal.search.refinesearchpanel', Portal.search.RefineSearchPanel);
 
-
-
-

--- a/web-app/js/portal/snapshot/SnapshotController.js
+++ b/web-app/js/portal/snapshot/SnapshotController.js
@@ -76,8 +76,8 @@ Portal.snapshot.SnapshotController = Ext.extend(Portal.common.Controller, {
 
     onFailedLoad:function () {
         Ext.MessageBox.show({
-            title:'Saved Map',
-            msg:'The map you are attempting to view is not available.'
+            title: OpenLayers.i18n('savedMap'),
+            msg: OpenLayers.i18n('mapUnavailable')
         });
     },
 

--- a/web-app/js/portal/ui/FeatureInfoPopup.js
+++ b/web-app/js/portal/ui/FeatureInfoPopup.js
@@ -15,7 +15,7 @@ Portal.ui.FeatureInfoPopup = Ext.extend(GeoExt.Popup, {
         this.numGoodResults = 0;
 
         var config = Ext.apply({
-            title: "Searching for Features at your click point",
+            title: OpenLayers.i18n('searchingForFeatures'),
             width: cfg.appConfig.popupWidth,
             height: 80, // set height later when there are results
             maximizable: true,
@@ -301,7 +301,8 @@ Portal.ui.FeatureInfoPopup = Ext.extend(GeoExt.Popup, {
             // Depth service can return 204 but our app changes that to a 200 and pipes down nothing
             if (xmldoc && xmldoc.getElementsByTagName('depth') !== undefined) {
                 var depth = xmldoc.getElementsByTagName('depth')[0].firstChild.nodeValue;
-                var str = (depth <= 0) ?  "Depth:" : "Elevation:";
+                var str = (depth <= 0) ? OpenLayers.i18n('depth') : OpenLayers.i18n('elevation');
+                str += ":"
                 this.popupHtml.update(this.locationString + " " + this._boldify(str) + " " + Math.abs(depth) + "m");
             }
             else {

--- a/web-app/js/portal/ui/LayerGridPanel.js
+++ b/web-app/js/portal/ui/LayerGridPanel.js
@@ -14,7 +14,7 @@ Portal.ui.LayerGridPanel = Ext.extend(Ext.grid.GridPanel, {
 		
 		var store = new Portal.data.LayerDataPanelStore({url: cfg.url});
 		var config = Ext.apply({
-			title: 'Drag layers or Servers to the menu tree',
+			title: OpenLayers.i18n('dragLayersOrServers'),
 	    	height: 500,
 	    	width: 600,
 	    	stripeRows: true,

--- a/web-app/js/portal/ui/TermSelectionPanel.js
+++ b/web-app/js/portal/ui/TermSelectionPanel.js
@@ -20,9 +20,9 @@ Portal.ui.TermSelectionPanel = Ext.extend(Ext.Panel, {
             cfg.separator = "|";
 
         var defaults = {
-            collapsible:true,
-            collapsed:true,
-            titleCollapse:true
+            collapsible: true,
+            collapsed: true,
+            titleCollapse: true
         };
 
         Ext.apply(this, cfg, defaults);

--- a/web-app/js/portal/ui/openlayers/MapOptions.js
+++ b/web-app/js/portal/ui/openlayers/MapOptions.js
@@ -19,11 +19,11 @@ Portal.ui.openlayers.MapOptions = Ext.extend(Object, {
         var container = document.getElementById("navtoolbar");
 
         this.navigation = new OpenLayers.Control.Navigation({
-            title: 'Pan Control'
+            title: OpenLayers.i18n('panControl')
         });
 
         var zoom = new OpenLayers.Control.ZoomBox({
-            title: "Zoom and centre [shift + mouse drag]"
+            title: OpenLayers.i18n('zoomAndCentre')
         });
         var toolPanel = new OpenLayers.Control.Panel({
             defaultControl: this.navigation,


### PR DESCRIPTION
Crushing some entropy, although there was not that much. All labels I could find are now in en.js. If you can find more of these please let me know and I'll move them as well.

Close ticket #481 if you're happy to merge it.
