### PR TITLE
Remove '(s)' suffix for Boolean filter labels.

### DIFF
--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -225,7 +225,7 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     resetActionText: 'reset',
 
     // BooleanFilterPanel.js
-    checkboxDescription: 'Select only data with {0}(s)',
+    checkboxDescription: 'Select only data with {0}',
 
     // ActiveLayersPanel.js
     dataCollectionsTitle: "Data Collections",


### PR DESCRIPTION
Fixes #1176
