### PR TITLE
Adding optional Google Analytics code

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -165,6 +165,9 @@ featureToggles {
     hierarchicalFacets = false
 }
 
+// Google Analytics
+googleAnalytics.trackingId = null
+
 geonetwork.searchPath = featureToggles.hierarchicalFacets ? 'xml.search.imos' : 'xml.search.summary'
 
 // set per-environment serverURL stem for creating absolute links
@@ -183,7 +186,7 @@ environments {
         geonetwork.url = env['GEONETWORK_URL'] ?: "http://catalogue-rc.aodn.org.au/geonetwork"
 
         grails.mail.disabled = true
-        
+
         featureToggles.pythonDownload = true
     }
 

--- a/grails-app/views/_google_analytics.gsp
+++ b/grails-app/views/_google_analytics.gsp
@@ -1,0 +1,11 @@
+<g:if test="${grailsApplication.config.googleAnalytics.trackingId}">
+    <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+        ga('create', '${grailsApplication.config.googleAnalytics.trackingId}', 'auto');
+        ga('send', 'pageview');
+    </script>
+</g:if>

--- a/grails-app/views/landing/IMOSindex.gsp
+++ b/grails-app/views/landing/IMOSindex.gsp
@@ -98,5 +98,6 @@ The AODN/IMOS Portal is distributed under the terms of the GNU General Public Li
                 </div>
             </div>
         </div>
+        <g:render template="/google_analytics"></g:render>
     </body>
 </html>


### PR DESCRIPTION
To help with our work with an SEO specialist Pete has asked that we add Google Analytics code to the Portal landing page.

There will be a separate chef PR for adding the correct tracking id to the production Portal.
