### PR TITLE
remove reference to name column in config table

### DIFF
--- a/grails-app/migrations/20140108-PB-IMOSHeaderChanges.groovy
+++ b/grails-app/migrations/20140108-PB-IMOSHeaderChanges.groovy
@@ -5,9 +5,5 @@ databaseChangeLog = {
         update(tableName: "config") {
             column(name: "header_height", value: "140")
         }
-
-        update(tableName: "config") {
-            column(name: "name", value: "Open Access to Ocean Data")
-        }
     }
 }

--- a/grails-app/migrations/imos-changelog.groovy
+++ b/grails-app/migrations/imos-changelog.groovy
@@ -11,15 +11,6 @@ databaseChangeLog = {
     if (System.getProperty("INSTANCE_NAME") == 'IMOS') {
         // All IMOS specific change sets must appear inside this if block
 
-        changeSet(author: "tfotak (generated)", id: "1332134693000-1", failOnError: true) {
-
-            update(tableName: "config")
-            {
-                column(name:"name", value: "Integrated Marine Observing System")
-                where "id = (select id from config limit 1)"
-            }
-        }
-
         changeSet(author: "tfotak (generated)", id: "1332201909000-1", failOnError: true) {
 
             update(tableName: "config")


### PR DESCRIPTION
the two references migrations are referencing the name column in the
config table which was removed. they are being included in the liquibase
migrations after the migration which removes the column was called and
cause a liquibase migrations on a clean database to fail
