### PR TITLE
Fixes #938 No errors on quick layer deletion

### DIFF
--- a/web-app/js/portal/prototypes/OpenLayers.js
+++ b/web-app/js/portal/prototypes/OpenLayers.js
@@ -178,7 +178,7 @@ OpenLayers.Layer.WMS.prototype.isNcwms = function() {
 };
 
 OpenLayers.Layer.WMS.prototype.isAodaac = function() {
-    return this.aodaacProducts.length > 0;
+    return (this.aodaacProducts) ? this.aodaacProducts.length > 0 : false;
 };
 
 OpenLayers.Layer.WMS.prototype.isBodaac = function() {


### PR DESCRIPTION
This is the only JS error I found on quick layer delete in Firefox or Chrome. Used ncWMS and WMS layers for testing
