### PR TITLE
Fix for #540

### DIFF
--- a/src/test/javascript/portal/cart/DownloadPanelTemplateSpec.js
+++ b/src/test/javascript/portal/cart/DownloadPanelTemplateSpec.js
@@ -70,14 +70,15 @@ describe('Portal.cart.DownloadPanelTemplate', function() {
             childTemplate = {
                 applyWithControls: jasmine.createSpy('applyWithControls')
             };
+
+            geoNetworkRecord.wmsLayer = {};
+            geoNetworkRecord.aodaac = {};
+
             spyOn(Portal.cart, 'AodaacDataRowTemplate').andReturn(childTemplate);
             spyOn(Portal.cart, 'WfsDataRowTemplate').andReturn(childTemplate);
         });
 
         it('uses AodaacDataRowTemplate where applicable', function() {
-
-            geoNetworkRecord.wmsLayer = { wfsLayer: undefined };
-            geoNetworkRecord.aodaac = {};
 
             tpl._dataRowTemplate(geoNetworkRecord);
 
@@ -85,10 +86,16 @@ describe('Portal.cart.DownloadPanelTemplate', function() {
             expect(childTemplate.applyWithControls).toHaveBeenCalledWith(geoNetworkRecord);
         });
 
+        it('does not use WfsDataRowTemplate when it is an AODAAC data collection', function() {
+
+            tpl._dataRowTemplate(geoNetworkRecord);
+
+            expect(Portal.cart.WfsDataRowTemplate).not.toHaveBeenCalled();
+        });
+
         it('uses WfsDataRowTemplate where applicable', function() {
 
-            geoNetworkRecord.wmsLayer = { wfsLayer: {} };
-            geoNetworkRecord.aodaac = undefined;
+            geoNetworkRecord.aodaac = null;
 
             tpl._dataRowTemplate(geoNetworkRecord);
 

--- a/web-app/js/portal/cart/DownloadPanelTemplate.js
+++ b/web-app/js/portal/cart/DownloadPanelTemplate.js
@@ -45,12 +45,11 @@ Portal.cart.DownloadPanelTemplate = Ext.extend(Ext.XTemplate, {
     _dataRowTemplate: function(values) {
         var html = '';
 
-        if (values.wmsLayer) {
-            html += new Portal.cart.WfsDataRowTemplate(this).applyWithControls(values);
-        }
-
         if (values.aodaac) {
             html += new Portal.cart.AodaacDataRowTemplate(this).applyWithControls(values);
+        }
+        else if (values.wmsLayer) {
+            html += new Portal.cart.WfsDataRowTemplate(this).applyWithControls(values);
         }
 
         return html;


### PR DESCRIPTION
The `WfsDataRowTemplate` should be displayed if there is an attached WMS layer (regardless of whether there is also an attached WFS layer. The `_getWfsServerUrl` function in the OpenLayers prototype will take care of which layer to use.
