### PR TITLE
Drawing a bounding box does not cause JS console error

### DIFF
--- a/src/test/javascript/portal/details/SubsetPanelSpec.js
+++ b/src/test/javascript/portal/details/SubsetPanelSpec.js
@@ -27,16 +27,10 @@ describe("Portal.details.SubsetPanel", function() {
             expect(subsetPanel.layout).toBeInstanceOf(Ext.layout.CardLayout);
         });
 
-        it('initialises filterGroupPanel', function() {
-            expect(subsetPanel.filterGroupPanel).toBeInstanceOf(Portal.filter.FilterGroupPanel);
-            expect(subsetPanel.items.itemAt(0)).toBe(subsetPanel.filterGroupPanel);
-            expect(subsetPanel.filterGroupPanel.title).toBeUndefined();
-        });
-
         it('initialises aodaacPanel', function() {
             expect(subsetPanel.aodaacPanel).toBeInstanceOf(Portal.details.AodaacPanel);
             expect(subsetPanel.aodaacPanel.map).toBe(map);
-            expect(subsetPanel.items.itemAt(1)).toBe(subsetPanel.aodaacPanel);
+            expect(subsetPanel.items.itemAt(0)).toBe(subsetPanel.aodaacPanel);
             expect(subsetPanel.aodaacPanel.title).toBeUndefined();
        });
     });
@@ -46,10 +40,13 @@ describe("Portal.details.SubsetPanel", function() {
         beforeEach(function() {
             spyOn(subsetPanel.layout, 'setActiveItem');
             spyOn(subsetPanel.aodaacPanel, 'handleLayer');
-            spyOn(subsetPanel.filterGroupPanel, 'handleLayer');
         });
 
         it('activates filterGroupPanel for non-ncWMS layers', function() {
+            subsetPanel.filterGroupPanel = {
+                id: 'fgp1',
+                handleLayer: noOp
+            }
             subsetPanel.handleLayer({
                 isNcwms: function() { return false; }
             });
@@ -66,12 +63,18 @@ describe("Portal.details.SubsetPanel", function() {
         });
 
         it('calls handleLayer in children', function() {
+            subsetPanel.filterGroupPanel = {
+                id: 'fgp1',
+                handleLayer: noOp
+            }
+            spyOn(subsetPanel.filterGroupPanel, 'handleLayer');
+
             subsetPanel.handleLayer({
                 isNcwms: function() { return true; }
             });
 
             expect(subsetPanel.aodaacPanel.handleLayer).toHaveBeenCalled();
-            expect(subsetPanel.filterGroupPanel.handleLayer).toHaveBeenCalled();
+            expect(subsetPanel.filterGroupPanel.handleLayer).not.toHaveBeenCalled();
         });
     });
 });

--- a/web-app/js/portal/details/SubsetPanel.js
+++ b/web-app/js/portal/details/SubsetPanel.js
@@ -11,7 +11,6 @@ Portal.details.SubsetPanel = Ext.extend(Ext.Panel, {
 
     constructor: function(cfg) {
 
-        this.filterGroupPanel = new Portal.filter.FilterGroupPanel();
         this.aodaacPanel = new Portal.details.AodaacPanel({
             map: cfg.map
         });
@@ -20,7 +19,6 @@ Portal.details.SubsetPanel = Ext.extend(Ext.Panel, {
             title: OpenLayers.i18n('subsetPanelTitle'),
             layout: new Ext.layout.CardLayout(),
             items: [
-                this.filterGroupPanel,
                 this.aodaacPanel
             ]
         }, cfg);
@@ -30,25 +28,24 @@ Portal.details.SubsetPanel = Ext.extend(Ext.Panel, {
 
     handleLayer: function(layer, show, hide, target) {
 
-        this._extJsLayoutHack();
+        this._extJsLayoutHack(layer);
         if (layer.isNcwms()) {
             this.layout.setActiveItem(this.aodaacPanel.id);
+            this.aodaacPanel.handleLayer(layer, show, hide, target);
         }
         else {
             this.layout.setActiveItem(this.filterGroupPanel.id);
+            this.filterGroupPanel.handleLayer(layer, show, hide, target);
         }
-
-        // Probably only need to call one or the other of these depending on which one is active (see above)
-        // - but for now, keeping same behaviour as before.
-        this.aodaacPanel.handleLayer(layer, show, hide, target);
-        this.filterGroupPanel.handleLayer(layer, show, hide, target);
     },
 
-    _extJsLayoutHack: function() {
-        // TODO: hopefully can remove this? Haven't got a test for it.
-        // Remove filter pane; and add afresh to avoid ExtJS layout bug
-        this.remove(this.filterGroupPanel);
-        this.filterGroupPanel = new Portal.filter.FilterGroupPanel();
-        this.insert(0, this.filterGroupPanel);
+    _extJsLayoutHack: function(layer) {
+        if (!layer.isNcwms()) {
+            // TODO: hopefully can remove this? Haven't got a test for it.
+            // Remove filter pane; and add afresh to avoid ExtJS layout bug
+            this.remove(this.filterGroupPanel, false);
+            this.filterGroupPanel = new Portal.filter.FilterGroupPanel();
+            this.add(this.filterGroupPanel);
+        }
     }
 });


### PR DESCRIPTION
Drawing a bounding box when there is more than one layer does not cause
JS console errors to be thrown, however I believe there is now a small
memory leak, I did not feel comfortable committing this but received the
all clear from other parties. Fix for issue #943
