### PR TITLE
Use an Ext label (instead of plain Container) so that there is no need t...

### DIFF
--- a/src/test/javascript/portal/details/NcWmsPanelSpec.js
+++ b/src/test/javascript/portal/details/NcWmsPanelSpec.js
@@ -163,7 +163,6 @@ describe('Portal.details.NcWmsPanel', function() {
 
     function _applyCommonSpies(panel) {
         var _panel = panel || ncwmsPanel;
-        spyOn(_panel, '_showAllControls');
         spyOn(_panel, '_onDateSelected');
         spyOn(_panel, '_setBounds');
     }

--- a/web-app/js/portal/details/NcWmsPanel.js
+++ b/web-app/js/portal/details/NcWmsPanel.js
@@ -47,18 +47,12 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Panel, {
 
         this.geoNetworkRecord = this.layer.parentGeoNetworkRecord;
 
-        this._showAllControls();
         this._clearDateTimeFields();
         this._attachTemporalEvents();
         this._attachSpatialEvents();
         this.layer.processTemporalExtent();
         this._removeLoadingInfo();
         this._applyFilterValuesFromMap();
-        this._showAllControls();
-    },
-
-    _showAllControls: function() {
-        this.temporalControls.show();
     },
 
     _removeLoadingInfo: function() {

--- a/web-app/js/portal/ui/TimeRangeLabel.js
+++ b/web-app/js/portal/ui/TimeRangeLabel.js
@@ -7,43 +7,31 @@
 
 Ext.namespace('Portal.ui');
 
-Portal.ui.TimeRangeLabel = Ext.extend(Ext.Container, {
+Portal.ui.TimeRangeLabel = Ext.extend(Ext.form.Label, {
 
     constructor: function(cfg) {
         var config = Ext.apply({
-            autoEl: 'div',
             html: this._loadingMessage()
         }, cfg);
 
         Portal.ui.TimeRangeLabel.superclass.constructor.call(this, config);
     },
 
-    initComponent: function() {
-
-        this.time = null;
-
-        this.on('afterrender', function() {
-            this.updateTime(this.time);
-        }, this);
-        Portal.ui.TimeRangeLabel.superclass.initComponent.call(this);
-    },
-
     updateTime: function(time) {
 
-        this.time = time;
-        if (this.isVisible()) {
-            this.update(String.format("<small><i><b>{0}</b>: {1}<br/></i></small>", OpenLayers.i18n('currentDateTimeLabel'), time));
-        }
+        this.setText(
+            String.format(
+                "<small><i><b>{0}</b>: {1}<br/></i></small>",
+                OpenLayers.i18n('currentDateTimeLabel'), time),
+            false
+        );
     },
 
     loading: function() {
-        if (this.rendered) {
-            this.update(this._loadingMessage());
-        }
+        this.setText(this._loadingMessage(), false);
     },
 
     _loadingMessage: function() {
         return String.format("<i>{0}</i>", OpenLayers.i18n("loadingMessage"));
     }
-
 });


### PR DESCRIPTION
...o handle/check for rendered status.

@pmbohm I have had a fiddle and made a couple of small changes... see below.

It seems that using an `Ext.form.Label`, as opposed to `Container`, and calling `setText` instead of `update`, handles both the rendered and non-rendered situation for us.

As you probably already found out, the problem before was that for the SRS layer, the code was trying to update the component before it was rendered.
