### PR TITLE
ignore polygons with potentially bad geometry

### DIFF
--- a/web-app/js/portal/search/MetadataExtent.js
+++ b/web-app/js/portal/search/MetadataExtent.js
@@ -18,7 +18,10 @@ Portal.search.MetadataExtent = Ext.extend(Object, {
     },
 
     addPolygon: function(polygon) {
-        this.polygons.push(this._wktPolygonToGeoBox(polygon));
+        var geoBox = this._wktPolygonToGeoBox(polygon);
+        if (geoBox) {
+            this.polygons.push(geoBox);
+        }
     },
 
     getLayer: function() {
@@ -79,13 +82,18 @@ Portal.search.MetadataExtent = Ext.extend(Object, {
 
     _wktPolygonToGeoBox: function(polygon) {
         var wktPolygon = new OpenLayers.Feature.Vector(OpenLayers.Geometry.fromWKT(polygon));
-        var bounds = wktPolygon.geometry.getBounds();
-        return {
-            west: bounds.left,
-            south: bounds.bottom,
-            east: bounds.right,
-            north: bounds.top
-        };
+        if (wktPolygon.geometry) {
+            var bounds = wktPolygon.geometry.getBounds();
+            return {
+                west: bounds.left,
+                south: bounds.bottom,
+                east: bounds.right,
+                north: bounds.top
+            };
+        }
+        else {
+            return null;
+        }
     },
 
     _toGeoBox: function(geoBoxStr) {


### PR DESCRIPTION
In the js log you gonna get:

```
TypeError: wktPolygon.geometry is null
    var bounds = wktPolygon.geometry.getBounds();
```

This just happened on edge.

It looks like that some polygons are just too big to handle and are chopped midway:

```
POLYGON((64 -68,64 -67,63 -67,62 -67,61 -67,61 -66,60 -66,60 -67,59 -67,58 -67,58 -66,57 -66,56 -66,55 -66,54 -66,53 -66,52 -66,51 -66,51 -67,50 -67,50 -68,49 -68,48 -68,48 -67,47 -67,46 -67,46 -68,45 -68,44 -68,43 -68,42 -68,41 -68,41 -69,40 -69,39 -69,38 -69,37 -69,36 -69,35 -69,34 -69,33 -69,32 -69,31 -69,30 -69,29 -69,28 -69,27 -69,27 -68,26 -68,25 -68,24 -68,23 -68,22 -68,21 -68,21 -67,20 -67,20 -68,19 -68,18 -68,18 -67,17 -67,16 -67,15 -67,15 -66,14 -66,13 -66,12 -66,11 -66,10 -66,9 -66,8 -66,8 -65,7 -65,7 -64,7 -63,7 -62,8 -62,8 -63,9 -63,10 -63,11 -63,12 -63,12 -62,12 -61,11 -61,11 -60,10 -60,9 -60,8 -60,7 -60,6 -60,5 -60,5 -61,5 -62,4 -62,4 -63,4 -64,4 -65,3 -65,2 -65,2 -64,1 -64,0 -64,-1 -64,-1 -63,-1 -62,-1 -61,0 -61,1 -61,2 -61,2 -60,3 -60,4 -60,4 -59,5 -59,5 -58,5 -57,6 -57,6 -56,7 -56,8 -56,9 -56,10 -56,11 -56,12 -56,12 -57,13 -57,14 -57,15 -57,16 -57,17 -57,18 -57,19 -57,20 -57,20 -56,21 -56,22 -56,22 -55,21 -55,21 -54,20 -54,19 -54,18 -54,17 -54,16 -54,15 -54,14 -54,14 -53,15 -53,16 -53,16 -52,17 -52,18 -52,19 -52,20 -52,21 -52,22 -52,23 -52,24 -52,24 -53,25 -53,26 -53,27 -53,28 -53,28 -52,29 -52,30 -52,31 -52,32 -52,32 -51,33 -51,34 -51,35 -51,36 -51,37 -51,38 -51,39 -51,40 -51,40 -52,41 -52,42 -52,43 -52,44 -52,44 -53,45 -53,46 -53,47 -53,48 -53,49 -53,50 -53,51 -53,51 -52,52 -52,53 -52,54 -52,55 -52,56 -52,57 -52,58 -52,59 -52,59 -51,60 -51,60 -50,60 -49,59 -49,59 -48,59 -47,60 -47,60 -46,59 -46,58 -46,57 -46,56 -46,55 -46,54 -46,53 -46,52 -46,52 -45,51 -45,50 -45,49 -45,49 -44,48 -44,47 -44,47 -43,46 -43,45 -43,44 -43,43 -43,42 -43,41 -43,41 -44,41 -45,41 -46,40 -46,39 -46,39 -45,38 -45,38 -44,38 -43,39 -43,39 -42,40 -42,41 -42,41 -41,42 -41,43 -41,44 -41,44 -42,45 -42,46 -42,47 -42,47 -41,48 -41,49 -41,49 -42,50 -42,51 -42,52 -42,53 -42,53 -43,54 -43,55 -43,56 -43,56 -44,57 -44,58 -44,59 -44,60 -44,60 -45,61 -45,61 -44,62 -44,63 -44,64 -44,65 -44,66 -44,66 -43,67 -43,68 -43,68 -44,69 -44,69 -45,70 -45,71 -45,72 -45,73 -45,74 -45,74 -46,75 -46,75 -47,75 -48,76 -48,77 -48,78 -48,79 -48,80 -48,80 -47,81 -47,82 -47,83 -47,84 -47,85 -47,86 -47,87 -47,88 -47,89 -47,90 -47,90 -46,91 -46,92 -46,93 -46,93 -45,94 -45,95 -45,96 -45,97 -45,98 -45,98 -44,99 -44,100 -44,101 -44,102 -44,102 -43,103 -43,104 -43,104 -44,105 -44,106 -44,107 -44,108 -44,108 -45,109 -45,110 -45,111 -45,112 -45,113 -45,114 -45,115 -45,116 -45,117 -45,118 -45,119 -45,120 -45,120 -44,121 -44,122 -44,122 -43,123 -43,123 -42,124 -42,124 -41,125 -41,126 -41,127 -41,127 -42,128 -42,128 -43,129 -43,129 -44,129 -45,129 -46,128 -46,128 -47,127 -47,127 -48,127 -49,126 -49,126 -50,125 -50,125 -51,124 -51,124 -52,123 -52,122 -52,122 -51,122 -50,121 -50,121 -51,121 -52,120 -52,120 -53,120 -54,119 -54,119 -55,120 -55,121 -55,122 -55,123 -55,123 -56,124 -56,125 -56,126 -56,127 -56,127 -55,128 -55,129 -55,130 -55,131 -55,132 -55,133 -55,133 -54,132 -54,132 -53,131 -53,131 -52,130 -52,130 -51,130 -50,130 -49,129 -49,129 -48,129 -47,130 -47,131 -47,132 -47,132 -48,132 -49,133 -49,134 -49,134 -48,134 -47,134 -46,134 -45,135 -45,135 -44,136 -44,137 -44,138 -44,139 -44,140 -44,140 -45,141 -45,142 -45,143 -45,144 -45,144 -46,145 -46,146 -46,147 -46,148 -46,149 -46,150 -46,151 -46,151 -47,152 -47,153 -47,153 -48,154 -48,154 -49,155 -49,156 -49,157 -49,158 -49,158 -50,159 -50,159 -51,160 -51,160 -50,161 -50,161 -51,162 -51,162 -52,163 -52,164 -52,165 -52,165 -51,165 -50,166 -50,167 -50,168 -50,169 -50,170 -50,171 -50,171 -51,172 -51,172 -50,173 -50,174 -50,174 -49,175 -49,175 -48,176 -48,177 -48,177 -47,178 -47,179 -47,179 -46,180 -46,180 -47,180 -48,180 -49,179 -49,178 -49,178 -50,177 -50,177 -51,176 -51,175 -51,175 -52,174 -52,174 -53,175 -53,176 -53,177 -53,177 -54,178 -54,179 -54,180 -54,180 -55,179 -55,178 -55,177 -55,177 -56,178 -56,179 -56,180 -56,180 -57,180 -58,180 -59,180 -60,180 -61,180 -62,180 -63,179 -63,179 -64,180 -64,180 -65,180 -66,179 -66,178 -66,177 -66,176 -66,175 -66,174 -66,173 -66,172 -66,171 -66,171 -67,172 -67,173 -67,173 -68,174 -68,175 -68,175 -69,176 -69,176 -70,177 -70,177 -71,178 -71,179 -71,179 -72,180 -72,180 -73,180 -74,179 -74,
```

@jonescc perhaps reduce resolution for some polygons?

@dnahodil any way of avoiding the JS chopping this string?
