### PR TITLE
switch to bounding box if reset button clicked

### DIFF
--- a/src/test/javascript/portal/form/PolygonTypeComboSpec.js
+++ b/src/test/javascript/portal/form/PolygonTypeComboSpec.js
@@ -50,4 +50,26 @@ describe('Portal.form.PolygonTypeCombo', function() {
             expect(mockMap.setSpatialConstraintStyle).toHaveBeenCalled();
         });
     });
+
+    describe('_spatialConstraintCleared', function() {
+        var labelsData = [
+            { value: "value1", label: "Some label 1" },
+            { value: "value2", label: "Some label 2" }
+        ];
+
+        beforeEach(function() {
+            polygonTypeCombo.store = new Ext.data.JsonStore({
+                fields: ['value', 'label'],
+                data: labelsData
+            });
+        });
+
+        it('sets to first item in store', function() {
+            spyOn(polygonTypeCombo, 'setValue');
+
+            polygonTypeCombo._spatialConstraintCleared();
+
+            expect(polygonTypeCombo.setValue).toHaveBeenCalledWith("value1");
+        });
+    });
 });

--- a/web-app/js/portal/details/SpatialSubsetControlsPanel.js
+++ b/web-app/js/portal/details/SpatialSubsetControlsPanel.js
@@ -29,7 +29,7 @@ Portal.details.SpatialSubsetControlsPanel = Ext.extend(Ext.Panel, {
         });
 
         resetLink.on('click', function() {
-            this.map.events.triggerEvent('spatialconstraintcleared', Portal.ui.openlayers.SpatialConstraintType.BOUNDING_BOX);
+            this.map.events.triggerEvent('spatialconstraintcleared');
         }, this);
 
         var spacer = new Ext.Spacer({

--- a/web-app/js/portal/form/PolygonTypeComboBox.js
+++ b/web-app/js/portal/form/PolygonTypeComboBox.js
@@ -38,7 +38,7 @@ Portal.form.PolygonTypeComboBox = Ext.extend(Ext.form.ComboBox, {
         });
         this.map.events.on({
             scope: this,
-            'spatialconstraintcleared': this._updateValue
+            'spatialconstraintcleared': this._spatialConstraintCleared
         });
     },
 
@@ -59,5 +59,10 @@ Portal.form.PolygonTypeComboBox = Ext.extend(Ext.form.ComboBox, {
     _updateValue: function(spatialConstraintType) {
         this.updating = true;
         this.setValue(spatialConstraintType);
+    },
+
+    _spatialConstraintCleared: function() {
+        var firstItem = this.store.getAt(0).data.value;
+        this.setValue(firstItem);
     }
 });


### PR DESCRIPTION
reset/reset all buttons will switch to a bounding box if clicked and
also clear the spatial extent. also solves the problem of having
"[object Object]" in the bounding box picker after clicking reset all
(#1457)
