### PR TITLE
improve _openDownload function to not modify window.location

### DIFF
--- a/web-app/js/portal/cart/Downloader.js
+++ b/web-app/js/portal/cart/Downloader.js
@@ -7,6 +7,8 @@
 
 Ext.namespace('Portal.cart');
 
+var $downloaderLink;
+
 Portal.cart.Downloader = Ext.extend(Object, {
     download: function(collection, generateUrlCallbackScope, generateUrlCallback, params) {
 
@@ -67,7 +69,14 @@ Portal.cart.Downloader = Ext.extend(Object, {
 
     _openDownload: function(proxyUrl) {
         log.debug('Downloading using URL: ' + proxyUrl);
-        window.location = proxyUrl;
+
+        // Download function shamelessly stolen from:
+        // http://stackoverflow.com/a/12671023/1920729
+        if ($downloaderLink && $downloaderLink.length > 0) {
+            $downloaderLink.attr('src', proxyUrl);
+        } else {
+            $downloaderLink = $('<iframe>', { id:'downloaderLink', src:proxyUrl }).hide().appendTo('body');
+        }
     },
 
     _downloadAsynchronously: function(collection, downloadUrl, params) {


### PR DESCRIPTION
this will allow outstanding log.info and log.debug to stay in the same
window and not get cancelled

Fixes #1281 
