### PR TITLE
"Rounding up" the end time so that all data is aggregated.

### DIFF
--- a/grails-app/services/au/org/emii/portal/GogoduckService.groovy
+++ b/grails-app/services/au/org/emii/portal/GogoduckService.groovy
@@ -1,8 +1,8 @@
 package au.org.emii.portal
 
+import grails.converters.JSON
 import groovyx.net.http.HTTPBuilder
 import groovyx.net.http.HttpResponseException
-import static groovyx.net.http.ContentType.JSON
 
 class GogoduckService {
 
@@ -14,8 +14,8 @@ class GogoduckService {
 
         _gogoduckConnection().post(
             [
-                body: jobParameters,
-                requestContentType: JSON
+                body: _roundUpEndTime(jobParameters),
+                requestContentType: groovyx.net.http.ContentType.JSON
             ],
             successHandler
         )
@@ -31,5 +31,22 @@ class GogoduckService {
     def successHandler = { response, reader ->
 
         log.debug "GoGoDuck response: ${response.statusLine}"
+    }
+
+    // This is to compensate for a lack of precision in the timestamps that NcWMS publishes
+    // (millisecond, whereas the NetCDF files can contain more precise timestamps).
+    def _roundUpEndTime(jobParametersAsString) {
+
+        def jobParameters = JSON.parse(jobParametersAsString)
+
+        if (jobParameters?.subsetDescriptor?.temporalExtent?.end) {
+            def endTime = 
+                jobParameters.subsetDescriptor.temporalExtent.end.replace('Z', '999Z')
+            jobParameters.subsetDescriptor.temporalExtent.end = endTime
+
+            return (jobParameters as JSON).toString()
+        }
+
+        return jobParametersAsString
     }
 }


### PR DESCRIPTION
The timestamps published by NcWMS are not as precise as those actually stored in the netCDF files, meaning that sometimes data is truncated without this change.

Fixes #1211 
