### PR TITLE
CSS to show the crosshair while spatialExtent drawing is active

### DIFF
--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -837,6 +837,16 @@ ul.x-tab-strip-top li:hover * {
 
 /* openlayers */
 
+div.olMap:not(.miniMap) {
+    cursor: crosshair;
+}
+
+div.olMap div[class^="olControl"],
+.olDragDown,
+.olControlNavigationActive {
+    cursor: default;
+}
+
 .olControlPanel .olControlNavigationItemActive,
 .olControlPanel .olControlNavigationItemInactive,
 .olControlPanel .olControlZoomBoxItemActive,


### PR DESCRIPTION
This has had a look over by @pblain and does as required. 
