### PR TITLE
Update metatdata URLS to catalogue-123

### DIFF
--- a/grails-app/migrations/1387762248000-Update123GeoNetworkMetadataUrls.groovy
+++ b/grails-app/migrations/1387762248000-Update123GeoNetworkMetadataUrls.groovy
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2013 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+
+databaseChangeLog = {
+
+    changeSet(author: "tfotak (generated)", id: "1319582037000-1") {
+        update(tableName: "metadata_url") {
+            column(name: "online_resource_href", valueComputed: "replace(online_resource_href, 'http://catalogue123.aodn.org.au', 'http://catalogue-123.aodn.org.au')")
+            where("online_resource_href like 'http://catalogue123.aodn.org.au%'")
+        }
+    }
+}

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -66,6 +66,7 @@ databaseChangeLog = {
     include file: '20131111-PB-extra-filter-parameters.groovy'
     include file: '20131107-DN-AddUrlDownloadField.groovy'
     include file: '20131112-DN-AddUrlDownloadReplacementFields.groovy'
+    include file: '1387762248000-Update123GeoNetworkMetadataUrls.groovy'
 
     // Changes that apply to all instances must be included here, above the calls to instance-specific change logs
 


### PR DESCRIPTION
Since the move from catalogue123 to catalogue-123 as the geonetwork
hostname the metadata URLs for layers have been returning unknown host
errors preventing the info panel from displaying metadata
information. This is a fix for #737
