### PR TITLE
preventing new tab opening on download

### DIFF
--- a/web-app/js/portal/cart/DownloadConfirmationWindow.js
+++ b/web-app/js/portal/cart/DownloadConfirmationWindow.js
@@ -105,6 +105,6 @@ Portal.cart.DownloadConfirmationWindow = Ext.extend(Ext.Window, {
     },
 
     _openDownload: function(url) {
-        window.open(url, '_blank');
+        window.location = url;
     }
 });


### PR DESCRIPTION
Fixes #600. Tested on IE8, Chrome, Firefox with:
- CSV
- Shapefile

GML3 still doesn't work, but that's unrelated to that fix.
