### PR TITLE
fixes #1476 

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/ServerController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/ServerController.groovy
@@ -19,12 +19,12 @@ class ServerController {
     def grailsApplication
 
     def getInfo = {
-        def server = params.server
 
+        def server = params.server
         def allowableServers = []
 
-        allowableServers.addAll _fromServersInDatabase() // Todo - Can be removed when we go full stateless
         allowableServers.addAll grailsApplication.config.knownServers
+        allowableServers.addAll _fromServersInDatabase() // Todo - Can be removed when we go full stateless
 
         def allowedServer = allowableServers.find { it.uri == server }
         if (!allowedServer) {
@@ -32,9 +32,12 @@ class ServerController {
         }
         else {
             // Filter only the attributes we're passing to the client
-            allowedServer = allowedServer.subMap(['uri', 'wmsVersion', 'type']).findAll { it.value }
+            allowedServer = [
+                'uri': allowedServer.uri,
+                'wmsVersion': allowedServer.wmsVersion,
+                'type': allowedServer.type
+            ]
         }
-
         render text: allowedServer as JSON
     }
 

--- a/src/test/javascript/portal/data/LayerStoreSpec.js
+++ b/src/test/javascript/portal/data/LayerStoreSpec.js
@@ -63,15 +63,29 @@ describe("Portal.data.LayerStore", function() {
         describe('blocked server', function() {
             beforeEach(function() {
                 spyOn(layerStore, '_serverUnrecognized').andCallFake(function() {});
+                layerLink = {
+                    title: "imos:detection_count_per_station_mv",
+                    server: {
+                        type: "WMS-1.1.1",
+                        uri: "http://geoserver.imos.org.au/geoserver/wms"
+                    },
+                    name: "imos:detection_count_per_station_mv",
+                    protocol: "OGC:WMS-1.1.1-http-get-map"
+                };
+                geonetworkRecord = {id: "blagh"};
+                layerRecordCallback = function(){};
             });
 
             it('empty response', function() {
                 spyOn(Ext.Ajax, 'request').andCallFake(function(options) {
                     options.success.call(layerStore, { responseText: Ext.util.JSON.encode({}) });
                 });
-                layerStore.addUsingLayerLink("layerName", layerLink);
+
+                layerStore.addUsingLayerLink("layerName", layerLink, geonetworkRecord, layerRecordCallback);
 
                 expect(layerStore._serverUnrecognized).toHaveBeenCalled();
+                expect(layerStore.geonetworkRecord).toEqual(undefined);
+                expect(layerStore.layerRecordCallback).toEqual(undefined);
             });
 
             it('failure', function() {


### PR DESCRIPTION
Collections from blocked servers are crippled so that the map still appears to attempt loading.

To test (for example):
- comment out the entry for catami.org from Config.groovy
- delete or cripple catami.org from the database
- add  the Catami layer, from the AUV platform
