### PR TITLE
Ensure the format parameter is submitted for GetFeatureInfo

### DIFF
--- a/web-app/js/portal/ui/FeatureInfoPopup.js
+++ b/web-app/js/portal/ui/FeatureInfoPopup.js
@@ -168,7 +168,8 @@ Portal.ui.FeatureInfoPopup = Ext.extend(GeoExt.Popup, {
                 expectedFormat: layer.getFeatureInfoFormat(),
                 units: layer.metadata.units,
                 animation: layer.isAnimated,
-                copyright: layer.metadata.copyright
+                copyright: layer.metadata.copyright,
+                format: "text/xml"
             },
             success: function(resp, options) {
                 // Delegate HTML formatting of response to layer
@@ -195,7 +196,6 @@ Portal.ui.FeatureInfoPopup = Ext.extend(GeoExt.Popup, {
                     this._clickPoint(),
                     { BUFFER: this.appConfig.mapGetFeatureInfoBuffer }
                 )
-                + "&format=text/xml"
             );
     },
 


### PR DESCRIPTION
If the format parameter is not set the response content type is not
explicitly set and Apache defaults to text/plain meaning in production
systems the JS falls over as it expects a xml response but the browser
believes it to be plain text
