### PR TITLE
Fixed style and alignment of checkbox in layerSwitcher

### DIFF
--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -1131,8 +1131,10 @@ div.allwhite {
     height: 19px;
     vertical-align: top;
     margin: 1px;
-    background-color: #ffff99
+    background-color: #ffff99;
+    border: 0;
 }
+
 
 .resultsRowBackground {
     background: #eeeeee;
@@ -1194,6 +1196,9 @@ div.allwhite {
 
 #activeLayerTreePanel img.x-tree-node-icon {
     width: 0px;
+}
+#activeLayerTreePanel input.x-tree-node-cb {
+    vertical-align: middle;
 }
 
 .hidden {


### PR DESCRIPTION
This is/was most noticable on Linux boxes. The checkbox was misaligned. Fuggly borders around other icons also removed.
