### PR TITLE
Doesn't have unused DownloadGif action in ProxyController

### DIFF
--- a/grails-app/conf/shiro/SecurityFilters.groovy
+++ b/grails-app/conf/shiro/SecurityFilters.groovy
@@ -104,7 +104,7 @@ class SecurityFilters {
             }
         }
 
-        proxyAccess(controller: "proxy", action: "index|cache|wmsOnly|downloadGif") {
+        proxyAccess(controller: "proxy", action: "index|cache|wmsOnly") {
             before = {
                 request.accessAllowed = true
             }

--- a/grails-app/controllers/au/org/emii/portal/ProxyController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/ProxyController.groovy
@@ -16,30 +16,6 @@ class ProxyController extends RequestProxyingController {
 
     // Index action inherited from RequestProxyingController
 
-    def downloadGif = {
-
-        // Todo - DN: building this filename should be done in Javascript. Then we wouldn't need this separate action.
-
-        def injectGifFilename = { params ->
-
-            def layersField = "LAYERS="
-            def fieldIndex = params.url.indexOf(layersField)
-
-            if (fieldIndex > -1) {
-                def layerName = params.url.substring(fieldIndex + layersField.length())
-                def timeStr = params.TIME
-                    .replaceAll("[-:]", "")
-                    .replaceAll("/", "_")
-
-                params.downloadFilename = "${layerName}_${timeStr}.gif"
-            }
-
-            return params
-        }
-
-        _performProxying(injectGifFilename)
-    }
-
     // this action is intended to always be cached by squid
     // expects Open layers requests
     def cache = {


### PR DESCRIPTION
This action is currently unused and if we do need it again the behaviour should be implemented in JS rather than server-side.
