### PR TITLE
CSV output format for downloads is now configured with a string.

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -198,7 +198,7 @@ knownServers = [
         uri: '', // The server URL (required) -- I would prefer to see that is url rather than uri but I have it as uri for now to match the field in the Server domain class.
         wmsVersion: '', // The version number as a string e.g. "1.1.1", "1.3.0" (not sure if we should make this required or not)
         type: '', // Identifying the specific server software. e.g. "nvWMS", "GeoServer". If omitted or blank then it is considered to just be a general WMS server without any extra functionality. Should be case insensitive.
-        supportsCsvMetadataHeaderOutputFormat: true, // False if omitted. Basically this tells us whether we can use the csvWithMetadata output type on this server
+        csvDownloadFormat: '', // We have some specialised CSV formats: 'csv-restricted-column' and 'csv-with-metadata-header'
         httpAuthUsername: '', // Some servers use HTTP authentication, so store the credentials here. Null be default
         httpAuthPassword: '',
         urlListDownloadPrefixToRemove: '', // For the time being these are still needed for BODAAC functionality, null by default
@@ -208,7 +208,7 @@ knownServers = [
         uri: 'http://geoserver-123.aodn.org.au/geoserver/wms',
         wmsVersion: '1.1.1',
         type: 'GeoServer',
-        supportsCsvMetadataHeaderOutputFormat: true,
+        csvDownloadFormat: 'csv-with-metadata-header',
         urlListDownloadPrefixToRemove: '/mnt/imos-t3/',
         urlListDownloadPrefixToSubstitue: 'http://data.aodn.org.au/'
     ],

--- a/grails-app/controllers/au/org/emii/portal/ServerController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/ServerController.groovy
@@ -27,7 +27,7 @@ class ServerController {
         }
         else {
             // Filter only the attributes we're passing to the client
-            serverInformation = serverInformation.subMap(['uri', 'wmsVersion', 'type']).findAll { it.value }
+            serverInformation = serverInformation.subMap(['uri', 'wmsVersion', 'type', 'csvDownloadFormat']).findAll { it.value }
         }
 
         render text: serverInformation as JSON

--- a/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
@@ -45,7 +45,7 @@ describe('Portal.cart.WfsDownloadHandler', function () {
 
                 downloadHandler(dummyCollection);
 
-                expect(dummyCollection.wmsLayer.getFeatureRequestUrl).toHaveBeenCalledWith('server_url', 'layer_name', 'csv-with-metadata-header');
+                expect(dummyCollection.wmsLayer.getFeatureRequestUrl).toHaveBeenCalledWith('server_url', 'layer_name', 'csv');
             });
         });
 

--- a/src/test/javascript/portal/prototypes/OpenLayersSpec.js
+++ b/src/test/javascript/portal/prototypes/OpenLayersSpec.js
@@ -169,17 +169,18 @@ describe('OpenLayers', function() {
             });
 
             describe('_getServerSupportedOutputFormat', function() {
-                it("returns 'csv-with-metadata-header' if server does support CSV metadata header", function() {
-                    openLayer.server.supportsCsvMetadataHeaderOutputFormat = true;
-                    expect(openLayer._getServerSupportedOutputFormat('csv-with-metadata-header')).toBe('csv-with-metadata-header');
+
+                it("returns configured CSV output format for server", function() {
+                    openLayer.server.csvDownloadFormat = 'csv-rulz-man';
+                    expect(openLayer._getServerSupportedOutputFormat('csv')).toBe('csv-rulz-man');
                 });
 
-                it("returns 'csv' if server does not support CSV metadata header", function() {
-                    openLayer.server.supportsCsvMetadataHeaderOutputFormat = false;
-                    expect(openLayer._getServerSupportedOutputFormat('csv-with-metadata-header')).toBe('csv');
+                it("returns 'csv' by default", function() {
+                    openLayer.server.csvDownloadFormat = null;
+                    expect(openLayer._getServerSupportedOutputFormat('csv')).toBe('csv');
                 });
 
-                it("returns given outputFormat for formats other than 'csv-with-metadata-header'", function() {
+                it("returns given outputFormat for formats other than 'csv'", function() {
                     expect(openLayer._getServerSupportedOutputFormat('xyz')).toBe('xyz');
                 });
             });

--- a/web-app/js/portal/cart/WfsDownloadHandler.js
+++ b/web-app/js/portal/cart/WfsDownloadHandler.js
@@ -40,7 +40,7 @@ Portal.cart.WfsDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
             return collection.wmsLayer.getFeatureRequestUrl(
                 _this._resourceHref(),
                 _this._resourceName(),
-                OpenLayers.Layer.DOWNLOAD_FORMAT_CSV_WITH_METADATA
+                OpenLayers.Layer.DOWNLOAD_FORMAT_CSV
             );
         };
     }

--- a/web-app/js/portal/data/LayerStore.js
+++ b/web-app/js/portal/data/LayerStore.js
@@ -79,7 +79,7 @@ Portal.data.LayerStore = Ext.extend(GeoExt.data.LayerStore, {
         log.error("Server '" + serverUri + "' is blocked!!");
     },
 
-    _addUsingLayerLinkDefault: function(layerDisplayName, layerLink, geonetworkRecord, layerRecordCallback) {
+    _addUsingLayerLinkDefault: function(layerDisplayName, layerLink, geonetworkRecord, layerRecordCallback, serverInfo) {
         var serverUri = layerLink.server.uri;
 
         Ext.Ajax.request({
@@ -91,6 +91,8 @@ Portal.data.LayerStore = Ext.extend(GeoExt.data.LayerStore, {
                     // Override layer name with GeoNetwork layer name
                     layerDescriptor.title = layerDisplayName;
                     layerDescriptor.cql = layerLink.cql;
+                    this._copyCsvDownloadFormatFromConfig(layerDescriptor, serverInfo);
+
                     this.addUsingDescriptor(layerDescriptor, layerRecordCallback);
                 }
             },
@@ -98,6 +100,14 @@ Portal.data.LayerStore = Ext.extend(GeoExt.data.LayerStore, {
                 this.addUsingDescriptor(new Portal.common.LayerDescriptor(layerLink), layerRecordCallback);
             }
         });
+    },
+
+    // Note: this function can hopefully go away after 'no-db' is merged... i.e. when all server config
+    // is coming from Config.groovy, rather than from the 'server' table.
+    _copyCsvDownloadFormatFromConfig: function(layerDescriptor, serverInfo) {
+        if (serverInfo && layerDescriptor && layerDescriptor.server) {
+            layerDescriptor.server.csvDownloadFormat = serverInfo.csvDownloadFormat;
+        }
     },
 
     _addUsingLayerLinkNcwms: function(layerDisplayName, layerLink, geonetworkRecord, layerRecordCallback, serverInfo) {

--- a/web-app/js/portal/prototypes/OpenLayers.js
+++ b/web-app/js/portal/prototypes/OpenLayers.js
@@ -6,7 +6,6 @@
  */
 
 OpenLayers.Layer.DOWNLOAD_FORMAT_CSV = 'csv';
-OpenLayers.Layer.DOWNLOAD_FORMAT_CSV_WITH_METADATA = 'csv-with-metadata-header';
 
 OpenLayers.Layer.prototype.isOverlay = function() {
     return !this.isBaseLayer;
@@ -111,17 +110,11 @@ OpenLayers.Layer.WMS.prototype._buildGetFeatureRequestUrl = function(baseUrl, la
 
 OpenLayers.Layer.WMS.prototype._getServerSupportedOutputFormat = function(outputFormat) {
 
-    // No special handling for formats other than 'csv'.
-    if (outputFormat != OpenLayers.Layer.DOWNLOAD_FORMAT_CSV_WITH_METADATA) {
-        return outputFormat;
+    if (outputFormat == OpenLayers.Layer.DOWNLOAD_FORMAT_CSV && this.server.csvDownloadFormat) {
+        return this.server.csvDownloadFormat;
     }
-    // Request to have metadata inserted, if it's available.
-    else if (this.server.supportsCsvMetadataHeaderOutputFormat) {
-        return OpenLayers.Layer.DOWNLOAD_FORMAT_CSV_WITH_METADATA;
-    }
-    else {
-        return OpenLayers.Layer.DOWNLOAD_FORMAT_CSV;
-    }
+
+    return outputFormat;
 };
 
 OpenLayers.Layer.WMS.prototype._getBoundingBox = function() {


### PR DESCRIPTION
This enables the possibility of using different output formats for different geoservers.

Depends on https://github.com/aodn/chef-private-sample/pull/8 and https://github.com/aodn/chef-private/pull/1348

**After** this change is deployed, then https://github.com/aodn/chef-private-sample/blob/csv_output_config/data_bags/imos_webapps_portal_known_servers/geoserver_123_aodn.json#L7 and likewise can be deleted.