### PR TITLE
Make Portal resilient to slowness/outages of AODAAC system

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -70,9 +70,11 @@ help.url = "http://help.aodn.org.au/"
 
 // AODAAC Aggregator
 aodaacAggregator {
-    allowApiCalls = true
     url = "http://aodaac.aodn.org.au"
     environment = "prod"
+    allowApiCalls = true
+    apiCallsConnectTimeout = 1000
+    apiCallsReadTimeout = 2000
     idleJobTimeout = 1 // In hours
     errorLookup = [
         /.*java\.lang\.Exception: requested ~ [0-9]+ bytes; limit = [0-9]+/: {


### PR DESCRIPTION
The major changes are:
- The Portal will not wait too long for a response from the AODAAC system. The timeouts are configurable.
- If there is a problem getting the product info from the AODAAC system then we return an empty list of products and continue on our way. The problem is handled silently for the user.

Together these changes should mean that any slowness or problems with the AODAAC system will not affect the majority of behaviour of the Portal and that the AODAAC functionality will just be unavailable until the problem is resolved.
