### PR TITLE
set default headers to application/xml in search

### DIFF
--- a/src/test/javascript/portal/service/CatalogSearcherSpec.js
+++ b/src/test/javascript/portal/service/CatalogSearcherSpec.js
@@ -126,6 +126,8 @@ describe('Portal.service.CatalogSearcher', function() {
             expect(loaderConfig.url).toBe(proxy(url));
             expect(loaderConfig.listeners.loadexception).toBe(searcher._logAndReturnErrors);
 
+            expect(Ext.Ajax.defaultHeaders).toEqual({ 'Content-Type': 'application/xml' });
+
             // Can't really compare a function.bind() request, so compare the
             // string output of the two functions
             expect(''+loaderConfig.listeners.load).toEqual(''+searcher._onSuccessfulSearch.bind(searcher, page));

--- a/web-app/js/portal/service/CatalogSearcher.js
+++ b/web-app/js/portal/service/CatalogSearcher.js
@@ -54,6 +54,13 @@ Portal.service.CatalogSearcher = Ext.extend(Ext.util.Observable, {
 
         this._logSearchRequest();
 
+        // DF: Set default headers to application/xml in order to avoid apache
+        // embedding a text/plain and then response.responseXML being unset,
+        // resulting in the XML tree class failing
+        // This parameter is globally set, but doesn't seem to interfere with
+        // the rest of the portal operation
+        Ext.Ajax.defaultHeaders = { 'Content-Type': 'application/xml' };
+
         var searchResponseLoader = this._newSearchResponseLoader({
             requestMethod: 'GET',
             preloadChildren: true,


### PR DESCRIPTION
this was the previous behaviour and it is generally not recommended to
override those globals, however without that the search queries will
cease to work. this is because if ran behind apache, apache will set
Content-Type to be text/plain and then the underlying xml will not be
parsed

fix #1470, amend to #1474 
