### PR TITLE
Issue 1603

### DIFF
--- a/src/test/javascript/OpenLayers/Layer/NcWMSSpec.js
+++ b/src/test/javascript/OpenLayers/Layer/NcWMSSpec.js
@@ -158,12 +158,6 @@ describe("OpenLayers.Layer.NcWMS", function() {
             spyOn(cachedLayer, 'loadTimeSeriesForDay').andCallFake(function() {});
         });
 
-        it('calls addDays', function() {
-            spyOn(cachedLayer.temporalExtent, 'addDays');
-            cachedLayer._timeSeriesDatesLoaded(sampleJson);
-            expect(cachedLayer.temporalExtent.addDays).toHaveBeenCalled();
-        });
-
         it('loads first day', function() {
             cachedLayer._timeSeriesDatesLoaded(sampleJson);
             expect(cachedLayer.temporalExtent.getFirstDay).toHaveBeenCalled();
@@ -213,8 +207,8 @@ describe("OpenLayers.Layer.NcWMS", function() {
         var datesWithData = null;
 
         spyOn(cachedLayer, '_timeSeriesDatesLoaded').andCallFake(
-            function(_datesWithData) {
-                datesWithData = _datesWithData;
+            function() {
+                datesWithData = cachedLayer.temporalExtent.getDays();
             }
         );
 

--- a/src/test/javascript/portal/visualise/animations/TemporalExtentSpec.js
+++ b/src/test/javascript/portal/visualise/animations/TemporalExtentSpec.js
@@ -91,6 +91,26 @@ describe("Portal.visualise.animations.TemporalExtent", function() {
         });
     });
 
+    describe('_createDay', function() {
+        var aMomentInTime = moment.utc('2000-01-01T01:00:00.000');
+        var calledWith = null;
+
+        beforeEach(function() {
+            spyOn(temporalExtent, '_setFirstDay').andCallFake(function(date) { calledWith = date; });
+            spyOn(temporalExtent, '_setLastDay').andCallFake(function(date) { calledWith = date; });
+            temporalExtent._createDay(aMomentInTime);
+        });
+
+        it('calls _setFirstDay', function() {
+            expect(temporalExtent._setFirstDay).toHaveBeenCalled();
+            expect(aMomentInTime).toBeSame(calledWith);
+        });
+
+        it('calls _setLastDay', function() {
+            expect(temporalExtent._setLastDay).toHaveBeenCalled();
+            expect(aMomentInTime).toBeSame(calledWith);
+        });
+    });
 
     describe('getDay', function() {
         it('return null when empty', function() {
@@ -248,11 +268,12 @@ describe("Portal.visualise.animations.TemporalExtent", function() {
 
         it('returns all defined dates in array', function() {
             temporalExtent.parse(['2000-01-01T23:00:00.000/2000-01-02T01:00:00.000/PT30M']);
-            expect(temporalExtent.getExtentAsArray()[0].toISOString()).toBe('2000-01-01T23:00:00.000Z');
-            expect(temporalExtent.getExtentAsArray()[1].toISOString()).toBe('2000-01-01T23:30:00.000Z');
-            expect(temporalExtent.getExtentAsArray()[2].toISOString()).toBe('2000-01-02T00:00:00.000Z');
-            expect(temporalExtent.getExtentAsArray()[3].toISOString()).toBe('2000-01-02T00:30:00.000Z');
-            expect(temporalExtent.getExtentAsArray()[4].toISOString()).toBe('2000-01-02T01:00:00.000Z');
+            var flatArrayOfDates = temporalExtent.getExtentAsArray();
+            expect(flatArrayOfDates[0].toISOString()).toBe('2000-01-01T23:00:00.000Z');
+            expect(flatArrayOfDates[1].toISOString()).toBe('2000-01-01T23:30:00.000Z');
+            expect(flatArrayOfDates[2].toISOString()).toBe('2000-01-02T00:00:00.000Z');
+            expect(flatArrayOfDates[3].toISOString()).toBe('2000-01-02T00:30:00.000Z');
+            expect(flatArrayOfDates[4].toISOString()).toBe('2000-01-02T01:00:00.000Z');
         });
     });
 

--- a/web-app/js/portal/ui/openlayers/layer/NcWMS.js
+++ b/web-app/js/portal/ui/openlayers/layer/NcWMS.js
@@ -158,9 +158,7 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
 
     loadTimeSeriesForDay: function(date) {
         if (this.getTimeSeriesForDay(date)) {
-            // Give UI precedence by using delayed function call (setTimeout)
-            var that = this;
-            setTimeout(function() { that._timeSeriesLoadedForDate(); }, 10);
+            this._timeSeriesLoadedForDate();
         }
         else {
             this._fetchTimeSeriesForDay(date);

--- a/web-app/js/portal/ui/openlayers/layer/NcWMS.js
+++ b/web-app/js/portal/ui/openlayers/layer/NcWMS.js
@@ -102,9 +102,7 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
         });
     },
 
-    _timeSeriesDatesLoaded: function(datesWithData) {
-        this.temporalExtent.addDays(datesWithData);
-
+    _timeSeriesDatesLoaded: function() {
         this.loadTimeSeriesForDay(this.temporalExtent.getFirstDay());
         this.loadTimeSeriesForDay(this.temporalExtent.getLastDay());
     },
@@ -269,8 +267,6 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
     },
 
     _parseDatesWithDataAsync: function(response) {
-        var datesWithDataArray = [];
-
         // Assume only one filter which is the one we're after
         var dateFilter = response[0];
         var datesToProcess = dateFilter['possibleValues'];
@@ -281,13 +277,16 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
         var that = this;
         (function() {
             var chunkEnd = idx + chunkSize;
+            var datesWithDataArray = [];
             for (; idx < datesToProcess.length && idx < chunkEnd; ++idx) {
                 datesWithDataArray.push(new moment.utc(datesToProcess[idx]));
             }
 
+            that.temporalExtent.addDays(datesWithDataArray);
+
             if (idx >= datesToProcess.length) {
                 // We're done, stop processing
-                that._timeSeriesDatesLoaded(datesWithDataArray);
+                that._timeSeriesDatesLoaded();
             }
             else {
                 setTimeout(arguments.callee, 0);

--- a/web-app/js/portal/visualise/animations/TemporalExtent.js
+++ b/web-app/js/portal/visualise/animations/TemporalExtent.js
@@ -24,6 +24,9 @@ Portal.visualise.animations.TemporalExtent = Ext.extend(Ext.util.Observable, {
 
     missingDays: null,
 
+    firstDay: undefined,
+    lastDay: undefined,
+
     constructor: function() {
         this.extent = {};
         this.missingDays = [];
@@ -229,6 +232,10 @@ Portal.visualise.animations.TemporalExtent = Ext.extend(Ext.util.Observable, {
         if (date.isValid() && ! this.extent[this._stringifyDate(date)]) {
             this.extent[this._stringifyDate(date)] = [];
         }
+
+        // When creating new days, initialize the min/max (firstDay/lastDay)
+        this._setFirstDay(date);
+        this._setLastDay(date);
     },
 
     getDay: function(date) {
@@ -241,26 +248,34 @@ Portal.visualise.animations.TemporalExtent = Ext.extend(Ext.util.Observable, {
         }
     },
 
+    _setFirstDay: function(day) {
+        if (!this.firstDay || day.isBefore(this.firstDay)) {
+            this.firstDay = this._startOfDay(day);
+        }
+    },
+
     getFirstDay: function() {
-        var firstDay = undefined;
-        Ext.iterate(this.extent, function(day, arrayOfDateTime) {
-            var iter = this._destringifyDate(day);
-            if (!firstDay || iter.isBefore(firstDay)) {
-                firstDay = iter.clone();
-            }
-        }, this);
-        return firstDay;
+        if (this.firstDay) {
+            return this.firstDay.clone();
+        }
+        else {
+            return undefined;
+        }
+    },
+
+    _setLastDay: function(day) {
+        if (!this.lastDay || day.isAfter(this.lastDay)) {
+            this.lastDay = this._startOfDay(day);
+        }
     },
 
     getLastDay: function() {
-        var lastDay = undefined;
-        Ext.iterate(this.extent, function(day, arrayOfDateTime) {
-            var iter = this._destringifyDate(day);
-            if (!lastDay || iter.isAfter(lastDay)) {
-                lastDay = iter.clone();
-            }
-        }, this);
-        return lastDay;
+        if (this.lastDay) {
+            return this.lastDay.clone();
+        }
+        else {
+            return undefined;
+        }
     },
 
     _stringifyDate: function(date) {


### PR DESCRIPTION
Fixes #1603

The issue became apparent as SRS layers have many days defined (1992-2015). In particular the functions `getFirstDay()` and `getLastDay()` were scanning a big hash. They were modified to return a fixed variables which is calculated every time a new date is being added. This is addressed at a6160c7.

Another problem was the inline addition of dates. When many dates are defined this proves to be a problem. This is now done in an interleaved manner which doesn't jam the UI. This is addressed in 924a871.

Altogether the UI experience is **much** snappier now when choosing NcWMS layers and it is very apparent.