### PR TITLE
Load external config *after* everything else.  This means that chef can ...

### DIFF
--- a/grails-app/conf/au/org/emii/portal/LoggingFilters.groovy
+++ b/grails-app/conf/au/org/emii/portal/LoggingFilters.groovy
@@ -26,14 +26,14 @@ class LoggingFilters {
 
                 // User data
                 def principal = SecurityUtils?.subject?.principal
-                MDC.put 'userInfoForFile', userInfoForFile(principal)
+                MDC.put 'username', userInfoForFile(principal)
             }
 
             afterView = {
 
                 MDC.remove 'clientAddress'
                 MDC.remove 'userAgent'
-                MDC.remove 'userInfoForFile'
+                MDC.remove 'username'
             }
         }
     }


### PR DESCRIPTION
...override _anything_ (including log configuration, which is specifically why this change is being done).

Consistency in custom log fields (c.f. aatams) - this is to make log collection and parsing easier.
