### PR TITLE
Root log level is now info (instead of error).

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -246,7 +246,7 @@ log4j = {
     }
 
     root {
-        error 'stdout'
+        info 'stdout'
     }
 
     error   'org.codehaus.groovy.grails.web.servlet',  //  controllers


### PR DESCRIPTION
I think this would fit in with most developers' expectations when coding log messages (i.e. that info and above are _probably_ going to end up in the log).
