### PR TITLE
login popup position

### DIFF
--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -242,11 +242,13 @@ hr {
 }
 
 #loginPopup {
-    padding: 6px;
-    border: solid 1px silver;
     background-color: #ffffff;
+    border: 1px solid silver;
+    border-radius: 6px;
+    padding: 6px;
     position: absolute;
-    border-radius: 10px;
+    right: 10px;
+    top: 25px;
 }
 
 .searchField {


### PR DESCRIPTION
The login popup is now too close to the right after removing other links. This change will keep the popup in the same place if links are added or taken away
