### PR TITLE
Commit issue #624 - problem still exists wrt opacity slider

### DIFF
--- a/web-app/js/portal/details/DetailsPanel.js
+++ b/web-app/js/portal/details/DetailsPanel.js
@@ -37,45 +37,15 @@ Portal.details.DetailsPanel = Ext.extend(Ext.Panel, {
             map: this.map
         });
 
-        this.opacitySlider = new Portal.common.LayerOpacitySliderFixed({
-            id: "opacitySlider",
-            layer: new OpenLayers.Layer("Dummy Layer"),
-            keyIncrement: 10,
-            increment: 5,
-            minValue: 20, // we dont want a user to be able to give zero vis
-            maxValue: 100,
-            aggressive: true,
-            width: 175,
-            isFormField: true,
-            inverse: false,
-            fieldLabel: "Opacity",
-            plugins: new GeoExt.LayerOpacitySliderTip({
-                template: '<div class="opacitySlider" >Opacity: {opacity}%</div>'
-            })
-        });
-
         this.status = new Ext.Container({
             html: OpenLayers.i18n('noActiveCollectionSelected'),
             cls: 'collectionTitle',
             margins: {top:20, right:5, bottom:10, left:0},
             autoHeight: true
         });
-
-        this.opacitySliderContainer = new Ext.Panel({
-            layout: 'form',
-            height: 26,
-            margins: {
-                top: 5,
-                right: 5,
-                bottom: 0,
-                left: 5
-            },
-            items: [this.opacitySlider]
-        });
         
         this.items = [
             this.status,
-            this.opacitySliderContainer,
             this.detailsPanelTabs
         ];
 
@@ -92,13 +62,6 @@ Portal.details.DetailsPanel = Ext.extend(Ext.Panel, {
 
             // show new layer unless user requested 'hideLayerOptions'
             this.detailsPanelTabs.update(layer);
-            this.opacitySliderContainer.doLayout();
-            this.opacitySliderContainer.show();
-            //weird stuff happens if you set layer before showing the container, see Bug #1582
-            this.opacitySlider.setLayer(layer);
-
-            // #2165 - need to "doLayout", since showing/hiding components above (or else, the opacity
-            // slider won't be rendered properly, for example).
             this.doLayout();
         }
         else {
@@ -119,7 +82,6 @@ Portal.details.DetailsPanel = Ext.extend(Ext.Panel, {
         // clear the details Panel. ie. Don't show any layer options
 
         //DO NOT HIDE THE opacitySlider directly, or you WILL break things.-Alex
-        this.opacitySliderContainer.setVisible(false);
         this.detailsPanelTabs.setVisible(false);
     },
 });

--- a/web-app/js/portal/details/StylePanel.js
+++ b/web-app/js/portal/details/StylePanel.js
@@ -26,11 +26,45 @@ Portal.details.StylePanel = Ext.extend(Ext.Panel, {
             imgCls: 'legendImage',
             flex: 1
         });
+        
+        //create an opacity slider
+        //usability bug #624 where the opacity slider thumb sits at the minimum slider value instead of the maximum one
+        this.opacitySlider = new Portal.common.LayerOpacitySliderFixed({
+            id: "opacitySlider",
+            layer: new OpenLayers.Layer("Dummy Layer"),
+            keyIncrement: 10,
+            increment: 5,
+            minValue: 20, // minimum visibility for the current layer is 20%
+            maxValue: 100,
+            aggressive: true,
+            width: 175,
+            isFormField: true,
+            inverse: false,
+            fieldLabel: "Opacity",
+            plugins: new GeoExt.LayerOpacitySliderTip({
+                template: '<div class="opacitySlider" >Opacity: {opacity}%</div>'
+            })
+        });
+        
+        //create a container for the opacity slider, and add the opacity slider object to the container
+        this.opacitySliderContainer = new Ext.Panel({
+            layout: 'form',
+            height: 26,
+            margins: {
+                top: 5,
+                right: 5,
+                bottom: 0,
+                left: 5
+            },
+            items: [this.opacitySlider]
+        });
 
         this.ncwmsColourScalePanel = new Portal.details.NCWMSColourScalePanel();
         this.styleCombo = this.makeCombo();
 
+        //add the opacity slider container, style combo picker and colour scale panel to the Styles panel
         this.items = [
+            this.opacitySliderContainer,
             this.styleCombo,
             this.ncwmsColourScalePanel,
             {
@@ -101,6 +135,16 @@ Portal.details.StylePanel = Ext.extend(Ext.Panel, {
         this.selectedLayer = layer;
 
         show.call(target, this);
+        
+        this.opacitySliderContainer.hide();
+        this.opacitySliderContainer.doLayout();
+        this.opacitySliderContainer.show();
+        //according to bug #1582, must set the layer for the opacity slider after the container has been shown
+        this.opacitySlider.setLayer(layer);
+
+        // #2165 - need to "doLayout", since showing/hiding components above (or else, the opacity
+        // slider won't be rendered properly, for example).
+        this.doLayout();
 
         this.styleCombo.hide();
 


### PR DESCRIPTION
Opacity slider moved to the Styles Panel. However, when the slider is rendered the thumb is displayed at the leftmost side of the slider (20% opacity) rather than the rightmost side (100%), despite the value of the slider being 100.
