### PR TITLE
Widening the string filter drop down to fit the most content as possible

### DIFF
--- a/web-app/js/portal/details/DetailsPanel.js
+++ b/web-app/js/portal/details/DetailsPanel.js
@@ -39,7 +39,7 @@ Portal.details.DetailsPanel = Ext.extend(Ext.Panel, {
         this.status = new Ext.Container({
             html: OpenLayers.i18n('noActiveCollectionSelected'),
             cls: 'collectionTitle',
-            margins: {top:20, right:5, bottom:10, left:0},
+            margins: {top:20, right:10, bottom:10, left:0},
             autoHeight: true
         });
         

--- a/web-app/js/portal/filter/ComboFilterPanel.js
+++ b/web-app/js/portal/filter/ComboFilterPanel.js
@@ -21,7 +21,7 @@ Portal.filter.ComboFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
         this.combo = new Ext.form.ComboBox({
             triggerAction: 'all',
             mode: 'local',
-            width: 165,
+            width: 320,
             editable: false,
             store: new Ext.data.ArrayStore({
                 fields: [


### PR DESCRIPTION
The filters will not all line up although they never used to. The Temporal Extent picker was wider and also some helper text. Maximum usage of the Subset panel is now used.
The change in DetailsPanel.js is too stop the title squashing onto the right margin.
