### PR TITLE
Supply (empty) variable now required in _formBody.gsp

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/LayerController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/LayerController.groovy
@@ -284,7 +284,7 @@ class LayerController {
                 redirect(action: "list", id: layerInstance.id)
             }
             else {
-                render(view: "edit", model: [layerInstance: layerInstance, linkedAodaacProducts: _getAodaacProductInfo(productInfo)])
+                render(view: "edit", model: [layerInstance: layerInstance, linkedAodaacProducts: _getAodaacProductInfo(layerInstance)])
             }
         }
         else {

--- a/test/unit/au/org/emii/portal/LayerControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/LayerControllerTests.groovy
@@ -21,6 +21,7 @@ class LayerControllerTests extends ControllerUnitTestCase {
 
         controller.metaClass.message = { LinkedHashMap args -> messageArgs = args }
         controller.metaClass._recache = {}
+        controller.metaClass._getAodaacProductInfo = {a->}
     }
 
     void testIndex() {


### PR DESCRIPTION
This is needed to be able to manually create a portal layer, which may be required for testing.
