### PR TITLE
async date loading

### DIFF
--- a/src/test/javascript/OpenLayers/Layer/NcWMSSpec.js
+++ b/src/test/javascript/OpenLayers/Layer/NcWMSSpec.js
@@ -99,11 +99,19 @@ describe("OpenLayers.Layer.NcWMS", function() {
 
     describe("loadTimeSeriesForDay", function() {
         it("when already loaded", function() {
-            spyOn(cachedLayer, '_timeSeriesLoadedForDate').andCallFake(function() {});
+            var functionCalled = false;
+            spyOn(cachedLayer, '_timeSeriesLoadedForDate').andCallFake(function() { functionCalled = true });
             cachedLayer.temporalExtent.parse(['2001-07-02T00:00:00']);
 
             cachedLayer.loadTimeSeriesForDay(moment.utc('2001-07-02T00:00:00Z'));
-            expect(cachedLayer._timeSeriesLoadedForDate).toHaveBeenCalled();
+
+            waitsFor(function() {
+                return functionCalled;
+            }, "_timeSeriesDatesLoaded not called", 1000);
+
+            runs(function() {
+                expect(cachedLayer._timeSeriesLoadedForDate).toHaveBeenCalled();
+            });
         });
 
         it("when not loaded", function() {

--- a/web-app/js/portal/ui/openlayers/layer/NcWMS.js
+++ b/web-app/js/portal/ui/openlayers/layer/NcWMS.js
@@ -148,7 +148,9 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
 
     loadTimeSeriesForDay: function(date) {
         if (this.getTimeSeriesForDay(date)) {
-            this._timeSeriesLoadedForDate();
+            // Give UI precedence by using delayed function call (setTimeout)
+            var that = this;
+            setTimeout(function() { that._timeSeriesLoadedForDate(); }, 10);
         }
         else {
             this._fetchTimeSeriesForDay(date);


### PR DESCRIPTION
- asynchronous date loading interleaves the loading by loading chunks and releasing control back to the browser every once in a while
- when a date is loaded, let the ui first handle the redrawing events and only then notify the date was already loaded
