### PR TITLE
Catch and log error during proxying

### DIFF
--- a/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
+++ b/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
@@ -35,7 +35,15 @@ class ProxiedRequest extends ExternalRequest {
 
         _determineResponseContentType()
 
-        executeRequest(streamProcessor)
+        try {
+            executeRequest(streamProcessor)
+        }
+        catch (Exception e) {
+            // Nothing more can be done here, we just don't want the Exception to propagate
+            // The outputStream might already have been written-to so it's in an unknown state
+
+            log.warn "Failure while proxying request", e
+        }
     }
 
     def _determineResponseContentType = {


### PR DESCRIPTION
If we try and render the error page (which is what would happen if we let the exception keep
going) we will get more exceptions because the outputStream has already been accessed (and
may have been written-to). These other exceptions just produce noise in the log file.
