### PR TITLE
Possible change for #1288

### DIFF
--- a/grails-app/services/au/org/emii/portal/BulkDownloadService.groovy
+++ b/grails-app/services/au/org/emii/portal/BulkDownloadService.groovy
@@ -88,7 +88,8 @@ class BulkDownloadService {
         }
         catch (Exception e) {
 
-            log.warn "Error adding file to download archive. URL: '$url'", e
+            log.warn "Error adding file to download archive. URL: '$url'"
+            log.debug "Caused by:", e
 
             if (!streamFromUrl) {
                 def filenameInArchive = filenameToUse + '.failed'


### PR DESCRIPTION
@danfruehauf  a possible change to avoid huge logs associated with #1288

Only log exception details (including stack trace) if logging is set to 'debug'. This way most of the time there won't be big logs with stack traces, but we can turn them on if the cause of the problem is not obvious from the URL alone.
