### PR TITLE
Now displaying only non-base layers and layers for which 'displayInLayer...

### DIFF
--- a/src/test/javascript/portal/ui/ActiveLayersPanelSpec.js
+++ b/src/test/javascript/portal/ui/ActiveLayersPanelSpec.js
@@ -105,4 +105,26 @@ describe("Portal.ui.ActiveLayersPanel", function() {
             });
         });
     });
+
+    describe('layers to display', function() {
+
+        it("displays only non-base, displayInLayerSwitcher layers", function() {
+            expect(activeLayersPanel._filter(constructLayerRecord(true, true))).toBeFalsy();
+            expect(activeLayersPanel._filter(constructLayerRecord(true, false))).toBeFalsy();
+            expect(activeLayersPanel._filter(constructLayerRecord(false, false))).toBeFalsy();
+
+            expect(activeLayersPanel._filter(constructLayerRecord(false, true))).toBeTruthy();
+        });
+
+        var constructLayerRecord = function(isBaseLayer, displayInLayerSwitcher) {
+            return {
+                getLayer: function() {
+                    return {
+                        isBaseLayer: isBaseLayer,
+                        displayInLayerSwitcher: displayInLayerSwitcher
+                    }
+                }
+            }
+        }
+    });
 });

--- a/web-app/js/portal/ui/ActiveLayersPanel.js
+++ b/web-app/js/portal/ui/ActiveLayersPanel.js
@@ -11,6 +11,8 @@ Portal.ui.ActiveLayersPanel = Ext.extend(Ext.tree.TreePanel, {
 
     constructor: function(cfg) {
 
+        var self = this;
+
         var config = Ext.apply({
             title: this._getDefaultEmptyMapText(),
             id: 'activeLayerTreePanel',
@@ -24,9 +26,7 @@ Portal.ui.ActiveLayersPanel = Ext.extend(Ext.tree.TreePanel, {
                 expanded: true,
                 loader: new GeoExt.tree.LayerLoader({
                     store: cfg.layerStore,
-                    filter: function(record) {
-                        return !record.getLayer().isBaseLayer;
-                    },
+                    filter: self._filter,
                     createNode: function(attr) {
 
                         attr.uiProvider = Portal.ui.ActiveLayersTreeNodeUI;
@@ -101,6 +101,10 @@ Portal.ui.ActiveLayersPanel = Ext.extend(Ext.tree.TreePanel, {
         if (newNode != null) {
             Ext.MsgBus.publish(PORTAL_EVENTS.BEFORE_SELECTED_LAYER_CHANGED, newNode.layer);
         }
+    },
+
+    _filter: function(record) {
+        return !record.getLayer().isBaseLayer && record.getLayer().displayInLayerSwitcher;
     },
 
     _getDefaultEmptyMapText: function() {

--- a/web-app/js/portal/ui/MapPanel.js
+++ b/web-app/js/portal/ui/MapPanel.js
@@ -31,10 +31,6 @@ Portal.ui.MapPanel = Ext.extend(Portal.common.MapPanel, {
 
         this.initMap();
 
-        // Without this, the mini-map does not load properly because it ends up without
-        // any base layers.
-        this.layers.bind(this.map);
-
         this.addEvents('tabchange', 'mouseover');
 
         this.on('afterlayout', function () {


### PR DESCRIPTION
...Switcher' is true.

Removed uneccessary bind call (it was there for the mini-map, which no longer exists).
