### PR TITLE
Issue #1117

### DIFF
--- a/grails-app/views/layer/_formBody.gsp
+++ b/grails-app/views/layer/_formBody.gsp
@@ -280,15 +280,6 @@
 
                             <tr class="prop">
                                 <td valign="top" class="name">
-                                    <label for="gogoduckLayerName"><g:message code="layer.gogoduckLayerName.label" default="Gogoduck Override Layer Name" /></label>
-                                </td>
-                                <td valign="top" class="value ${hasErrors(bean: layerInstance, field: 'gogoduckLayerName', 'errors')}">
-                                    <g:textField name="gogoduckLayerName" value="${layerInstance?.gogoduckLayerName}" />
-                                </td>
-                            </tr>
-
-                            <tr class="prop">
-                                <td valign="top" class="name">
                                     AODAAC&nbsp;Linked&nbsp;Products
                                 </td>
                                 <td valign="top">


### PR DESCRIPTION
This fixes #1117. There are more changes to remove other usages of gogoduckLayerName but this is the one stopping Layers from being editable.
