### PR TITLE
Keep copy of config locally

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/ConfigController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/ConfigController.groovy
@@ -141,7 +141,7 @@ class ConfigController {
 
             if (!configInstance.hasErrors() && configInstance.save(flush: true) && (flash.message == null)) {
                 flash.message = 'Config updated'
-                Config._configInstance = null
+                Config.reload()
             }
 
             render(view: "edit", model: [configInstance: configInstance])

--- a/grails-app/domain/au/org/emii/portal/Config.groovy
+++ b/grails-app/domain/au/org/emii/portal/Config.groovy
@@ -123,6 +123,10 @@ class Config {
         return _configInstance
     }
 
+    static reload() {
+        _configInstance = null;
+    }
+
     static def recacheDefaultMenu() {
 
         def configInstance = Config.activeInstance()

--- a/test/integration/au/org/emii/portal/ServerServiceTests.groovy
+++ b/test/integration/au/org/emii/portal/ServerServiceTests.groovy
@@ -8,8 +8,6 @@
 
 package au.org.emii.portal
 
-import au.org.emii.portal.config.JsonMarshallingRegistrar;
-
 class ServerServiceTests extends GroovyTestCase {
 
     protected void setUp() {
@@ -19,7 +17,7 @@ class ServerServiceTests extends GroovyTestCase {
     protected void tearDown() {
         super.tearDown()
     }
-	
+
     void testService() {
 
 //		JsonMarshallingRegistrar.registerJsonMarshallers()
@@ -89,6 +87,7 @@ class ServerServiceTests extends GroovyTestCase {
                                                          //is set as default layer
 
         conf.save(failOnError:  true,flush:true)
+        Config.reload()
 
         s1.delete(flush:true)
         s3.delete(flush:true)

--- a/test/unit/au/org/emii/portal/FilterControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/FilterControllerTests.groovy
@@ -90,6 +90,7 @@ class FilterControllerTests extends ControllerUnitTestCase {
         assertFalse controller._validateCredential("12345")
 
         cfg.wfsScannerCallbackPassword = "12345"
+        Config.reload()
 
         // Check wrong password
         assertFalse controller._validateCredential("asdf")

--- a/test/unit/au/org/emii/portal/WmsScannerControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/WmsScannerControllerTests.groovy
@@ -79,6 +79,7 @@ class WmsScannerControllerTests extends ControllerUnitTestCase {
     void testControls_NoProblems_ScanJobListReturned() {
 
         mockDomain Config, [validConfig]
+        Config.reload()
 
         // Prepare for calls
         Server.metaClass.static.findAllByTypeInListAndAllowDiscoveries = {
@@ -107,6 +108,7 @@ class WmsScannerControllerTests extends ControllerUnitTestCase {
     void testControls_ExceptionThrown_EmptyListReturned() {
 
         mockDomain Config, [validConfig]
+        Config.reload()
 
         // Prepare for calls
         Server.metaClass.static.findAllByTypeInListAndAllowDiscoveries = {
@@ -139,6 +141,7 @@ class WmsScannerControllerTests extends ControllerUnitTestCase {
     void testControls_InvalidConfig_EmptyListReturned() {
 
         mockDomain Config, [invalidConfig]
+        Config.reload()
 
         def returnParams = controller.controls() // Make the call
 
@@ -164,7 +167,6 @@ class WmsScannerControllerTests extends ControllerUnitTestCase {
         controller.callRegister()
 
         assertEquals count, 1
-
     }
 
     void testCallRegister_ExceptionThrown_RedirectedWithMessage() {
@@ -181,8 +183,6 @@ class WmsScannerControllerTests extends ControllerUnitTestCase {
 &callbackPassword=pwd\
 &scanFrequency=45\
 """
-
-
 
         Server.metaClass.static.get = { map -> return server2 }
 
@@ -224,7 +224,6 @@ class WmsScannerControllerTests extends ControllerUnitTestCase {
             count++
             return "Updated"
         }
-
 
         controller.callUpdate() // Make the call
 


### PR DESCRIPTION
**Do not merge**

@danfruehauf a while ago I considered doing something like this. I never got around to doing it, though. This might help with the db connections in HostVerifier?

But the biggest one will be getting the list of known servers each time. But we could do something similar with that. That is, keep the list of URIs and just clear it when a Server gets updated.
