### PR TITLE
Use single tile mode for mini-maps on search page.

### DIFF
--- a/web-app/js/portal/search/FacetedSearchResultsMiniMap.js
+++ b/web-app/js/portal/search/FacetedSearchResultsMiniMap.js
@@ -53,9 +53,14 @@ Portal.search.FacetedSearchResultsMiniMap = Ext.extend(OpenLayers.Map, {
     _getBaseLayer: function() {
         return new OpenLayers.Layer.WMS(
             "baselayer",
-            "http://tilecache.emii.org.au/cgi-bin/tilecache.cgi/1.0.0/",
-            { layers: 'HiRes_aus-group' },
-            { wrapDateLine: true }
+//            "http://tilecache.emii.org.au/cgi-bin/tilecache.cgi/1.0.0/",
+            "http://geoserver.emii.org.au/geoserver/wms",
+//            { layers: 'HiRes_aus-group' },
+            { layers: 'default_basemap_simple' },
+            {
+                wrapDateLine: true,
+                singleTile: true
+            }
         );
     },
 


### PR DESCRIPTION
**DO NOT MERGE** (need to address notes below)

Addresses #878 

The effect of this is that only a single request is made per map (which is ok, we don't need buffering because the mini-map cannot be panned).

Notes:
- doesn't work when hitting tilecache.emii.org.au (not sure why)
- we have 'HiRes_aus-group' only in tilecache (not in geoserver)
- layer URL still hard-coded

If we can resolve the above, I think this would be a good fix to take a bit of load off our infrastructure.

Comments, @danfruehauf @julian1 @pmbohm @pblain ? 
