### PR TITLE
#464 - restore store load events when loading search response so that se...

### DIFF
--- a/src/test/javascript/portal/search/FacetedSearchResultsPanelSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsPanelSpec.js
@@ -8,6 +8,7 @@
 describe("Portal.search.FacetedSearchResultsPanel", function() {
 
     var resultsPanel;
+    var searcher;
     var store;
     var testTarget;
     var testLayerLink;
@@ -15,12 +16,23 @@ describe("Portal.search.FacetedSearchResultsPanel", function() {
     beforeEach(function() {
         Portal.search.FacetedSearchResultsPanel.prototype._refreshView = function() {}
 
+        searcher = {
+            pageSize: 999
+        };
+
         store = new Portal.data.GeoNetworkRecordStore();
         resultsPanel = new Portal.search.FacetedSearchResultsPanel({
+            searcher: searcher,
             store: store
         });
 
         spyOn(Portal.data.ActiveGeoNetworkRecordStore.instance(), 'add');
+    });
+
+    describe('paging control' , function() {
+        it(' pageSize should match searcher pageSize', function() {
+            expect(resultsPanel.pagingBar.pageSize).toEqual(999);
+        });
     });
 
     describe('active geo network record store events', function() {

--- a/web-app/js/portal/search/FacetedSearchResultsPanel.js
+++ b/web-app/js/portal/search/FacetedSearchResultsPanel.js
@@ -12,7 +12,7 @@ Portal.search.FacetedSearchResultsPanel = Ext.extend(Ext.Panel, {
     initComponent:function () {
 
         this.pagingBar = new Ext.PagingToolbar({
-            pageSize: 25,
+            pageSize: this.searcher.pageSize,
             store: this.store,
             height: 40,
             autoLoad: true

--- a/web-app/js/portal/ui/search/SearchBodyPanel.js
+++ b/web-app/js/portal/ui/search/SearchBodyPanel.js
@@ -19,6 +19,7 @@ Portal.ui.search.SearchBodyPanel = Ext.extend(Ext.Panel, {
         this.searcher = cfg.searcher;
 
         this.searchResultsPanel = new Portal.search.FacetedSearchResultsPanel({
+            searcher: this.searcher,
             store: this.resultsStore
         });
 

--- a/web-app/js/portal/ui/search/SearchPanel.js
+++ b/web-app/js/portal/ui/search/SearchPanel.js
@@ -20,7 +20,8 @@ Portal.ui.search.SearchPanel = Ext.extend(Ext.Panel, {
             catalogUrl: Portal.app.config.catalogUrl,
             spatialSearchUrl: appConfigStore.getById('spatialsearch.url').data.value,
             defaultParams: {
-                protocol: Portal.app.config.metadataLayerProtocols.split("\n").join(' or ')
+                protocol: Portal.app.config.metadataLayerProtocols.split("\n").join(' or '),
+                sortBy: 'popularity'
             }
         });
 
@@ -67,15 +68,8 @@ Portal.ui.search.SearchPanel = Ext.extend(Ext.Panel, {
     },
 
     _loadResults: function(response, page) {
-
         this.resultsStore.startRecord = page.from - 1;
-        this.resultsStore.suspendEvents();
-
         this.resultsStore.loadData(response);
-        this.resultsStore.sort('popularity', 'DESC');
-
-        this.resultsStore.resumeEvents();
-        this.resultsStore.fireEvent('datachanged', this);
     }
 
 });


### PR DESCRIPTION
...arch results scroll position is reset to top of page
#646 - restore store load events so that page control is updated when loading search response and make sure the page size used by the page control matches the search page size
#614 - get Geonetwork to sort by popularity rather than doing it on a page by page basis in the client as otherwise the order of results changes between searches when there is more than one page of results and fix paging as per 646 and 464 so that all results can be found
