### PR TITLE
Create unique timestamp based element ids for download estimates

### DIFF
--- a/src/test/javascript/portal/cart/DownloadEstimatorSpec.js
+++ b/src/test/javascript/portal/cart/DownloadEstimatorSpec.js
@@ -81,4 +81,19 @@ describe('Portal.cart.DownloadEstimator', function() {
             expect(mockHtml).toEqual('<div>' + OpenLayers.i18n('estimatedDlMessage') + ' 400.0MB </div><div class="clear"></div>');
         });
     });
+
+    describe('creates a unique html element per download view request', function() {
+        it('responds to getIdElementName', function() {
+            expect(estimator.getIdElementName).toBeDefined();
+        });
+
+        it('defines getIdElementName as a function', function() {
+            expect(typeof(estimator.getIdElementName)).toEqual('function');
+        });
+
+        it('creates a unique id element name for each estimator for a uuid', function() {
+            var otherEstimator = new Portal.cart.DownloadEstimator({ initTimestampString: '0' });
+            expect(estimator.getIdElementName('1')).not.toEqual(otherEstimator.getIdElementName('1'));
+        });
+    });
 });

--- a/web-app/js/portal/cart/DownloadEstimator.js
+++ b/web-app/js/portal/cart/DownloadEstimator.js
@@ -13,8 +13,18 @@ Portal.cart.DownloadEstimator = Ext.extend(Object, {
     HALF_GB_IN_BYTES: 536870912,
     EST_FAIL_CODE: -1,
 
-    constructor: function() {
+    constructor: function(cfg) {
+        Ext.apply(
+            this,
+            cfg,
+            { initTimestampString: new Date().getTime().toString() }
+        );
+
         Portal.cart.DownloadEstimator.superclass.constructor.call(this);
+    },
+
+    getIdElementName: function(uuid) {
+        return String.format("downloadEst-{0}-{1}", uuid, this.initTimestampString);
     },
 
     _getDownloadEstimate: function(collection, downloadUrl) {
@@ -36,10 +46,7 @@ Portal.cart.DownloadEstimator = Ext.extend(Object, {
     },
 
     _createFailMessage: function(result, uuid) {
-        var elementId = 'downloadEst' + uuid;
-        var sizeEstimate = this._generateFailureResponse(result);
-
-        this._addDownloadEstimate.defer(1, this, [sizeEstimate, elementId]);
+        this._addDownloadEstimate.defer(1, this, [this._generateFailureResponse(result), this.getIdElementName(uuid)]);
     },
 
     _generateFailureResponse: function(result) {
@@ -56,10 +63,7 @@ Portal.cart.DownloadEstimator = Ext.extend(Object, {
     },
 
     _createDownloadEstimate: function(result, uuid) {
-        var sizeEstimate = parseInt(result.responseText);
-        var elementId = 'downloadEst' + uuid;
-
-        this._addDownloadEstimate.defer(1, this, [sizeEstimate, elementId]);
+        this._addDownloadEstimate.defer(1, this, [parseInt(result.responseText), this.getIdElementName(uuid)]);
     },
 
     _addDownloadEstimate: function(sizeEstimate, elementId) {
@@ -78,11 +82,13 @@ Portal.cart.DownloadEstimator = Ext.extend(Object, {
             }
         }
 
-        sizeDiv.update(htmlAddition);
+        if (sizeDiv) {
+            sizeDiv.update(htmlAddition);
+        }
     },
 
     _generateEstHtmlString: function(estimateInBytes) {
-        var html = '<div>{0} {1}{2} {3}</div>' + '<div class="clear"></div>';
+        var html = '<div>{0} {1}{2} {3}</div><div class="clear"></div>';
         var downloadMessage;
         var fileSizeEstimate;
         var fileMagnitude;

--- a/web-app/js/portal/cart/WfsDataRowTemplate.js
+++ b/web-app/js/portal/cart/WfsDataRowTemplate.js
@@ -99,7 +99,12 @@ Portal.cart.WfsDataRowTemplate = Ext.extend(Portal.cart.NoDataRowTemplate, {
             this._bodaacCsvDownloadUrl(values)
         );
 
-        return '<div id="downloadEst' + values.uuid + '">' + OpenLayers.i18n("estimatedDlLoadingMessage") + OpenLayers.i18n("estimatedDlLoadingSpinner") + '</div>';
+        return String.format(
+            "<div id=\"{0}\">{1}{2}</div>",
+            estimator.getIdElementName(values.uuid),
+            OpenLayers.i18n("estimatedDlLoadingMessage"),
+            OpenLayers.i18n("estimatedDlLoadingSpinner")
+        );
     },
 
     _cql: function(wmsLayer) {


### PR DESCRIPTION
Fixes issue #944. A request for a large download estimate can take some
time and further subsetting can occur, the estimate is set but the
longer running, earlier larger estimate completes and updates the
UI.
