### PR TITLE
Fixes #489 activate a default control on geo facet

### DIFF
--- a/src/test/javascript/portal/search/FacetMapPanelSpec.js
+++ b/src/test/javascript/portal/search/FacetMapPanelSpec.js
@@ -22,6 +22,14 @@ describe("Portal.search.FacetMapPanel", function() {
         it('geofacet map toolbar', function() {
             expect(facetMapPanel.map.controls[1]).toBeInstanceOf(Portal.search.GeoFacetMapToolbar);
         });
+
+        it('activates the geo facet map toolbar default control', function() {
+            spyOn(Portal.search.GeoFacetMapToolbar.prototype, 'activateDefaultControl');
+            var panel = new Portal.search.FacetMapPanel({
+                initialBbox: '1, 2, 3, 4'
+            });
+            expect(Portal.search.GeoFacetMapToolbar.prototype.activateDefaultControl).toHaveBeenCalled();
+        });
     });
 
     describe('getBoundingPolygonAsWKT', function() {

--- a/web-app/js/portal/search/FacetMapPanel.js
+++ b/web-app/js/portal/search/FacetMapPanel.js
@@ -21,11 +21,12 @@ Portal.search.FacetMapPanel = Ext.extend(Portal.search.CloneMapPanel, {
             this.fireEvent('polygonadded', this.getCurrentFeature());
         });
 
+        this.geoFacetMapToolbar = new Portal.search.GeoFacetMapToolbar(this.polygonVector);
         var config = Ext.apply({
             mapConfig: {
                 controls: [
                     new OpenLayers.Control.ZoomPanel(),
-                    new Portal.search.GeoFacetMapToolbar(this.polygonVector)
+                    this.geoFacetMapToolbar
                 ],
                 resolutions: this.RESOLUTIONS
             }
@@ -44,6 +45,7 @@ Portal.search.FacetMapPanel = Ext.extend(Portal.search.CloneMapPanel, {
         this.map.addLayer(this.polygonVector);
         // Otherwise we end up off the west coast of Africa
         this.zoomToInitialBbox();
+        this.geoFacetMapToolbar.activateDefaultControl();
     },
 
     getCurrentFeature: function () {

--- a/web-app/js/portal/search/GeoFacetMapToolbar.js
+++ b/web-app/js/portal/search/GeoFacetMapToolbar.js
@@ -24,16 +24,21 @@ Portal.search.GeoFacetMapToolbar = OpenLayers.Class(OpenLayers.Control.Panel, {
 
         OpenLayers.Control.Panel.prototype.initialize.apply(this, [options]);
 
+        this.polygonDrawControl = new OpenLayers.Control.DrawFeature(
+            layer,
+            OpenLayers.Handler.Polygon,
+            {
+                'displayClass': 'olControlDrawFeaturePolygon'
+            }
+        );
         this.addControls([
             new OpenLayers.Control.Navigation(),
-            new OpenLayers.Control.DrawFeature(
-                layer,
-                OpenLayers.Handler.Polygon,
-                {
-                    'displayClass': 'olControlDrawFeaturePolygon'
-                }
-            )
+            this.polygonDrawControl
         ]);
+    },
+
+    activateDefaultControl: function() {
+        this.polygonDrawControl.activate();
     },
 
     CLASS_NAME: "Portal.search.GeoFacetMapToolbar"


### PR DESCRIPTION
When the control toolbar is added to the geo facet map the polygon draw control
is activated by default
