### PR TITLE
Clicking anywhere on action panel was clearing spatial extent.  Don't bu...

### DIFF
--- a/web-app/js/portal/ui/openlayers/MapActionsControl.js
+++ b/web-app/js/portal/ui/openlayers/MapActionsControl.js
@@ -246,6 +246,7 @@ Portal.ui.openlayers.MapActionsControl = OpenLayers.Class(OpenLayers.Control, {
      */
     mouseDown : function(evt) {
         this.isMouseDown = true;
+        this.ignoreEvent(evt);
     },
 
     /**
@@ -260,6 +261,7 @@ Portal.ui.openlayers.MapActionsControl = OpenLayers.Class(OpenLayers.Control, {
     mouseUp : function(evt) {
         if (this.isMouseDown) {
             this.isMouseDown = false;
+            this.ignoreEvent(evt);
         }
     },
 


### PR DESCRIPTION
...bble mouse down events from action panel to map or mouse-up events as per standard open layers layer switcher processing.
