### PR TITLE
Fixes #1278 by keeping the subset panel open but offset

### DIFF
--- a/web-app/js/portal/details/SubsetPanel.js
+++ b/web-app/js/portal/details/SubsetPanel.js
@@ -33,6 +33,7 @@ Portal.details.SubsetPanel = Ext.extend(Ext.Panel, {
         var config = Ext.apply({
             title: OpenLayers.i18n('subsetPanelTitle'),
             layout: 'fit',
+            hideMode: 'offsets', // fixes #1278
             items: items
         }, cfg);
 


### PR DESCRIPTION
I want the comment to stay. This is an obtuse bug that took a day of work to come up with this tiny one line fix. 
