### PR TITLE
Fixes #913

### DIFF
--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -107,7 +107,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         if (organisation) {
             return template.apply({
                 "label": OpenLayers.i18n('organisation'),
-                "value": organisation
+                "value": organisation.join(', ')
             });
         }
 


### PR DESCRIPTION
Use join on the organisation array rather than returning the array
directly when parsing the search results template
