### PR TITLE
Refreshes Step 3 on collection removal

### DIFF
--- a/src/test/javascript/portal/cart/DownloadPanelSpec.js
+++ b/src/test/javascript/portal/cart/DownloadPanelSpec.js
@@ -33,6 +33,12 @@ describe("Portal.cart.DownloadPanel", function() {
 
             expect(downloadPanel.downloadPanelBody.generateBodyContent).toHaveBeenCalled();
         });
+
+        it('listens for ACTIVE_GEONETWORK_RECORD_REMOVED event', function() {
+            Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED);
+
+            expect(downloadPanel.downloadPanelBody.generateBodyContent).toHaveBeenCalled();
+        });
     });
 
     describe('step title', function() {

--- a/web-app/js/portal/cart/DownloadPanel.js
+++ b/web-app/js/portal/cart/DownloadPanel.js
@@ -33,6 +33,7 @@ Portal.cart.DownloadPanel = Ext.extend(Ext.Panel, {
     _registerEvents: function() {
         this.on('beforeshow', function() { this.generateContent() }, this);
         Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, this.generateContent, this);
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED, this.generateContent, this);
     },
 
     generateContent: function() {

--- a/web-app/js/portal/cart/DownloadPanelItemTemplate.js
+++ b/web-app/js/portal/cart/DownloadPanelItemTemplate.js
@@ -11,7 +11,6 @@ Portal.cart.DownloadPanelItemTemplate = Ext.extend(Ext.XTemplate, {
     constructor: function(cfg) {
 
         var templateLines = this._getHtmlContent();
-        Ext.apply(this, cfg);
 
         Portal.cart.DownloadPanelItemTemplate.superclass.constructor.call(this, templateLines);
     },
@@ -138,7 +137,6 @@ Portal.cart.DownloadPanelItemTemplate = Ext.extend(Ext.XTemplate, {
         var collectionId = this.getIdFromButtonContainerId(button, "removeButtonId");
         var record = Portal.data.ActiveGeoNetworkRecordStore.instance().getRecordFromUuid(collectionId);
         Portal.data.ActiveGeoNetworkRecordStore.instance().remove(record);
-        this.generateContent();
     },
 
     _getFileListEntries: function(values) {


### PR DESCRIPTION
Important fix as the remove button seems to have no effect. Where this went pear shaped, i have no idea! But it listens to the ACTIVE_GEONETWORK_RECORD_REMOVED event which is a better solution. 
Fixes #1466
