### PR TITLE
disable WMS requests via proxy controller

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -108,7 +108,7 @@ minimap {
     }
 }
 
-proxyWmsRequests = true
+proxyWmsRequests = false
 
 geoserver_static = [
     uri: "http://geoserver-static.aodn.org.au/geoserver/baselayers/wms",


### PR DESCRIPTION
Disabled, until we resolve the DB connection issue, where too many DB connections are used while proxying.

See also #1244.
