### PR TITLE
Add server URL to the build info

### DIFF
--- a/grails-app/taglib/au/org/emii/portal/BuildInfoTagLib.groovy
+++ b/grails-app/taglib/au/org/emii/portal/BuildInfoTagLib.groovy
@@ -31,6 +31,7 @@ class BuildInfoTagLib {
     def getDetailedInfo() {
         """
             Instance name: ${portalInstance.name()}
+            URL: ${grailsApplication.config.grails.serverURL}
             Environment: ${Environment.current.name}
             App version: ${metadata.'app.version'}
             Build date: ${metadata.'app.build.date'}


### PR DESCRIPTION
With the new build pipeline, all of the environments (edge, RC, prod) will say "Environment: production" because that is the Grails Environment used for the build. This has already caused confusion for people reading/writing bug reports. Strictly speaking it's not build information but having the site URL in there should help avoid confusion.
