### PR TITLE
Issue #588 - Add a call to doLayout to render date time fields

### DIFF
--- a/src/test/javascript/portal/details/AodaacPanelSpec.js
+++ b/src/test/javascript/portal/details/AodaacPanelSpec.js
@@ -61,6 +61,20 @@ describe('Portal.details.AodaacPanel', function() {
         });
     });
 
+    describe('layout rendering', function() {
+        it('calls doLayout when a collection is added or selected', function() {
+            spyOn(Ext.Ajax, 'request').andCallFake(
+                function(params) {
+                    params.success.call(params.scope, { responseText: '[{"extents":{"lat":{"min":-48.02,"max":-7.99},"lon":{"min":103.99,"max":165.02},"dateTime":{"min":"01/01/2001","max":"31/12/2012"}},"name":"GHRSST SST subskin","productId":"1"}]' });
+                }
+            );
+
+            spyOn(aodaacPanel, 'doLayout');
+            aodaacPanel.update(layer, noOp, noOp, {});
+            expect(aodaacPanel.doLayout).toHaveBeenCalled();
+        });
+    });
+
     describe('input controls', function() {
 
         beforeEach(function() {

--- a/web-app/js/portal/details/AodaacPanel.js
+++ b/web-app/js/portal/details/AodaacPanel.js
@@ -60,6 +60,7 @@ Portal.details.AodaacPanel = Ext.extend(Ext.Panel, {
                     this._attachTemporalEvents();
                     this._populateFormFields();
                     this._showAllControls();
+                    this.doLayout();
                     show.call(target, this);
                 }
                 else {


### PR DESCRIPTION
Fixes #588

In FF if you do not let a collection load completely before going back and
adding another collection the date time fields overlap, getting the
panel to redo the layout whenever a collection is added seems to address
the problem, ugly as calling doLayout all the time is.
