### PR TITLE
Fix for PO box Portal not starting

### DIFF
--- a/grails-app/migrations/imos-changelog.groovy
+++ b/grails-app/migrations/imos-changelog.groovy
@@ -38,7 +38,7 @@ databaseChangeLog = {
             }
         }
 
-        changeSet(author: "dnahodil (generated)", id: "1334815305155-2", failOnError: true) {
+        /*changeSet(author: "dnahodil (generated)", id: "1334815305155-2", failOnError: true) {
 
             update(tableName: "config")
             {
@@ -169,7 +169,7 @@ databaseChangeLog = {
 </table>\
 """)
             }
-        }
+        }*/
 
         changeSet(author: "dnahodil (generated)", id: "1353908954037-2", failOnError: true) {
 


### PR DESCRIPTION
aodn/project_officers_vm#8

Comment-out IMOS-specific migrations updating download_cart_confirmation_window_content in Config table. These migrations run out-of-order (a known problem) and the column no longer exists. This was stopping any recent build of the Portal (including that on the PO's dev box) from starting up from a clean database.
