### PR TITLE
Fixes #1597.

### DIFF
--- a/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
@@ -114,4 +114,25 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
             expect(window.trackUsage).toHaveBeenCalledWith("Collection", "select", "Argo Australia Profiles");
         });
     });
+
+    describe('_getMeasuredParametersAsCommaSeparatedString', function() {
+
+        beforeEach(function() {
+            params = [];
+
+            facetedSearchDataView._getMeasuredParameters = function() {
+                return params;
+            };
+        });
+
+
+        it('with some parameters', function() {
+            params = ['temp', 'salinity'];
+            expect(facetedSearchDataView._getMeasuredParametersAsCommaSeparatedString()).toEqual('temp, salinity');
+        });
+
+        it('with no parameters', function() {
+            expect(facetedSearchDataView._getMeasuredParametersAsCommaSeparatedString()).toEqual('No parameters');
+        });
+    });
 });

--- a/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
@@ -117,6 +117,8 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
 
     describe('_getMeasuredParametersAsCommaSeparatedString', function() {
 
+        var params;
+
         beforeEach(function() {
             params = [];
 
@@ -128,11 +130,11 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
 
         it('with some parameters', function() {
             params = ['temp', 'salinity'];
-            expect(facetedSearchDataView._getMeasuredParametersAsCommaSeparatedString()).toEqual('temp, salinity');
+            expect(facetedSearchDataView._getMeasuredParametersText()).toEqual('temp, salinity');
         });
 
         it('with no parameters', function() {
-            expect(facetedSearchDataView._getMeasuredParametersAsCommaSeparatedString()).toEqual('No parameters');
+            expect(facetedSearchDataView._getMeasuredParametersText()).toEqual('No parameters');
         });
     });
 });

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -182,6 +182,7 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     facetedSearchNewSearchButton: 'Start new search',
     facetedSearchUnavailable: 'Search is currently unavailable.',
     facetedSearchResetting: 'Resetting search',
+    noParametersForCollection: 'No parameters',
 
     showAll: {'true': '(less\u2025)', 'false': '(more\u2025)'},
 

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -132,13 +132,24 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         if (values.parameter) {
             return template.apply({
                 "label": label,
-                "value": this.getMeasuredParameters(values)
+                "value": this._getMeasuredParametersAsCommaSeparatedString(values)
             });
         }
         return "";
     },
 
-    getMeasuredParameters: function(values) {
+    _getMeasuredParametersAsCommaSeparatedString: function(values) {
+        var params = this._getMeasuredParameters(values);
+
+        if (params.length > 0) {
+            return params.join(', ');
+        }
+        else {
+            return OpenLayers.i18n('noParametersForCollection');
+        }
+    },
+
+    _getMeasuredParameters: function(values) {
         var broader = [];
         Ext.each(values.parameter, function(param) {
             var broaderTerms = this.classificationStore.getBroaderTerms(param, 2, 'Measured parameter');
@@ -149,7 +160,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         broader = broader.sort();
         return broader.filter( function(item, pos) {
             return !pos || item != broader[pos - 1];
-        }).join( ', ');
+        });
     },
 
     _getOrganisationAsHtml: function(template, organisation) {

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -132,13 +132,13 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         if (values.parameter) {
             return template.apply({
                 "label": label,
-                "value": this._getMeasuredParametersAsCommaSeparatedString(values)
+                "value": this._getMeasuredParametersText(values)
             });
         }
         return "";
     },
 
-    _getMeasuredParametersAsCommaSeparatedString: function(values) {
+    _getMeasuredParametersText: function(values) {
         var params = this._getMeasuredParameters(values);
 
         if (params.length > 0) {


### PR DESCRIPTION
If a collection does not have any measured parameters, show a message indicating such, as opposed to a blank string.