### PR TITLE
revert b8f0c5, fix minimap loading

### DIFF
--- a/web-app/js/portal/search/FacetedSearchResultsMiniMap.js
+++ b/web-app/js/portal/search/FacetedSearchResultsMiniMap.js
@@ -60,7 +60,6 @@ Portal.search.FacetedSearchResultsMiniMap = Ext.extend(OpenLayers.Map, {
             Portal.app.appConfig.minimap.baselayer.name,
             Portal.app.appConfig.minimap.baselayer.url,
             { layers: Portal.app.appConfig.minimap.baselayer.params.layers },
-            { buffer: 0 },
             { wrapDateLine: true }
         );
     },


### PR DESCRIPTION
using buffer 0 for openlayers maps causes maps that are defined only
within the -180 180 lon to not display nicely around the date line, this
is apparent when loading some minimaps

fixes #1461 
