### PR TITLE
Ie warning

### DIFF
--- a/grails-app/views/home/index.gsp
+++ b/grails-app/views/home/index.gsp
@@ -18,12 +18,6 @@ The AODN/IMOS Portal is distributed under the terms of the GNU General Public Li
 
     ${buildInfo}
 
-    <!--[if lt IE 8]>
-        <script type="text/javascript">
-        alert("Sorry. The Portal requires IE8 or better! Although the site may appear to work, the functionality is not guaranteed or supported in your web browser. Please update!");
-        </script>
-        <![endif]-->
-
     <!--link rel="stylesheet" media="print" type="text/css"  href="${resource(dir: 'css', file: 'mapprint.css')}" /-->
     <link rel="stylesheet" type="text/css" href="${resource(dir: 'js', file: 'GeoExt1.1/resources/css/geoext-all.css')}"/>
     <!-- User extensions -->
@@ -32,6 +26,12 @@ The AODN/IMOS Portal is distributed under the terms of the GNU General Public Li
 
     <g:render template="/js_includes"></g:render>
     <g:render template="/public_theme_includes"></g:render>
+
+    <!--[if IE]>
+        <script type="text/javascript">
+            alert(OpenLayers.i18n('ieWarningMessage'));
+        </script>
+    <![endif]-->
 
     <script>
 

--- a/grails-app/views/landing/IMOSindex.gsp
+++ b/grails-app/views/landing/IMOSindex.gsp
@@ -14,14 +14,16 @@ The AODN/IMOS Portal is distributed under the terms of the GNU General Public Li
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>${cfg?.name}</title>
 
-    <!--[if lt IE 8]>
-        <script type="text/javascript">
-        alert("Sorry. The Portal requires IE8 or better! Although the site may appear to work, the functionality is not guaranteed or supported in your web browser. Please update!");
-        </script>
-        <![endif]-->
 
     <g:render template="/js_includes"></g:render>
     <g:render template="/public_theme_includes"></g:render>
+
+    <!--[if IE]>
+        <script type="text/javascript">
+            alert(OpenLayers.i18n('ieWarningMessage'));
+        </script>
+    <![endif]-->
+
   </head>
 
   <body>

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -7,6 +7,8 @@
 
 OpenLayers.Util.extend(OpenLayers.Lang.en, {
 
+    ieWarningMessage: "Your browser is not supported. Please switch to Firefox or Chrome.",
+
     navigationButtonNext: "Next <div class=doubleArrow>&gt;&gt;</div>",
     navigationButtonPrevious: "<div class=doubleArrow>&lt;&lt;</div> Previous",
     navigationButtonSelect: "Select <div class=doubleArrow>&gt;&gt;</div>",


### PR DESCRIPTION
Note that the backlog description and the acceptance criteria don't quite match up.  I've gone with what's on the front, as it's much easier to detect IE than it is to detect `!(firefox || chrome)`.  Additionally, things seem to work ok in Safari anyway, after a quick smoke test.
