### PR TITLE
fix #1149, main panel activated when gn record added

### DIFF
--- a/src/test/javascript/portal/ui/MainPanelSpec.js
+++ b/src/test/javascript/portal/ui/MainPanelSpec.js
@@ -25,7 +25,7 @@ describe("Portal.ui.MainPanel", function() {
     });
 
     afterEach(function() {
-        Ext.MsgBus.unsubscribe(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, mainPanel._onViewGeoNetworkRecord, mainPanel);
+        Ext.MsgBus.unsubscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, mainPanel._onActiveGeoNetworkRecordAdded, mainPanel);
     });
 
     describe('initialisation', function() {
@@ -56,9 +56,9 @@ describe("Portal.ui.MainPanel", function() {
             expect(mainPanel.activeItem).toBe(TAB_INDEX_SEARCH);
         });
 
-        it('should set visualise to active item when geonetwork record is viewed', function() {
+        it('should set visualise to active item when geonetwork record is added', function() {
             spyOn(mainPanel.layout, 'setActiveItem');
-            Ext.MsgBus.publish(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD);
+            Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED);
             expect(mainPanel.layout.setActiveItem).toHaveBeenCalledWith(TAB_INDEX_VISUALISE);
         });
 

--- a/web-app/js/portal/ui/MainPanel.js
+++ b/web-app/js/portal/ui/MainPanel.js
@@ -41,10 +41,10 @@ Portal.ui.MainPanel = Ext.extend(Ext.Panel, {
 
         Portal.ui.MainPanel.superclass.constructor.call(this, config);
 
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, this._onViewGeoNetworkRecord, this);
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, this._onActiveGeoNetworkRecordAdded, this);
     },
 
-    _onViewGeoNetworkRecord: function() {
+    _onActiveGeoNetworkRecordAdded: function() {
         this.setActiveTab(TAB_INDEX_VISUALISE);
     },
 


### PR DESCRIPTION
make MainPanel register on ACTIVE_GEONETWORK_RECORD_ADDED as only after
this even is fired all the attributes of the collection are being set
properly for step 2 and step 3. registering on VIEW_GEONETWORK_RECORD
can potentially allow the user to navigate to step 2 and 3 with
uninitialized variables.
