### PR TITLE
Renaming 'metadata' when referring to extra ncWMS layer information

### DIFF
--- a/src/test/javascript/OpenLayers/Layer/NcWMSSpec.js
+++ b/src/test/javascript/OpenLayers/Layer/NcWMSSpec.js
@@ -141,7 +141,7 @@ describe("OpenLayers.Layer.NcWMS", function() {
         });
     });
 
-    describe('_metadataLoaded', function() {
+    describe('_extraLayerInfoLoaded', function() {
         var sampleJson = '{ test: 1, supportedStyles: [], palettes: [] }';
 
         beforeEach(function() {
@@ -152,39 +152,39 @@ describe("OpenLayers.Layer.NcWMS", function() {
         });
 
         it('calls _parseDatesWithData', function() {
-            cachedLayer._metadataLoaded(sampleJson);
+            cachedLayer._extraLayerInfoLoaded(sampleJson);
             expect(cachedLayer._parseDatesWithData).toHaveBeenCalled();
         });
 
         it('calls addDays', function() {
             spyOn(cachedLayer.temporalExtent, 'addDays');
-            cachedLayer._metadataLoaded(sampleJson);
+            cachedLayer._extraLayerInfoLoaded(sampleJson);
             expect(cachedLayer.temporalExtent.addDays).toHaveBeenCalled();
         });
 
         it('loads first day', function() {
-            cachedLayer._metadataLoaded(sampleJson);
+            cachedLayer._extraLayerInfoLoaded(sampleJson);
             expect(cachedLayer.temporalExtent.getFirstDay).toHaveBeenCalled();
             expect(cachedLayer.loadTimeSeriesForDay).toHaveBeenCalled();
         });
 
         it('loads last day', function() {
-            cachedLayer._metadataLoaded(sampleJson);
+            cachedLayer._extraLayerInfoLoaded(sampleJson);
             expect(cachedLayer.temporalExtent.getLastDay).toHaveBeenCalled();
             expect(cachedLayer.loadTimeSeriesForDay).toHaveBeenCalled();
         });
     });
 
-    describe('_loadStylesFromMetadata', function() {
+    describe('_loadStylesFromExtraLayerInfo', function() {
 
-        it('sets styles property from metadata', function() {
+        it('sets styles property from extraLayerInfo', function() {
 
-            cachedLayer.metadata = {
+            cachedLayer.extraLayerInfo = {
                 supportedStyles: ['styleA', 'styleC', 'styleB'],
                 palettes: ['paletteB', 'paletteC', 'paletteA']
             };
 
-            cachedLayer._loadStylesFromMetadata();
+            cachedLayer._loadStylesFromExtraLayerInfo();
 
             expect(cachedLayer.styles).toEqual(
                 [

--- a/src/test/javascript/portal/ui/openlayers/layer/NcWMSSpec.js
+++ b/src/test/javascript/portal/ui/openlayers/layer/NcWMSSpec.js
@@ -44,28 +44,28 @@ describe('Portal.ui.openlayers.layer.NcWMS', function() {
     describe('_setMetadataFromNcWMS', function() {
 
         it('called from initialize', function() {
-            spyOn(OpenLayers.Layer.NcWMS.prototype, '_setMetadataFromNcWMS');
+            spyOn(OpenLayers.Layer.NcWMS.prototype, '_setExtraLayerInfoFromNcWMS');
 
             var ncwmsLayer = mockNcwmsLayer();
 
-            expect(ncwmsLayer._setMetadataFromNcWMS).toHaveBeenCalled();
+            expect(ncwmsLayer._setExtraLayerInfoFromNcWMS).toHaveBeenCalled();
         });
 
-        it('_getMetadataFromNcWMS generates URL', function() {
+        it('_getExtraLayerInfoFromNcwmsUrl generates URL', function() {
             var ncwmsLayer = mockNcwmsLayer();
 
-            expect(ncwmsLayer._getMetadataFromNcWMS()).toEqual(
+            expect(ncwmsLayer._getExtraLayerInfoFromNcwmsUrl()).toEqual(
                 'http://ncwms.aodn.org.au/ncwms/wms?layerName=ncwmsLayerName&REQUEST=GetMetadata&item=layerDetails'
             );
         });
 
-        it('_setMetadataFromNcWMS calls URL', function() {
-            spyOn(OpenLayers.Layer.NcWMS.prototype, '_getMetadataFromNcWMS').andReturn('mockedMetadataUrl');
+        it('_setExtraLayerInfoFromNcWMS calls URL', function() {
+            spyOn(OpenLayers.Layer.NcWMS.prototype, '_getExtraLayerInfoFromNcwmsUrl').andReturn('mockedMetadataUrl');
             spyOn(Ext.ux.Ajax, 'proxyRequest');
 
             var ncwmsLayer = mockNcwmsLayer();
 
-            expect(ncwmsLayer._getMetadataFromNcWMS).toHaveBeenCalled();
+            expect(ncwmsLayer._getExtraLayerInfoFromNcwmsUrl).toHaveBeenCalled();
 
             var ajaxParams = Ext.ux.Ajax.proxyRequest.mostRecentCall.args[0];
             expect(ajaxParams.url).toBe("mockedMetadataUrl");

--- a/web-app/js/portal/ui/openlayers/layer/NcWMS.js
+++ b/web-app/js/portal/ui/openlayers/layer/NcWMS.js
@@ -39,36 +39,36 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
 
         // We assume that before the first GFI request we will be quick enough
         // to complete that little tiny request
-        this._setMetadataFromNcWMS();
+        this._setExtraLayerInfoFromNcWMS();
     },
 
-    _setMetadataFromNcWMS: function() {
+    _setExtraLayerInfoFromNcWMS: function() {
         Ext.ux.Ajax.proxyRequest({
             scope: this,
-            url: this._getMetadataFromNcWMS(),
+            url: this._getExtraLayerInfoFromNcwmsUrl(),
             success: function(resp, options) {
                 try {
-                    this._metadataLoaded(resp.responseText);
+                    this._extraLayerInfoLoaded(resp.responseText);
                 }
                 catch (e) {
-                    log.error("Could not parse metadata for NcWMS layer '" + this.params.LAYERS + "'");
+                    log.error("Could not parse extra layer info for NcWMS layer '" + this.params.LAYERS + "'");
                 }
             },
             failure: function() {
-                log.error("Could not get metadata for NcWMS layer '" + this.params.LAYERS + "'");
+                log.error("Could not get extra layer info for NcWMS layer '" + this.params.LAYERS + "'");
             }
         });
     },
 
-    _metadataLoaded: function(response) {
-        this.metadata = Ext.util.JSON.decode(response);
+    _extraLayerInfoLoaded: function(response) {
+        this.extraLayerInfo = Ext.util.JSON.decode(response);
 
-        this._loadTimesFromMetadata();
-        this._loadStylesFromMetadata();
+        this._loadTimesFromExtraLayerInfo();
+        this._loadStylesFromExtraLayerInfo();
     },
 
-    _loadTimesFromMetadata: function() {
-        var datesWithData = this._parseDatesWithData(this.metadata);
+    _loadTimesFromExtraLayerInfo: function() {
+        var datesWithData = this._parseDatesWithData(this.extraLayerInfo);
 
         this.temporalExtent.addDays(datesWithData);
 
@@ -76,16 +76,16 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
         this.loadTimeSeriesForDay(this.temporalExtent.getLastDay());
     },
 
-    _loadStylesFromMetadata: function() {
+    _loadStylesFromExtraLayerInfo: function() {
 
         var styles = [];
 
-        this.metadata.supportedStyles.sort();
-        this.metadata.palettes.sort();
+        this.extraLayerInfo.supportedStyles.sort();
+        this.extraLayerInfo.palettes.sort();
 
-        Ext.each(this.metadata.supportedStyles, function(style) {
+        Ext.each(this.extraLayerInfo.supportedStyles, function(style) {
 
-            Ext.each(this.metadata.palettes, function(palette) {
+            Ext.each(this.extraLayerInfo.palettes, function(palette) {
 
                 styles.push({
                     name: style,
@@ -245,15 +245,15 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
         return OpenLayers.Layer.WMS.prototype.getURL.apply(this, [bounds]);
     },
 
-    _parseDatesWithData: function(ncwmsMetadata) {
+    _parseDatesWithData: function(ncwmsExtraLayerInfo) {
         datesWithDataArray = [];
 
-        if (ncwmsMetadata['datesWithData']) {
-            Ext.each(Object.keys(ncwmsMetadata['datesWithData']), function(year) {
+        if (ncwmsExtraLayerInfo['datesWithData']) {
+            Ext.each(Object.keys(ncwmsExtraLayerInfo['datesWithData']), function(year) {
                 year = parseInt(year);
-                Ext.each(Object.keys(ncwmsMetadata['datesWithData'][year]), function(month) {
+                Ext.each(Object.keys(ncwmsExtraLayerInfo['datesWithData'][year]), function(month) {
                     month = parseInt(month);
-                    Ext.each(ncwmsMetadata['datesWithData'][year][month], function(day) {
+                    Ext.each(ncwmsExtraLayerInfo['datesWithData'][year][month], function(day) {
                         day = parseInt(day);
                         // IMPORTANT - month is zero based (0-11)
                         var dateWithData = new moment.utc();
@@ -274,14 +274,12 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
         return dateTime.clone().utc().format('YYYY-MM-DDTHH:mm:ss.SSS');
     },
 
-    _getMetadataFromNcWMS: function() {
-        var metadataUrl = this.url + "?layerName=" + this.params.LAYERS + "&REQUEST=GetMetadata&item=layerDetails";
-        return metadataUrl;
+    _getExtraLayerInfoFromNcwmsUrl: function() {
+        return this.url + "?layerName=" + this.params.LAYERS + "&REQUEST=GetMetadata&item=layerDetails";
     },
 
     _getTimeSeriesUrl: function(date) {
-        var timeSeriesUrl = this.url + "?layerName=" + this.params.LAYERS + "&REQUEST=GetMetadata&item=timesteps&day=" + date.clone().startOf('day').toISOString();
-        return timeSeriesUrl;
+        return this.url + "?layerName=" + this.params.LAYERS + "&REQUEST=GetMetadata&item=timesteps&day=" + date.clone().startOf('day').toISOString();
     },
 
     /* Overrides */


### PR DESCRIPTION
Renaming 'metadata' to 'extraLayerInfo' when referring to extra information about ncWMS layers to avoid confusion.

What do you think of "extraLayerInfo" replacing "metadata", @danfruehauf?
