### PR TITLE
Correct cursor when drag/panning in Step 2

### DIFF
--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -830,6 +830,10 @@ div.olMap div[class^="olControl"],
     cursor: default;
 }
 
+div.olMap .olControlDragPanActive.olDragDown {
+    cursor: all-scroll;
+}
+
 .olControlPanel .olControlNavigationItemActive,
 .olControlPanel .olControlNavigationItemInactive,
 .olControlPanel .olControlZoomBoxItemActive,


### PR DESCRIPTION
When Pan Drag is active and the users drags on the map a drag icon is used for the cursor.
The CSS3 'drag' or 'dragging' options are not yet supported.
