### PR TITLE
#1069 - Don't generate change events when datetime field is invalid - it...

### DIFF
--- a/src/test/javascript/portal/form/UtcExtentDateTimeSpec.js
+++ b/src/test/javascript/portal/form/UtcExtentDateTimeSpec.js
@@ -113,4 +113,25 @@ describe("Portal.form.UtcExtentDateTime", function() {
         });
     });
 
+    describe('isValid', function() {
+        it('returns true when date field is valid', function() {
+            expect(utcDateTime.isValid()).toEqual(true);
+        });
+
+        it('returns false when date field is invalid', function() {
+            spyOn(utcDateTime.df, 'isValid').andReturn(false);
+            expect(utcDateTime.isValid()).toEqual(false);
+        });
+    });
+
+    describe('onBlur', function() {
+        it('no change events when invalid ', function() {
+            spyOn(utcDateTime.df, 'isValid').andReturn(false);
+            spyOn(utcDateTime, '_fireEventsForChange');
+            utcDateTime.onBlur(utcDateTime.df);
+            expect(utcDateTime._fireEventsForChange).not.toHaveBeenCalled();
+        });
+
+    });
+
 });

--- a/web-app/js/portal/form/UtcExtentDateTime.js
+++ b/web-app/js/portal/form/UtcExtentDateTime.js
@@ -111,7 +111,7 @@ Portal.form.UtcExtentDateTime = Ext.extend(Ext.ux.form.DateTime, {
 
     onBlur: function(field) {
         this._setTimeFieldChangeFlag(field);
-        if (this._isDirty()) {
+        if (this.isValid() && this._isDirty()) {
             this._fireEventsForChange(this._matchTime());
         }
     },
@@ -196,6 +196,10 @@ Portal.form.UtcExtentDateTime = Ext.extend(Ext.ux.form.DateTime, {
 
     _preventStoreChangesBeingIgnored: function() {
         this.tf.generateStore = function() {};
+    },
+
+    isValid: function() {
+        return this.df.isValid();
     },
 
     _isDirty: function() {


### PR DESCRIPTION
... hasn't really been changed yet

Fixes #1069 
