### PR TITLE
Platform and parameter filter panels on step 1 now expand correctly

### DIFF
--- a/web-app/js/portal/ui/TermSelectionPanel.js
+++ b/web-app/js/portal/ui/TermSelectionPanel.js
@@ -27,6 +27,8 @@ Portal.ui.TermSelectionPanel = Ext.extend(Ext.Panel, {
 
         Ext.apply(this, cfg, defaults);
 
+        this.collapsedByDefault = this.collapsed;
+
         this.selectionStore = this._buildSelectionStore(this.hierarchical, this.separator);
         this.termStore = this._buildTermStore(this.separator);
 
@@ -332,11 +334,11 @@ Portal.ui.TermSelectionPanel = Ext.extend(Ext.Panel, {
     removeAnyFilters: function () {
         this.selectedView.clear();
 
-        if (this.titleText == OpenLayers.i18n('platformFilter') || this.titleText == OpenLayers.i18n('parameterFilter')) {
-            this.expand();
+        if (this.collapsedByDefault) {
+            this.collapse();
         }
         else {
-            this.collapse();
+            this.expand();
         }
     },
 

--- a/web-app/js/portal/ui/search/SearchFiltersPanel.js
+++ b/web-app/js/portal/ui/search/SearchFiltersPanel.js
@@ -15,7 +15,8 @@ Portal.ui.search.SearchFiltersPanel = Ext.extend(Ext.Panel, {
             hierarchical: false,
             fieldGroup: 'longParamNames',
             fieldName: 'longParamName',
-            searcher: config.searcher
+            searcher: config.searcher,
+            collapsed: false
         });
 
         this._buildTermFilter('organisationFilter', {
@@ -31,7 +32,8 @@ Portal.ui.search.SearchFiltersPanel = Ext.extend(Ext.Panel, {
             hierarchical: false,
             fieldGroup: 'platformNames',
             fieldName: 'platform',
-            searcher: config.searcher
+            searcher: config.searcher,
+            collapsed: false
         });
 
         this._buildFilter(Portal.search.DateSelectionPanel, 'dateFilter', {
@@ -163,10 +165,6 @@ Portal.ui.search.SearchFiltersPanel = Ext.extend(Ext.Panel, {
         }
 
         var termFilter = this.filterFactory.getInstance(constructor, Ext.apply({}, config));
-
-        if (name == "parameterFilter" || name == "platformFilter") {
-            termFilter.collapsed = false;
-        }
 
         this.filters.push(termFilter);
         this[name] = termFilter;


### PR DESCRIPTION
When new search is selected, these filters now expand as per default. Fix for Issue #805 
