### PR TITLE
slow loading GetFeatureInfo images need the resizer to wait a little

### DIFF
--- a/web-app/js/portal/ui/FeatureInfoPopup.js
+++ b/web-app/js/portal/ui/FeatureInfoPopup.js
@@ -166,7 +166,7 @@ Portal.ui.FeatureInfoPopup = Ext.extend(GeoExt.Popup, {
                     options.extraParams.name
                 );
                 this._featureInfoRequestCompleted();
-                setTimeout(imgSizer, 0);
+                setTimeout(imgSizer, 500);
             },
             failure: this._featureInfoRequestCompleted
         });


### PR DESCRIPTION
Give half a second before resizing large slow loading images in the geteFeatureInfo . I'm sure it was never intended to be micro seconds!
