### PR TITLE
Cleans up map extent events from Ext components

### DIFF
--- a/src/test/javascript/portal/ui/MainToolbarSpec.js
+++ b/src/test/javascript/portal/ui/MainToolbarSpec.js
@@ -114,7 +114,7 @@ describe("Portal.ui.MainToolbar", function() {
     describe('MsgBus events', function() {
         it('should trigger render on layer removal', function() {
             spyOn(mainToolbar, '_renderNavigationButtons').andCallFake(function() {});
-            Ext.MsgBus.publish(PORTAL_EVENTS.LAYER_REMOVED, null);
+            Ext.MsgBus.publish(PORTAL_EVENTS.LAYER_REMOVED, { id: "1234567890" });
             expect(mainToolbar._renderNavigationButtons).toHaveBeenCalled();
         });
     });

--- a/web-app/js/portal/details/SpatialConstraintDisplayPanel.js
+++ b/web-app/js/portal/details/SpatialConstraintDisplayPanel.js
@@ -36,20 +36,25 @@ Portal.details.SpatialConstraintDisplayPanel = Ext.extend(Ext.Panel, {
 
             this.map.events.on({
                 scope: this,
-                'spatialconstraintadded': function(geometry) {
-                    this._showCardForGeometry(geometry);
-                }
+                'spatialconstraintadded': this._showCardForGeometry
             });
 
             this.map.events.on({
                 scope: this,
-                'spatialconstraintcleared': function() {
-                    this._showCard(this.noneDisplayPanel);
-                }
+                'spatialconstraintcleared': this._showCardForNone
+            });
+
+            this.on('beforedestroy', function(self) {
+                self.map.events.unregister('spatialconstraintadded', self, self._showCardForGeometry);
+                self.map.events.unregister('spatialconstraintcleared', self, self._showCardForNone);
             });
 
             this._showCardForGeometry(this.map.getConstraint());
         }
+    },
+
+    _showCardForNone: function() {
+        this._showCard(this.noneDisplayPanel);
     },
 
     _showCardForGeometry: function(geometry) {

--- a/web-app/js/portal/details/SubsetPanel.js
+++ b/web-app/js/portal/details/SubsetPanel.js
@@ -26,6 +26,12 @@ Portal.details.SubsetPanel = Ext.extend(Ext.Panel, {
         this.filterGroupPanels = {};
 
         Portal.details.SubsetPanel.superclass.constructor.call(this, config);
+
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.LAYER_REMOVED, function(subject, openLayer) {
+            if (this.filterGroupPanels[openLayer.id]) {
+                this.filterGroupPanels[openLayer.id].destroy();
+            }
+        }, this);
     },
 
     handleLayer: function(layer, show, hide, target) {

--- a/web-app/js/portal/form/PolygonTypeComboBox.js
+++ b/web-app/js/portal/form/PolygonTypeComboBox.js
@@ -26,6 +26,7 @@ Portal.form.PolygonTypeComboBox = Ext.extend(Ext.form.ComboBox, {
         Portal.form.PolygonTypeComboBox.superclass.constructor.call(this, config);
 
         this._bindToMap();
+        this._registerCleanUpEvents();
     },
 
     _bindToMap: function() {
@@ -35,6 +36,13 @@ Portal.form.PolygonTypeComboBox = Ext.extend(Ext.form.ComboBox, {
             scope: this,
             'spatialconstrainttypechanged': this._updateValue,
             'spatialconstraintadded': this._updateComboValue
+        });
+    },
+
+    _registerCleanUpEvents: function() {
+        this.on('beforedestroy', function(self) {
+            self.map.events.unregister('spatialconstrainttypechanged', self, self._updateValue);
+            self.map.events.unregister('spatialconstraintadded', self, self._updateComboValue);
         });
     },
     


### PR DESCRIPTION
Fix for issue #984 JS Console errors when re-adding a layer after a
bounding box has been drawn. The issue stems from Ext components having
to register listeners with the map, which is of course OpenLayers, so
when the Ext components are destroyed their listeners are still
registered with the map. This change ensures they are removed when
components are destroyed.
