### PR TITLE
Fixes #1047

### DIFF
--- a/web-app/js/portal/ui/TermSelectionPanel.js
+++ b/web-app/js/portal/ui/TermSelectionPanel.js
@@ -49,7 +49,8 @@ Portal.ui.TermSelectionPanel = Ext.extend(Ext.Panel, {
                     layout:'hbox',
                     items:[
                         {xtype:'spacer', flex:1},
-                        this.toggleAllLink
+                        this.toggleAllLink,
+                        {xtype:'spacer', width:5}
                     ]
                 }
             ]
@@ -193,7 +194,13 @@ Portal.ui.TermSelectionPanel = Ext.extend(Ext.Panel, {
             },
             _onTermsLoaded: function () {
                 this.setShowAll(false);
-                this.setVisible(termStore.canLimit);
+                if (termStore.getCount() == 1) {
+                    this.setVisible(false);
+                }
+                else {
+                    this.setVisible(termStore.canLimit, true);
+                }
+                this.doLayout();
             }
         });
 


### PR DESCRIPTION
The doLayout() fixes the more/less link moving right and or left after a facet is unchecked
