### PR TITLE
#595 - Fix issue with error icon not being shown in IE8.

### DIFF
--- a/web-app/js/portal/prototypes/OpenLayers.js
+++ b/web-app/js/portal/prototypes/OpenLayers.js
@@ -372,7 +372,8 @@ OpenLayers.Tile.Image.prototype.initImgDiv = function() {
         OpenLayers.Event.observe(this.imgDiv, "error", function() {
             onerror.defer(1, that)
         });
-    } else {
+    }
+    else {
         OpenLayers.Event.observe(this.imgDiv, "error",
                                      OpenLayers.Function.bind(onerror, this));
     }


### PR DESCRIPTION
Caused by an OpenLayers 2.10 bug where the loadend event isn't being generated when there are errors loading tiles in IE8.

Fixed by correcting the order of onImageLoadError and onerror event handler execution
