### PR TITLE
#646 - Restore events required for correct operation of paging control

### DIFF
--- a/web-app/js/portal/data/GeoNetworkRecordStore.js
+++ b/web-app/js/portal/data/GeoNetworkRecordStore.js
@@ -14,6 +14,10 @@ Portal.data.GeoNetworkRecordStore = Ext.extend(Ext.data.XmlStore, {
         var config = {
             record : 'metadata',
             totalProperty: 'summary/@count',
+            sortInfo: {
+                field: 'popularity',
+                direction: 'DESC'
+            },
             fields: Portal.data.GeoNetworkRecord
         };
 

--- a/web-app/js/portal/ui/search/SearchPanel.js
+++ b/web-app/js/portal/ui/search/SearchPanel.js
@@ -67,15 +67,8 @@ Portal.ui.search.SearchPanel = Ext.extend(Ext.Panel, {
     },
 
     _loadResults: function(response, page) {
-
         this.resultsStore.startRecord = page.from - 1;
-        this.resultsStore.suspendEvents();
-
         this.resultsStore.loadData(response);
-        this.resultsStore.sort('popularity', 'DESC');
-
-        this.resultsStore.resumeEvents();
-        this.resultsStore.fireEvent('datachanged', this);
     }
 
 });


### PR DESCRIPTION
Sorting can be applied as a config option rather than as a separate sort action requiring supression of events
