### PR TITLE
no need to update cart on layer changed event

### DIFF
--- a/web-app/js/portal/cart/DownloadPanelBody.js
+++ b/web-app/js/portal/cart/DownloadPanelBody.js
@@ -21,10 +21,6 @@ Portal.cart.DownloadPanelBody = Ext.extend(Ext.Panel, {
 
         Ext.apply(this, config);
         Portal.cart.DownloadPanelBody.superclass.initComponent.call(this, arguments);
-
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.SELECTED_LAYER_CHANGED, function (eventName, openlayer) {
-            this.generateContent();
-        }, this);
     },
 
     generateContent: function() {


### PR DESCRIPTION
It might be a bit premature, but looks like this fixes #1158.

I couldn't find any side effects, but please do verify that before merge.
