### PR TITLE
Issue 799

### DIFF
--- a/web-app/js/portal/ui/openlayers/layer/NcWMS.js
+++ b/web-app/js/portal/ui/openlayers/layer/NcWMS.js
@@ -59,7 +59,6 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
     },
 
     processTemporalExtent: function() {
-
         if (this._destroyed()) {
             return;
         }
@@ -73,7 +72,6 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
         this.temporalExtent = new Portal.visualise.animations.TemporalExtent();
         this.temporalExtent.on('extentparsed', this._processTemporalExtentDone, this);
         this.temporalExtent.parse(this.rawTemporalExtent);
-
     },
 
     _processTemporalExtentDone: function() {


### PR DESCRIPTION
Now creates a listener before a trigger is called. 
How did it ever work before? The processing of temporal extent must have taken longer?
