### PR TITLE
Tidy up suggestion

### DIFF
--- a/web-app/js/portal/cart/BodaacDownloadHandler.js
+++ b/web-app/js/portal/cart/BodaacDownloadHandler.js
@@ -53,8 +53,11 @@ Portal.cart.BodaacDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
     },
 
     getDownloadEstimateParams: function(collection) {
+
+        var urlFn = this._getUrlGeneratorFunction();
+
         return {
-            url: this._getWmsFeatureRequestUrl(collection),
+            url: urlFn(collection),
             urlFieldName: this._urlFieldName()
         };
     },
@@ -64,19 +67,7 @@ Portal.cart.BodaacDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
         return this._resourceHrefNotEmpty() && this._resourceNameNotEmpty() && (this._resourceName().indexOf(this.NAME_FIELD_DELIMETER) > -1);
     },
 
-    _getWmsFeatureRequestUrl: function(collection) {
-
-        var wmsLayer = collection.wmsLayer;
-
-        return wmsLayer._buildGetFeatureRequestUrl(
-            this._resourceHref(),
-            this._layerName(),
-            OpenLayers.Layer.DOWNLOAD_FORMAT_CSV,
-            wmsLayer.getMapLayerFilters(true)
-        );
-    },
-
-    _getUrlGeneratorFunction: function(collection) {
+    _getUrlGeneratorFunction: function() {
 
         var _this = this;
 


### PR DESCRIPTION
@jkburges just wanted your feedback on this. 

It removes duplication but uses a function in a way that might be confusing.
ie.

<pre>
var urlFn = this._getUrlGeneratorFunction();

return {
    url: urlFn(collection),
    urlFieldName: this._urlFieldName()
};
</pre>


There might be a different way of declaring the functions so that the scoping works but this usage is clearer?
