### PR TITLE
Fixes #584 email address placeholder text removal

### DIFF
--- a/src/test/javascript/portal/cart/AodaacDataRowTemplateSpec.js
+++ b/src/test/javascript/portal/cart/AodaacDataRowTemplateSpec.js
@@ -251,7 +251,7 @@ describe('Portal.cart.AodaacDataRowTemplate', function() {
             spyOn(tpl, '_createMenuItems').andReturn(mockMenuItems);
             spyOn(Ext.menu, 'Menu').andReturn(mockMenu);
             spyOn(Ext, 'Button').andReturn(mockButton);
-            spyOn(tpl, '_emailTextfieldElement').andReturn(mockElement);
+            spyOn(tpl, '_emailTextFieldElement').andReturn(mockElement);
             mockButton.render = jasmine.createSpy('button render');
             mockElement.on = jasmine.createSpy();
 
@@ -283,11 +283,11 @@ describe('Portal.cart.AodaacDataRowTemplate', function() {
             expect(mockButton.render).toHaveBeenCalledWith('html', '12345');
         });
 
-        it('calls _emailTextfieldElement', function() {
-            expect(tpl._emailTextfieldElement).toHaveBeenCalled();
+        it('calls _emailTextFieldElement', function() {
+            expect(tpl._emailTextFieldElement).toHaveBeenCalled();
         });
 
-        it('calls _emailTextfieldElement to attach events to', function() {
+        it('calls _emailTextFieldElement to attach events to', function() {
             expect(mockElement.on).toHaveBeenCalled();
         });
     });

--- a/web-app/js/portal/cart/AodaacDataRowTemplate.js
+++ b/web-app/js/portal/cart/AodaacDataRowTemplate.js
@@ -102,8 +102,10 @@ Portal.cart.AodaacDataRowTemplate = Ext.extend(Ext.XTemplate, {
             menu: downloadMenu
         }).render(html, id);
 
-        this._emailTextfieldElement(collection.uuid).on('click', function() {
-            this.set({ value: '' });
+        this._emailTextFieldElement(collection.uuid).on('click', function() {
+            if (this.getValue() == OpenLayers.i18n('emailAddressPlaceholder')) {
+                this.set({ value: '' });
+            }
         });
     },
 
@@ -173,7 +175,7 @@ Portal.cart.AodaacDataRowTemplate = Ext.extend(Ext.XTemplate, {
         return re.test(address);
     },
 
-    _emailTextfieldElement: function(uuid) {
+    _emailTextFieldElement: function(uuid) {
         return Ext.get(Ext.query("#aodaac-email-address-" + uuid)[0]);
     }
 });


### PR DESCRIPTION
For an AODAAC download there is placeholder text in the input, when the
user clicks in the field this should automatically clear, unfortunately
we cannot use the placeholder attribute yet http://caniuse.com/input-placeholder
