### PR TITLE
estimate size only on download step

### DIFF
--- a/src/test/javascript/portal/cart/BaseInjectorSpec.js
+++ b/src/test/javascript/portal/cart/BaseInjectorSpec.js
@@ -36,7 +36,34 @@ describe('Portal.cart.BaseInjector', function() {
         });
     });
 
+    describe('_shouldEstimateSize', function() {
+        beforeEach(function() {
+            viewport = {
+                isOnTab: function(tabIndex) {
+                    return viewport.currentTab == tabIndex;
+                },
+                currentTab: -1
+            };
+        });
+
+        it('on download step', function() {
+            viewport.currentTab = TAB_INDEX_DOWNLOAD;
+            spyOn(viewport, 'isOnTab').andCallThrough();
+            expect(injector._shouldEstimateSize()).toEqual(true);
+            expect(viewport.isOnTab).toHaveBeenCalledWith(TAB_INDEX_DOWNLOAD);
+        });
+
+        it('any other step', function() {
+            spyOn(viewport, 'isOnTab').andCallThrough();
+            expect(injector._shouldEstimateSize()).toEqual(false);
+            expect(viewport.isOnTab).toHaveBeenCalledWith(TAB_INDEX_DOWNLOAD);
+        });
+    });
+
     describe('getDataMarkup', function() {
+        beforeEach(function() {
+            injector._shouldEstimateSize = function() { return true; }
+        });
 
         it('returns the failed message if it can not calculate an estimate', function() {
 

--- a/web-app/js/portal/cart/BaseInjector.js
+++ b/web-app/js/portal/cart/BaseInjector.js
@@ -58,6 +58,10 @@ Portal.cart.BaseInjector = Ext.extend(Object, {
         }
     },
 
+    _shouldEstimateSize: function() {
+        return viewport.isOnTab(TAB_INDEX_DOWNLOAD);
+    },
+
     _addDownloadEstimate: function(collection) {
 
         var estimateHandler = this._getDownloadEstimateHandler(collection);
@@ -66,10 +70,13 @@ Portal.cart.BaseInjector = Ext.extend(Object, {
             var estimator = new Portal.cart.DownloadEstimator({
                 estimateRequestParams: estimateHandler.getDownloadEstimateParams(collection)
             });
-            estimator._getDownloadEstimate(
-                collection,
-                this._hideButton
-            );
+
+            if (this._shouldEstimateSize()) {
+                estimator._getDownloadEstimate(
+                    collection,
+                    this._hideButton
+                );
+            }
 
             return String.format(
                 "<div id=\"{0}\">{1}{2}</div>",

--- a/web-app/js/portal/ui/Viewport.js
+++ b/web-app/js/portal/ui/Viewport.js
@@ -103,5 +103,10 @@ Portal.ui.Viewport = Ext.extend(Ext.Viewport, {
 
     setDownloadTab: function() {
         this.mainPanel.setDownloadTab();
+    },
+
+    isOnTab: function(tabIndex) {
+        var currentTabIndex = this.mainPanel.items.indexOf(this.mainPanel.getActiveTab());
+        return tabIndex == currentTabIndex;
     }
 });


### PR DESCRIPTION
avoid premature size estimation, trigger size estimations only if user
has move to download step (aka step 3). also avoid expensive size
estimate call when no subset exist after initially moving to subset step
(step 2)

Fixes #1485 
