### PR TITLE
Filters are grouped in containers in step 2

### DIFF
--- a/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
@@ -11,7 +11,7 @@ describe("Portal.filter.FilterGroupPanel", function() {
 
     beforeEach(function() {
         layer = new OpenLayers.Layer.WMS();
-        layer.isKnownToThePortal = function() { return true; }
+        layer.isKnownToThePortal = function() { return true; };
 
         filterGroupPanel = new Portal.filter.FilterGroupPanel({
             layer: layer
@@ -60,27 +60,27 @@ describe("Portal.filter.FilterGroupPanel", function() {
             layer = {};
             layer.filters = [
                 {type: 'Boolean', label: 'A'},
-                {type: 'Boolean', label: 'E'},
                 {type: 'Date', label: 'B'},
                 {type: 'DateRange', label: 'Z'},
+                {type: 'Boolean', label: 'E'},
                 {type: 'BoundingBox', label: 'C'},
                 {type: 'String', label: 'D'}
             ];
             expectedReturn = [
-                {type : 'BoundingBox', sortOrder : 2, label: 'C'},
-                {type : 'Date', sortOrder : 1, label: 'B'},
-                {type : 'DateRange', sortOrder : 0, label: 'Z'},
-                {type : 'Boolean', sortOrder : -1, label: 'A'},
-                {type : 'String', sortOrder : -1, label: 'D'},
-                {type : 'Boolean', sortOrder : -1, label: 'E'}
-            ]
+                {type : 'BoundingBox', sortOrder : 5, label: 'C'},
+                {type : 'Date', sortOrder : 4, label: 'B'},
+                {type : 'DateRange', sortOrder : 3, label: 'Z'},
+                {type : 'Boolean', sortOrder : 2, label: 'A'},
+                {type : 'Boolean', sortOrder : 2, label: 'E'},
+                {type : 'String', sortOrder : 0, label: 'D'}
+            ];
 
             filterGroupPanel = new Portal.filter.FilterGroupPanel({
                 layer: layer
             });
         });
 
-        it('sorts with spatial and temporal filters at the top, alphabetic afterwards', function() {
+        it('sorts by specified order', function() {
             expect(filterGroupPanel._filtersSort(layer.filters)).toEqual(expectedReturn);
         });
     });

--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -345,6 +345,16 @@ hr {
     margin: 7px 0;
 }
 
+.block {
+    display: block;
+    clear: both;
+}
+
+/* matches fixed width comboFilters */
+.clearFiltersButton {
+    margin-left: 220px;
+}
+
 .logoSpacer {
     margin: 2px;
 }
@@ -1099,6 +1109,10 @@ div.allwhite {
     height: inherit;
 }
 
+.filterGroupPanel {
+    padding-left: 10px ;
+}
+
 .search-filter-panel .x-panel-header {
     height: 12px;
     font-size: 13px;
@@ -1117,6 +1131,10 @@ div.allwhite {
 
 .term-selection-panel .x-panel-header:hover {
     background-color: #eeeeee;
+}
+
+.filterGroupPanel h4 {
+    padding: 7px 0;
 }
 
 .p-selected-view {
@@ -1374,7 +1392,9 @@ div.allwhite {
     top: 3px;
     font-style: italic;
 }
-
+.x-menu-list-item {
+    font: inherit;
+}
 .bboxExtentPicker .x-box-layout-ct {
     margin: 4px;
 }

--- a/web-app/js/ext-3.3.1/resources/css/xBaseTheme.css
+++ b/web-app/js/ext-3.3.1/resources/css/xBaseTheme.css
@@ -635,7 +635,6 @@ td.x-grid3-hd-over, td.sort-desc, td.sort-asc, td.x-grid3-hd-menu-open {
 td.x-grid3-hd-over .x-grid3-hd-inner, td.sort-desc .x-grid3-hd-inner, td.sort-asc .x-grid3-hd-inner, td.x-grid3-hd-menu-open .x-grid3-hd-inner {
     background-color: #f9f9f9;
     background-image: url(../images/xBase/grid/grid3-hrow-over2.gif);
-
 }
 
 .sort-asc .x-grid3-sort-icon {
@@ -1405,7 +1404,6 @@ a.x-menu-item {
 }
 
 .x-panel-bbar .x-toolbar, .x-panel-tbar .x-toolbar {
-
     border: none;
 }
 
@@ -1472,6 +1470,7 @@ a.x-menu-item {
 .x-panel-fbar td, .x-panel-fbar span, .x-panel-fbar input, .x-panel-fbar div, .x-panel-fbar select, .x-panel-fbar label {
     font: normal 11px arial, tahoma, helvetica, sans-serif;
 }
+
 .x-panel-footer {
     margin: 7px;
 }

--- a/web-app/js/portal/details/NcWmsPanel.js
+++ b/web-app/js/portal/details/NcWmsPanel.js
@@ -19,17 +19,9 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Panel, {
         this.layer = cfg.layer;
 
         var config = Ext.apply({
-            layout: 'table',
+            cls: 'filterGroupPanel',
             autoScroll: true,
-            layoutConfig: {
-                columns: 1,
-                tableAttrs: {
-                    cellspacing: '10px',
-                    style: {
-                        width: '100%'
-                    }
-                }
-            }
+            items: [this._getASpacer(10)]
         }, cfg);
 
         Portal.details.NcWmsPanel.superclass.constructor.call(this, config);
@@ -57,11 +49,18 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Panel, {
         this._addClearButton();
     },
 
+    _getASpacer: function(sizeInPixels) {
+        return new Ext.Spacer({
+            cls:'block',
+            height: sizeInPixels
+        })
+    },
+
     _addClearButton: function() {
 
         this.add(
             new Ext.Button({
-                cls: "x-btn-text-icon",
+                cls: "x-btn-text-icon clearFiltersButton",
                 icon: "images/go-back-icon.png",
                 text: OpenLayers.i18n('clearFilterButtonLabel'),
                 listeners: {
@@ -214,7 +213,6 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Panel, {
         this.temporalControls = new Ext.Container({
             items: [
                 temporalExtentHeader,
-                this._newSectionSpacer(5),
                 dateStartRow,
                 dateEndRow,
                 this._newSectionSpacer(10),

--- a/web-app/js/portal/details/SpatialSubsetControlsPanel.js
+++ b/web-app/js/portal/details/SpatialSubsetControlsPanel.js
@@ -12,7 +12,6 @@ Portal.details.SpatialSubsetControlsPanel = Ext.extend(Ext.Panel, {
     initComponent: function() {
         Portal.details.SpatialSubsetControlsPanel.superclass.initComponent.call(this);
         this._addLabel(OpenLayers.i18n('spatialExtentHeading'));
-        this._addVerticalSpacer();
         this._addPickerPanel();
         this._addVerticalSpacer();
         this._addSpatialConstraintDisplayPanel();
@@ -63,10 +62,13 @@ Portal.details.SpatialSubsetControlsPanel = Ext.extend(Ext.Panel, {
     },
 
     _addLabel: function(labelText) {
-        var label = new Ext.form.Label({
-            html: "<h4>" + labelText + "</h4>"
-        });
 
-        this.add(label);
+        if (!this.hideLabel){
+            var label = new Ext.form.Label({
+                html: "<h4>" + labelText + "</h4>"
+            });
+
+            this.add(label);
+        }
     }
 });

--- a/web-app/js/portal/filter/BaseFilterPanel.js
+++ b/web-app/js/portal/filter/BaseFilterPanel.js
@@ -15,6 +15,7 @@ Portal.filter.BaseFilterPanel = Ext.extend(Ext.Panel, {
     constructor: function(cfg) {
         var config = Ext.apply({
             emptyText : OpenLayers.i18n("pleasePickCondensed"),
+            typeLabel: OpenLayers.i18n('generalFilterHeading'),
             listeners: {
                 beforeremove: function(panel, component) {
                     this.removeAll(true);

--- a/web-app/js/portal/filter/BooleanFilterPanel.js
+++ b/web-app/js/portal/filter/BooleanFilterPanel.js
@@ -13,7 +13,6 @@ Portal.filter.BooleanFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
         var config = Ext.apply({
             layout: 'menu',
             layoutConfig: {
-                padding: '5',
                 align: 'centre'
             },
             autoDestroy: true
@@ -25,7 +24,8 @@ Portal.filter.BooleanFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
         this.checkbox = new Ext.form.Checkbox({
             name: this.filter.name,
             value: true,
-            boxLabel: String.format(OpenLayers.i18n('checkboxDescription'), this._formatBoxLabel()),
+            labelStyle: "inheritFont",
+            boxLabel: this._formatBoxLabel(),
             listeners: {
                 scope: this,
                 check: this._buttonChecked
@@ -35,8 +35,13 @@ Portal.filter.BooleanFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
         this.add(this.checkbox);
     },
 
+    getFilterName: function() {
+        // No titles for booleans
+        return null;
+    },
+
     _formatBoxLabel: function() {
-        var label = this.filter.label.split('_').join(' ').toLowerCase();
+        var label = this.filter.label.split('_').join(' ').toTitleCase();
         return label;
     },
 
@@ -52,7 +57,6 @@ Portal.filter.BooleanFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
             return undefined;
         }
     },
-
 
     _getCQLHumanValue: function() {
         if (this.checkbox.getValue()) {

--- a/web-app/js/portal/filter/BoundingBoxFilterPanel.js
+++ b/web-app/js/portal/filter/BoundingBoxFilterPanel.js
@@ -11,7 +11,11 @@ Portal.filter.BoundingBoxFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel,
 
     constructor: function(cfg) {
 
-        Portal.filter.BoundingBoxFilterPanel.superclass.constructor.call(this, cfg);
+        var config = Ext.apply({
+            typeLabel: OpenLayers.i18n('spatialExtentHeading')
+        }, cfg);
+
+        Portal.filter.BoundingBoxFilterPanel.superclass.constructor.call(this, config);
 
         this.map = cfg.layer.map;
         this.map.events.on({
@@ -27,7 +31,8 @@ Portal.filter.BoundingBoxFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel,
 
     _createField: function() {
         this.spatialSubsetControlsPanel = new Portal.details.SpatialSubsetControlsPanel({
-            map: this.layer.map
+            map: this.layer.map,
+            hideLabel: true
         });
         this.add(this.spatialSubsetControlsPanel);
     },

--- a/web-app/js/portal/filter/ComboFilterPanel.js
+++ b/web-app/js/portal/filter/ComboFilterPanel.js
@@ -38,6 +38,12 @@ Portal.filter.ComboFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
         });
 
         this.add(this.combo);
+        this.add(
+            new Ext.Spacer({
+                cls:'block',
+                height: 5
+            })
+        );
 
         var data = [];
         var clearFilter = [OpenLayers.i18n('clearFilterOption')];

--- a/web-app/js/portal/filter/DateFilterPanel.js
+++ b/web-app/js/portal/filter/DateFilterPanel.js
@@ -13,6 +13,7 @@ Portal.filter.DateFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
         var config = Ext.apply({
             layout: 'form',
             labelSeparator: '',
+            typeLabel: OpenLayers.i18n('temporalExtentHeading'),
             labelWidth: 35,
             layoutConfig: {
                 align: 'left'
@@ -31,17 +32,23 @@ Portal.filter.DateFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
         this.toDate = this._createResettableDate('toDate', OpenLayers.i18n('toDateLabel'), OpenLayers.i18n('toDateEmptyText'));
 
         this.add(this.fromDate);
-
-        this.add(new Ext.Spacer({
-            height: 5
-        }));
-
+        this._addVerticalSpacer(5);
         this.add(this.toDate);
+        this._addVerticalSpacer(15);
 
         if (this.filter.possibleValues != undefined) {
             this._setMinMax(this.fromDate, this.filter.possibleValues);
             this._setMinMax(this.toDate, this.filter.possibleValues);
         }
+    },
+
+    _addVerticalSpacer: function(sizeInPixels) {
+        this.add(
+            new Ext.Spacer({
+                cls:'block',
+                height: sizeInPixels
+            })
+        );
     },
 
     _createResettableDate: function(name, fieldLabel, emptyText) {
@@ -54,6 +61,11 @@ Portal.filter.DateFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
                 change: this._applyDateFilterPanel
             }
         });
+    },
+
+    getFilterName: function() {
+        // No titles for DateFilter
+        return null;
     },
 
     _setMinMax: function(resettableDate, vals) {

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -197,9 +197,6 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     toDateEmptyText: 'Max',
     resetActionText: 'reset',
 
-    // BooleanFilterPanel.js
-    checkboxDescription: 'Select only data with {0}',
-
     // ActiveLayersPanel.js
     dataCollectionsTitle: "Data Collections",
     noCollectionSelectedHelp: "Please return and search for data collections.",
@@ -209,9 +206,9 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     asyncDownloadSuccessMsg: 'Your subsetting job has been created. Processing commenced.<br /><br />When the job is complete we will send an email to <i>${email}</i> with download instructions.<br /><br />NB. Subsetting jobs can vary considerably in how long they take, from minutes to hours. Both the number of source files and the selected area can affect how long a job takes to run.',
     asyncDownloadErrorMsg: 'Unable to create subsetting job. Please re-check the parameters you provided and try again.',
 
-    // Gridded data
     spatialExtentHeading: 'Spatial Extent',
     temporalExtentHeading: 'Temporal Extent',
+    generalFilterHeading: 'Specific Filters',
     currentDateTimeLabel: 'Displaying',
 
     emptyDownloadPlaceholder: "The full data collection will be downloaded. Consider filtering the collection.",


### PR DESCRIPTION
The filters were once displayed in a 2 column table. Now its grouped in containers by typeLabel and the specified order. More than one filter type can be grouped together if they have the same typeLabel, with spacing in between the different types
Fixes #1427. 
