### PR TITLE
#672 - milliseconds not being returned correctly using datepicker getVal...

### DIFF
--- a/web-app/js/portal/form/UtcExtentDateTime.js
+++ b/web-app/js/portal/form/UtcExtentDateTime.js
@@ -27,6 +27,13 @@ Portal.form.UtcExtentDateTime = Ext.extend(Ext.ux.form.DateTime, {
         this._setTimeValues(momentDate.utc(), this.extent, toMaxTime);
     },
 
+    getValue: function() {
+        // create new instance of date using clone
+        // new Date(this.dateValue) used by superclass doesn't preserve milliseconds
+        // on firefox
+        return this.dateValue ? this.dateValue.clone() : '';
+    },
+    
     reset: function() {
         this.df.reset();
         this.tf.reset();


### PR DESCRIPTION
...ue method on firefox

Use clone instead of new Date
