### PR TITLE
fix #1149 using 2 phase layer loading

### DIFF
--- a/src/test/javascript/portal/cart/DownloadPanelBodySpec.js
+++ b/src/test/javascript/portal/cart/DownloadPanelBodySpec.js
@@ -48,7 +48,8 @@ describe("Portal.cart.DownloadPanelBody", function() {
             var items = [];
             Ext.each(collections, function(collection) {
                 items.push({
-                    data: collection
+                    data: collection,
+                    loaded: true
                 });
             });
 

--- a/src/test/javascript/portal/cart/DownloadPanelSpec.js
+++ b/src/test/javascript/portal/cart/DownloadPanelSpec.js
@@ -17,17 +17,19 @@ describe("Portal.cart.DownloadPanel", function() {
         spyOn(downloadPanel.downloadPanelBody, 'generateContent');
     });
 
+    afterEach(function() {
+        downloadPanel.destroy();
+    });
+
     describe('initComponent()', function() {
         it('listens for beforeshow event', function() {
             downloadPanel.fireEvent('beforeshow');
 
             expect(downloadPanel.downloadPanelBody.generateContent).toHaveBeenCalled();
         });
-    });
 
-    describe('onBeforeShow()', function() {
-        it('calls refresh() on its view', function() {
-            downloadPanel.onBeforeShow();
+        it('listens for ACTIVE_GEONETWORK_RECORD_ADDED event', function() {
+            Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED);
 
             expect(downloadPanel.downloadPanelBody.generateContent).toHaveBeenCalled();
         });

--- a/src/test/javascript/portal/data/ActiveGeoNetworkRecordStoreSpec.js
+++ b/src/test/javascript/portal/data/ActiveGeoNetworkRecordStoreSpec.js
@@ -33,6 +33,28 @@ describe("Portal.data.ActiveGeoNetworkRecordStore", function() {
             });
         });
 
+        describe('returns only loaded records', function() {
+            it('when no records', function() {
+                expect(activeRecordStore.getLoadedRecords().length).toBe(0);
+            });
+
+            it('when 3 records, only 1 loaded', function() {
+                activeRecordStore.add(new Portal.data.GeoNetworkRecord({ title: 'my record1' }));
+                activeRecordStore.add(new Portal.data.GeoNetworkRecord({ title: 'my record2' }));
+                activeRecordStore.add(new Portal.data.GeoNetworkRecord({ title: 'my record3' }));
+
+                // Sanity check to make sure we have 3 records in
+                expect(activeRecordStore.getLoadedRecords().length).toBe(3);
+
+                // Mark record as not loaded by setting loaded to false
+                activeRecordStore.data.items[0].loaded = false;
+                // Mark record as not loaded by removing attribute
+                delete activeRecordStore.data.items[1].loaded;
+
+                expect(activeRecordStore.getLoadedRecords().length).toBe(1);
+            });
+        });
+
         describe('interaction with MsgBus', function() {
 
             var myRecord;
@@ -47,7 +69,7 @@ describe("Portal.data.ActiveGeoNetworkRecordStore", function() {
             describe('when adding/removing records', function() {
                 it('geonetwork added message is fired', function() {
                     activeRecordStore.add(myRecord);
-                    expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, [myRecord]);
+                    expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, myRecord);
                 });
 
                 it('geonetwork removed message is fired', function() {

--- a/web-app/js/portal/cart/DownloadPanel.js
+++ b/web-app/js/portal/cart/DownloadPanel.js
@@ -27,10 +27,15 @@ Portal.cart.DownloadPanel = Ext.extend(Ext.Panel, {
 
         Ext.apply(this, config);
         Portal.cart.DownloadPanel.superclass.initComponent.call(this, arguments);
-        this.on('beforeshow', function() { this.onBeforeShow() }, this);
+        this._registerEvents();
     },
 
-    onBeforeShow: function() {
+    _registerEvents: function() {
+        this.on('beforeshow', function() { this.generateContent() }, this);
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, this.generateContent, this);
+    },
+
+    generateContent: function() {
         this.downloadPanelBody.generateContent();
     }
 });

--- a/web-app/js/portal/cart/DownloadPanelBody.js
+++ b/web-app/js/portal/cart/DownloadPanelBody.js
@@ -28,8 +28,7 @@ Portal.cart.DownloadPanelBody = Ext.extend(Ext.Panel, {
         var html = '';
 
         // Reverse the order of items, last item added will be displayed first
-        for (var i = this.store.data.items.length - 1; i >= 0; i--) {
-            var item = this.store.data.items[i];
+        Ext.each(this.store.getLoadedRecords().reverse(), function(item) {
             var collection = item.data;
 
             var service = new Portal.cart.InsertionService(this);
@@ -38,7 +37,7 @@ Portal.cart.DownloadPanelBody = Ext.extend(Ext.Panel, {
             this._loadMenuItemsFromHandlers(processedValues, collection);
 
             html += tpl.apply(processedValues);
-        }
+        }, this);
 
         if (!html) {
             html = this._contentForEmptyView();

--- a/web-app/js/portal/data/ActiveGeoNetworkRecordStore.js
+++ b/web-app/js/portal/data/ActiveGeoNetworkRecordStore.js
@@ -27,6 +27,8 @@ Portal.data.ActiveGeoNetworkRecordStore = Ext.extend(Portal.data.GeoNetworkRecor
     },
 
     _onAdd: function(store, geoNetworkRecords) {
+        var thisStore = this;
+
         Ext.each(geoNetworkRecords, function(geoNetworkRecord) {
             if (geoNetworkRecord.hasWmsLink()) {
 
@@ -42,12 +44,20 @@ Portal.data.ActiveGeoNetworkRecordStore = Ext.extend(Portal.data.GeoNetworkRecor
                         wmsLayer.parentGeoNetworkRecord = geoNetworkRecord;
                         // Make it easier to access geonetwork UUID of this layer
                         wmsLayer.metadataUuid = geoNetworkRecord.data.uuid;
+
+                        thisStore._recordLoaded(geoNetworkRecord);
                     }
                 );
             }
+            else {
+                thisStore._recordLoaded(geoNetworkRecord);
+            }
         }, this);
+    },
 
-        Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, geoNetworkRecords);
+    _recordLoaded: function(geoNetworkRecord) {
+        geoNetworkRecord.loaded = true;
+        Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, geoNetworkRecord);
     },
 
     _onRemove: function(store, record) {
@@ -110,6 +120,14 @@ Portal.data.ActiveGeoNetworkRecordStore = Ext.extend(Portal.data.GeoNetworkRecor
             return this.recordAttributes.uuid.key;
         }
         return null;
+    },
+
+    getLoadedRecords: function() {
+        var loadedRecords = [];
+        this.each(function(record) {
+            if (record.loaded) { loadedRecords.push(record); }
+        });
+        return loadedRecords;
     }
 });
 

--- a/web-app/js/portal/ui/openlayers/layer/NcWMS.js
+++ b/web-app/js/portal/ui/openlayers/layer/NcWMS.js
@@ -199,6 +199,9 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
     },
 
     getCqlForTemporalExtent: function() {
+        if (!this.bodaacFilterParams) {
+            return null;
+        }
 
         var cqlParts = [];
 


### PR DESCRIPTION
ActiveGeoNetworkRecordStore will load collections in 2 steps. the first
step is to insert the layer into the store, the second would be to mark
it as 'loaded', so the download InsertionService knows what collections
are loaded and can be displayed in the cart and what collections are
still loaded. after a collection is fully loaded it'll trigger a redraw
of the cart.
