### PR TITLE
Removed restriction on title and name length when configuring layers.

### DIFF
--- a/grails-app/views/layer/_formBody.gsp
+++ b/grails-app/views/layer/_formBody.gsp
@@ -13,7 +13,7 @@
                                     <label for="title"><g:message code="layer.title.label" default="Title" /></label>
                                 </td>
                                 <td valign="top" class="value ${hasErrors(bean: layerInstance, field: 'title', 'errors')}">
-                                    <g:textField name="title" maxlength="25" value="${layerInstance?.title}" />
+                                    <g:textField name="title" size="60" value="${layerInstance?.title}" />
                                 </td>
                             </tr>
 
@@ -22,7 +22,7 @@
                                     <label for="name"><g:message code="layer.name.label" default="Name" /></label>
                                 </td>
                                 <td valign="top" class="value ${hasErrors(bean: layerInstance, field: 'name', 'errors')}">
-                                    <g:textField name="name" maxlength="25" value="${layerInstance?.name}" />
+                                    <g:textField name="name" size="60" value="${layerInstance?.name}" />
                                 </td>
                             </tr>
 


### PR DESCRIPTION
(It's certainly possible to have names/titles longer than the previous restriction in geoserver).

Hopefully this makes someone's day a little bit brighter.
