### PR TITLE
Ncwms - dates will be updated as soon as user types a valid date

### DIFF
--- a/web-app/js/portal/form/UtcExtentDateTime.js
+++ b/web-app/js/portal/form/UtcExtentDateTime.js
@@ -26,6 +26,12 @@ Portal.form.UtcExtentDateTime = Ext.extend(Ext.ux.form.DateTime, {
             this.onBlur(field);
         }, this);
 
+        // date picker selection
+        this.df.on('select', function(field, e) {
+            this.onBlur(field);
+        }, this);
+
+        // typing a date
         this.df.on('keyup', function(field, e) {
             this.onBlur(field);
         }, this);

--- a/web-app/js/portal/form/UtcExtentDateTime.js
+++ b/web-app/js/portal/form/UtcExtentDateTime.js
@@ -14,6 +14,7 @@ Portal.form.UtcExtentDateTime = Ext.extend(Ext.ux.form.DateTime, {
 
         // least nasty hack to add altFormats
         this.df = this.df.cloneConfig({
+            enableKeyEvents: true,
             altFormats: OpenLayers.i18n('dateAltFormats'),
             emptyText: OpenLayers.i18n('loadingMessage'),
             minText: OpenLayers.i18n('dateNcWmsMinError'),
@@ -25,7 +26,7 @@ Portal.form.UtcExtentDateTime = Ext.extend(Ext.ux.form.DateTime, {
             this.onBlur(field);
         }, this);
 
-        this.df.on('select', function(field, record, index) {
+        this.df.on('keyup', function(field, e) {
             this.onBlur(field);
         }, this);
     },

--- a/web-app/js/portal/form/UtcExtentDateTime.js
+++ b/web-app/js/portal/form/UtcExtentDateTime.js
@@ -135,9 +135,10 @@ Portal.form.UtcExtentDateTime = Ext.extend(Ext.ux.form.DateTime, {
     },
 
     onBlur: function(field) {
+        
         this._setTimeFieldChangeFlag(field);
-
-        if (this._isDirty()) {
+        
+        if (this._isDirty() && this.df.isValid()) {
             this._fireEventsForChange(this._matchTime());
         }
     },


### PR DESCRIPTION
Updates are done as soon as a valid date is typed into the date field requiring the enableKeyEvents = true flag set. The timefield remains as is, as its not editable, only selectable.