### PR TITLE
Change 'csv' -> 'csv-with-metadata-headers' behaviour

### DIFF
--- a/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
@@ -46,7 +46,7 @@ describe('Portal.cart.WfsDownloadHandler', function () {
 
                 downloadHandler(dummyCollection);
 
-                expect(dummyCollection.wmsLayer.getWfsLayerFeatureRequestUrl).toHaveBeenCalledWith('server_url', 'layer_name', 'csv');
+                expect(dummyCollection.wmsLayer.getWfsLayerFeatureRequestUrl).toHaveBeenCalledWith('server_url', 'layer_name', 'csv-with-metadata-header');
             });
         });
 

--- a/src/test/javascript/portal/prototypes/OpenLayersSpec.js
+++ b/src/test/javascript/portal/prototypes/OpenLayersSpec.js
@@ -204,15 +204,15 @@ describe('OpenLayers', function() {
             describe('_getServerSupportedOutputFormat', function() {
                 it("returns 'csv-with-metadata-header' if server does support CSV metadata header", function() {
                     openLayer.server.supportsCsvMetadataHeaderOutputFormat = true;
-                    expect(openLayer._getServerSupportedOutputFormat('csv')).toBe('csv-with-metadata-header');
+                    expect(openLayer._getServerSupportedOutputFormat('csv-with-metadata-header')).toBe('csv-with-metadata-header');
                 });
 
                 it("returns 'csv' if server does not support CSV metadata header", function() {
                     openLayer.server.supportsCsvMetadataHeaderOutputFormat = false;
-                    expect(openLayer._getServerSupportedOutputFormat('csv')).toBe('csv');
+                    expect(openLayer._getServerSupportedOutputFormat('csv-with-metadata-header')).toBe('csv');
                 });
 
-                it("returns given outputFormat for formats other than 'csv'", function() {
+                it("returns given outputFormat for formats other than 'csv-with-metadata-header'", function() {
                     expect(openLayer._getServerSupportedOutputFormat('xyz')).toBe('xyz');
                 });
             });

--- a/web-app/js/portal/cart/WfsDownloadHandler.js
+++ b/web-app/js/portal/cart/WfsDownloadHandler.js
@@ -43,7 +43,11 @@ Portal.cart.WfsDownloadHandler = Ext.extend(Object, {
         var serverUrl = this.onlineResource.href;
 
         return function(collection) {
-            return collection.wmsLayer.getWfsLayerFeatureRequestUrl(serverUrl, layerName, 'csv');
+            return collection.wmsLayer.getWfsLayerFeatureRequestUrl(
+                serverUrl,
+                layerName,
+                OpenLayers.Layer.DOWNLOAD_FORMAT_CSV_WITH_METADATA
+            );
         };
     }
 });

--- a/web-app/js/portal/cart/WmsInjector.js
+++ b/web-app/js/portal/cart/WmsInjector.js
@@ -49,6 +49,8 @@ Portal.cart.WmsInjector = Ext.extend(Portal.cart.BaseInjector, {
 
     _csvDownloadUrl: function(collection) {
 
-        return this._wmsDownloadUrl(collection, { format: 'csv' });
+        return this._wmsDownloadUrl(collection, {
+            format: OpenLayers.Layer.DOWNLOAD_FORMAT_CSV
+        });
     }
 });

--- a/web-app/js/portal/prototypes/OpenLayers.js
+++ b/web-app/js/portal/prototypes/OpenLayers.js
@@ -4,6 +4,10 @@
  * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
  *
  */
+
+OpenLayers.Layer.DOWNLOAD_FORMAT_CSV = 'csv';
+OpenLayers.Layer.DOWNLOAD_FORMAT_CSV_WITH_METADATA = 'csv-with-metadata-header';
+
 OpenLayers.Layer.prototype.isOverlay = function() {
     return !this.isBaseLayer;
 };
@@ -120,15 +124,15 @@ OpenLayers.Layer.WMS.prototype._buildGetFeatureRequestUrl = function(baseUrl, la
 OpenLayers.Layer.WMS.prototype._getServerSupportedOutputFormat = function(outputFormat) {
 
     // No special handling for formats other than 'csv'.
-    if (outputFormat != 'csv') {
+    if (outputFormat != OpenLayers.Layer.DOWNLOAD_FORMAT_CSV_WITH_METADATA) {
         return outputFormat;
     }
     // Request to have metadata inserted, if it's available.
     else if (this.server.supportsCsvMetadataHeaderOutputFormat) {
-        return 'csv-with-metadata-header';
+        return OpenLayers.Layer.DOWNLOAD_FORMAT_CSV_WITH_METADATA;
     }
     else {
-        return 'csv';
+        return OpenLayers.Layer.DOWNLOAD_FORMAT_CSV;
     }
 };
 


### PR DESCRIPTION
Demote a request for the enhanced behaviour if it can't be fulfilled rather than promoting it if it can. This means that callers can still request the simple behaviour if required.

Fix for #1257
