### PR TITLE
handle bad polygons

### DIFF
--- a/web-app/js/portal/search/MetadataExtent.js
+++ b/web-app/js/portal/search/MetadataExtent.js
@@ -19,11 +19,11 @@ Portal.search.MetadataExtent = Ext.extend(Object, {
 
     addPolygon: function(wktPolygon) {
         var geometry = new OpenLayers.Geometry.fromWKT(wktPolygon);
-        if (geometry) {
+        if (geometry instanceof OpenLayers.Geometry) {
             this.geometries.push(geometry);
         }
         else {
-            log.debug("Cannot make polygon out of " + wktPolygon);
+            log.error("Cannot make polygon out of '" + wktPolygon + "'");
         }
     },
 


### PR DESCRIPTION
if a polygon coming from geonetwork is too long to process for some
browsers it will be truncated and openlayers will not return a proper
geometry
