### PR TITLE
Removed the 'canDownload' field from GeoNetwordRecord

### DIFF
--- a/src/test/javascript/portal/data/GeoNetworkRecordStoreSpec.js
+++ b/src/test/javascript/portal/data/GeoNetworkRecordStoreSpec.js
@@ -85,10 +85,6 @@ describe("Portal.data.GeoNetworkRecordStore", function() {
             expect(geoNetworkRecordStore.getAt(0).get('source')).toEqual('987654321');
         });
 
-        it('canDownload', function() {
-            expect(geoNetworkRecordStore.getAt(0).get('canDownload')).toBe(true);
-        });
-
         describe('bbox', function() {
             it('west', function() {
                 expect(geoNetworkRecordStore.getAt(0).get('bbox').getBounds().left).toBe(112);

--- a/web-app/js/portal/data/GeoNetworkRecord.js
+++ b/web-app/js/portal/data/GeoNetworkRecord.js
@@ -131,7 +131,6 @@ Portal.data.GeoNetworkRecord = function() {
         pointOfTruthLinkField,
         aggregatorField,
         'source',
-        { name: 'canDownload', mapping: '*/canDownload', defaultValue: true },
         bboxField,
         'wmsLayer',
         'ncwmsParams'


### PR DESCRIPTION
I don't think this field is used anymore
