### PR TITLE
UTAS Logo updates

### DIFF
--- a/grails-app/views/landing/IMOSindex.gsp
+++ b/grails-app/views/landing/IMOSindex.gsp
@@ -70,14 +70,14 @@ The AODN/IMOS Portal is distributed under the terms of the GNU General Public Li
 
                     <div class="footer">
                         <div class="landingSubLeft">
-                            <img class="logoSpacer" src="http://static.emii.org.au/images/logo/Utas_vert.png" alt="UTAS logo" />
-                            <img class="logoSpacer" src="http://static.emii.org.au/images/logo/NCRIS_Initiative_stacked200.png" width="110" alt="DIISTRE logo" />
+                            <img class="miniSpacer" src="http://static.emii.org.au/images/logo/utas/UTAS_MONO_190w.png" alt="UTAS logo" />
+                            <img class="miniSpacer" src="http://static.emii.org.au/images/logo/NCRIS_Initiative_stacked200.png" width="140" alt="DIISTRE logo" />
                             <br />
                             <a class="noUnderline" href="http://twitter.com/AusOceanDataNet" target="_blank">
-                                <img class="logoSpacer" src="${resource(dir: 'images', file: 'Twitter_logo_black.png')}" title="Follow us on twitter" alt="Follow us on twitter" />
+                                <img class="miniSpacer" src="${resource(dir: 'images', file: 'Twitter_logo_black.png')}" title="Follow us on twitter" alt="Follow us on twitter" />
                             </a>
                             <a class="noUnderline" href="http://www.facebook.com/AusOceanDataNet" target="_blank">
-                                <img class="logoSpacer" src="${resource(dir: 'images', file: 'FB-logo-gray.png')}" title="Find us on Facebook" alt="Find us on Facebook" />
+                                <img class="miniSpacer" src="${resource(dir: 'images', file: 'FB-logo-gray.png')}" title="Find us on Facebook" alt="Find us on Facebook" />
                             </a>
                         </div>
 

--- a/grails-app/views/landing/_link2AODNMini.gsp
+++ b/grails-app/views/landing/_link2AODNMini.gsp
@@ -1,6 +1,6 @@
 
 <a title="Link to the AODN portal" href="http://portal.aodn.org.au/aodn">
 <h4>AODN Ocean Portal</h4></a>
-<p class="minispacer">
+<p class="miniSpacer">
 The <a  target="_blank" class="external"  title="AODN Ocean Data Portal" href="http://portal.aodn.org.au/aodn" >AODN Ocean Data Portal</a> has access to the complete IMOS metadata catalog and all available ocean data. The AODN includes data from the six Commonwealth Agencies with responsibilities in the Australian marine jurisdiction (AAD, AIMS, BOM, CSIRO, GA and RAN).
 </p>

--- a/grails-app/views/landing/_oceanCurrentMini.gsp
+++ b/grails-app/views/landing/_oceanCurrentMini.gsp
@@ -1,7 +1,7 @@
 <a title="Link to the IMOS Ocean Current site" href="${oceanCurrent.baseURL}">
 <h4>Ocean Currents and Temperature Graphs</h4></a>
 
-<div class="minispacer"  >
+<div class="miniSpacer"  >
   To view the latest state of Australian oceans and coastal seas,
   go to our <a class="external" title="Ocean Current page"  href="${oceanCurrent.baseURL}" target="_blank"><nobr>Ocean Current</nobr></a> page.
 </div>

--- a/grails-app/views/splash/_oceanCurrent.gsp
+++ b/grails-app/views/splash/_oceanCurrent.gsp
@@ -7,7 +7,7 @@ The AODN/IMOS Portal is distributed under the terms of the GNU General Public Li
 --%>
 
 <h2>Latest Ocean Currents and Temperature Graphs</h2>
-<div class="minispacer floatLeft homePanelWidget"  style="width:230px">
+<div class="miniSpacer floatLeft homePanelWidget"  style="width:230px">
 
   <a class="imageLabel" title="Latest 'OceanCurrent' graph for the randomly chosen region" href="${oceanCurrent.baseURL}${oceanCurrent.acron}${oceanCurrent.parentPage}"  target="_blank" >
     <img class="roundedImages" src="${oceanCurrent.imageURL}" width="230"> ${oceanCurrent.speil}</img>
@@ -15,7 +15,7 @@ The AODN/IMOS Portal is distributed under the terms of the GNU General Public Li
   <br/>
 </div>
 
-<div class="minispacer floatLeft homePanelWidget"  style="width:250px">
+<div class="miniSpacer floatLeft homePanelWidget"  style="width:250px">
   The oceans around Australia are dynamic and ever-changing, to view the latest state of Australian oceans and coastal seas,
   go to our <a class="external" title="Ocean Current page"  href="${oceanCurrent.baseURL}" target="_blank"><NOBR>Ocean Current</NOBR></a> page.
 

--- a/grails-app/views/splash/aodnIndex.gsp
+++ b/grails-app/views/splash/aodnIndex.gsp
@@ -27,7 +27,7 @@ The AODN/IMOS Portal is distributed under the terms of the GNU General Public Li
 
     <div class="spacer clear footer">
       <div class="spacer floatLeft homePanelWidget"  style="width:110px">
-        <img class="minispacer" src="http://static.emii.org.au/images/logo/NCRIS_Initiative_stacked110.png" alt="DIISTRE logo"/>
+        <img class="miniSpacer" src="http://static.emii.org.au/images/logo/NCRIS_Initiative_stacked110.png" alt="DIISTRE logo"/>
       </div>
       <div class="spacer floatLeft homePanelWidget"  style="width:360px">
         ${ cfg.footerContent }

--- a/grails-app/views/splash/imosIndex.gsp
+++ b/grails-app/views/splash/imosIndex.gsp
@@ -8,30 +8,6 @@ The AODN/IMOS Portal is distributed under the terms of the GNU General Public Li
 --%>
 
 <div class="p-centre">
-  <div class="p-centre-item" style="width:560px">
 
-    <g:render template='imosIntroduction' />
-
-    <div class="clear spacer"></div>
-
-    <g:render template='oceanCurrent' />
-
-    <div class="clear"></div>
-    <div >There is a technical summary for those interested in the <a class="external" href="${ grailsApplication.config.help.url }?q=node/99" title="technical summary" target="_blank">information infrastructure</a> behind this portal.
-    </div>
-
-
-    <div class="spacer clear footer">
-      <div class="spacer floatLeft homePanelWidget"  style="width:100px">
-        <img class="minispacer" src="http://static.emii.org.au/images/logo/NCRIS_Initiative_stacked110.png" alt="DIISTRE logo"/>
-        <img class="minispacer" src="http://static.emii.org.au/images/logo/Utas_vert.png" alt="UTAS logo" height="50" />
-      </div>
-      <div class="spacer floatLeft homePanelWidget"  style="width:420px">
-        ${ cfg.footerContent }
-      </div>
-    </div>
-    <div class="clear footer"> ${ portalBuildInfo }</div>
-
-  </div>
 
 </div>

--- a/grails-app/views/splash/soosIndex.gsp
+++ b/grails-app/views/splash/soosIndex.gsp
@@ -25,8 +25,8 @@ The AODN/IMOS Portal is distributed under the terms of the GNU General Public Li
     <div class="clear footer">
 
       <div class="spacer floatLeft homePanelWidget" style="width:100px">
-        <img class="minispacer" src="images/soos/baselogo-dark.png" alt="SOOS Logo" /><BR>
-        <a href="http://imos.org.au/"><img src="images/soos/IMOSLogo.png"  class="minispacer"  alt="IMOS Logo" /></a>
+        <img class="miniSpacer" src="images/soos/baselogo-dark.png" alt="SOOS Logo" /><BR>
+        <a href="http://imos.org.au/"><img src="images/soos/IMOSLogo.png"  class="miniSpacer"  alt="IMOS Logo" /></a>
       </div>
 
       <div class="spacer floatLeft homePanelWidget" style="width:370px">

--- a/grails-app/views/splash/waodnIndex.gsp
+++ b/grails-app/views/splash/waodnIndex.gsp
@@ -25,7 +25,7 @@ The AODN/IMOS Portal is distributed under the terms of the GNU General Public Li
     <div class="clear"></div>
     <div class="spacer clear footer">
       <div class="spacer floatLeft homePanelWidget"  style="width:110px">
-        <img class="minispacer" src="http://static.emii.org.au/images/logo/NCRIS_Initiative_stacked110.png" alt="DIISTRE logo"/>
+        <img class="miniSpacer" src="http://static.emii.org.au/images/logo/NCRIS_Initiative_stacked110.png" alt="DIISTRE logo"/>
       </div>
       <div class="spacer floatLeft homePanelWidget"  style="width:360px">
         ${ cfg.footerContent }

--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -352,7 +352,7 @@ hr {
     margin: 25px 0;
 }
 
-.minispacer {
+.miniSpacer {
     margin: 7px 0;
 }
 


### PR DESCRIPTION
A few files got touched here due to renameing (and using) a CSS class "miniSpacer" instead of "minispacer".
The imos splash page got emptied to avoid confusion. The splash mechanism needs to get revisited soon for AODN purposes and also the needs of other wanting to deploy our code, but that's outside the scope of this logo change.
