### PR TITLE
Fix for #846 (extremely quick and dirty).

### DIFF
--- a/src/test/javascript/portal/prototypes/OpenLayersSpec.js
+++ b/src/test/javascript/portal/prototypes/OpenLayersSpec.js
@@ -161,7 +161,7 @@ describe('OpenLayers', function() {
 
                 openLayer.server = { uri: "uri" };
                 openLayer.params = { LAYERS: 'name' };
-                openLayer. downloadOnlyFilters = 'cql';
+                openLayer.wmsDownloadOnlyFilters = 'cql';
 
                 openLayer.getWmsLayerFeatureRequestUrl('csv');
 

--- a/web-app/js/portal/cart/WfsDataRowTemplate.js
+++ b/web-app/js/portal/cart/WfsDataRowTemplate.js
@@ -134,7 +134,7 @@ Portal.cart.WfsDataRowTemplate = Ext.extend(Portal.cart.NoDataRowTemplate, {
     },
 
     _cql: function(wmsLayer) {
-        return wmsLayer.getDownloadFilter();
+        return wmsLayer.getWmsDownloadFilter();
     },
 
     _downloadWfsHandler: function(collection, format) {

--- a/web-app/js/portal/filter/BaseFilterPanel.js
+++ b/web-app/js/portal/filter/BaseFilterPanel.js
@@ -59,6 +59,10 @@ Portal.filter.BaseFilterPanel = Ext.extend(Ext.Panel, {
         return this.getCQL();
     },
 
+    getWmsDownloadCQL: function() {
+        return this.getDownloadCQL();
+    },
+
     getCQL: function() {
         throw "subclasses must override this function";
     },

--- a/web-app/js/portal/filter/DateRangeFilterPanel.js
+++ b/web-app/js/portal/filter/DateRangeFilterPanel.js
@@ -9,5 +9,9 @@ Ext.namespace('Portal.filter');
 Portal.filter.DateRangeFilterPanel = Ext.extend(Portal.filter.DateFilterPanel, {
     getVisualisationCQL: function() {
         return this._getCQLUsingColumnNames(this.filter.wmsStartDateName, this.filter.wmsEndDateName);
+    },
+
+    getWmsDownloadCQL: function() {
+        return this.getVisualisationCQL();
     }
 });

--- a/web-app/js/portal/filter/FilterGroupPanel.js
+++ b/web-app/js/portal/filter/FilterGroupPanel.js
@@ -194,6 +194,7 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Panel, {
         if (this._isLayerActive(this.layer)) {
             this.layer.setCqlFilter(this._getVisualisationCQLFilter());
             this.layer.downloadOnlyFilters = this._getDownloadCQLFilter();
+            this.layer.wmsDownloadOnlyFilters = this._getWmsDownloadCQLFilter();
         }
     },
 
@@ -215,6 +216,16 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Panel, {
 
         Ext.each(this._getActiveFilters(), function(filter) {
             cql.push(filter.getDownloadCQL());
+        });
+
+        return cql.join(this.AND_QUERY);
+    },
+
+    _getWmsDownloadCQLFilter: function() {
+        var cql = [];
+
+        Ext.each(this._getActiveFilters(), function(filter) {
+            cql.push(filter.getWmsDownloadCQL());
         });
 
         return cql.join(this.AND_QUERY);

--- a/web-app/js/portal/prototypes/OpenLayers.js
+++ b/web-app/js/portal/prototypes/OpenLayers.js
@@ -86,7 +86,7 @@ OpenLayers.Layer.WMS.prototype.getWmsLayerFeatureRequestUrl = function(outputFor
         this.server.uri,
         this.params.LAYERS,
         outputFormat,
-        this.getDownloadFilter()
+        this.getWmsDownloadFilter()
     );
 };
 
@@ -211,6 +211,16 @@ OpenLayers.Layer.WMS.prototype.getDownloadFilter = function() {
 
     if (this.downloadOnlyFilters) {
         filters.push(this.downloadOnlyFilters);
+    }
+
+    return filters.join(' AND ');
+};
+
+OpenLayers.Layer.WMS.prototype.getWmsDownloadFilter = function() {
+    var filters = [];
+
+    if (this.wmsDownloadOnlyFilters) {
+        filters.push(this.wmsDownloadOnlyFilters);
     }
 
     return filters.join(' AND ');


### PR DESCRIPTION
Ensure that for wms download, we use the time coverage columns from the WMS layer (not the WFS layer, as was previously happening).

Note that there are some excellent examples of cut-and-paste coding in this PR which I intent to factor out, but wanted to get this quick and dirty fix in ASAP because of the impending release.

Fixes #846 
