### PR TITLE
Fixes #1433 - the autozoom to layer checkbox label is now visible

### DIFF
--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -924,6 +924,7 @@ div.olControlMousePosition {
     border-radius: 6px 0 0 6px;
     font-size: smaller ! important;
     font-weight: normal ! important;
+    color: inherit! important;
 }
 
 .olControlLayerSwitcher .layersDiv, .olControlLayerSwitcher > div > span {

--- a/web-app/js/portal/ui/MapOptionsPanel.js
+++ b/web-app/js/portal/ui/MapOptionsPanel.js
@@ -37,20 +37,10 @@ Portal.ui.MapOptionsPanel = Ext.extend(Ext.Panel, {
             id: 'mapOptions',
             padding: 5,
             items: [
-                new Ext.Panel({
-                    height: 20,
-                    items: [
-                        {
-                            flex: 3,
-                            items: [
-                                this.autoZoomCheckbox
-                            ]
-                        }
-                    ]
-                }),
+                this.autoZoomCheckbox,
                 new Ext.Spacer({height: 5}),
                 this.buttonPanel,
-                new Ext.Spacer({height: 2}),
+                new Ext.Spacer({height: 5}),
                 this.baseLayerCombo
             ]
         }, cfg);


### PR DESCRIPTION
The autozoom to layer checkbox label is now visible
