### PR TITLE
Filter now returns to edit form on error

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/FilterController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/FilterController.groovy
@@ -29,17 +29,16 @@ class FilterController {
 
         def filterInstance = new Filter(params)
         filterInstance.layer = Layer.get(params.layerId)
+        def layerInstance = Layer.get(params.layerId)
 
         // Split possible values on comma.
-        filterInstance.possibleValues = params.possibleValues?.tokenize(",") ?: [] // Todo: separate (possibly into a 'before' filter?
+        filterInstance.possibleValues = params.possibleValues?.tokenize(",") ?: []
 
         if (filterInstance.save()) {
-
             redirect(controller: "layer", action: "editFilters", id: filterInstance.layerId)
         }
         else {
-
-            redirect(action: 'edit', params: params)
+            render (view: 'create',  model: [filterInstance: filterInstance, layerInstance: layerInstance])
         }
     }
 

--- a/grails-app/views/filter/create.gsp
+++ b/grails-app/views/filter/create.gsp
@@ -72,6 +72,23 @@
                                     <g:textField name="wmsEndDateName" value="${filterInstance?.wmsEndDateName}" />
                                 </td>
                             </tr>
+                            <tr class="prop">
+                                <td valign="top" class="name">
+                                    <label for="label"><g:message code="filter.enabled.label" default="Enabled" /></label>
+                                </td>
+                                <td valign="top" class="value ${hasErrors(bean: filterInstance, field: 'enabled', 'errors')}">
+                                    <g:checkBox name="enabled" checked="${filterInstance?.enabled}" />
+                                </td>
+                            </tr>
+
+                            <tr class="prop">
+                                <td valign="top" class="name">
+                                    <label for="label"><g:message code="filter.downloadOnly.label" default="Download Only" /></label>
+                                </td>
+                                <td valign="top" class="value ${hasErrors(bean: filterInstance, field: 'downloadfOnly', 'errors')}">
+                                    <g:checkBox name="downloadOnly" checked="${filterInstance?.downloadOnly}" />
+                                </td>
+                            </tr>
 
                             <tr class="prop">
                                 <td valign="top" class="name">


### PR DESCRIPTION
Fixes #668 On error (such as no values for string type ) the user would see a stack trace rather than return to the form to make changes.
Also added the download and enable elements to the create form.
