### PR TITLE
Updating URL when collections are added/removed.

### DIFF
--- a/grails-app/views/_js_includes.gsp
+++ b/grails-app/views/_js_includes.gsp
@@ -149,6 +149,7 @@
     <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'GeoNetworkRecordFetcher.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'GeoNetworkRecordStore.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'ActiveGeoNetworkRecordStore.js')}"></script>
+    <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'UrlUpdater.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/ui', file: 'EmptyDropZonePlaceholder.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/mainMap', file: 'map.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/common', file: 'GeoExt.ux.BaseLayerCombobox.js')}"></script>

--- a/src/test/javascript/portal/data/GeoNetworkRecordFetcherSpec.js
+++ b/src/test/javascript/portal/data/GeoNetworkRecordFetcherSpec.js
@@ -47,8 +47,10 @@ describe("Portal.data.GeoNetworkRecordFetcher", function() {
         };
         var record = {};
         spyOn(Portal.data.GeoNetworkRecordStore.prototype, 'loadData');
+        spyOn(Portal.data.GeoNetworkRecordStore.prototype, 'getCount').andReturn(1);
         spyOn(Portal.data.GeoNetworkRecordStore.prototype, 'getAt').andReturn(record);
         spyOn(Portal.data.ActiveGeoNetworkRecordStore.instance(), 'add');
+
         spyOn(Ext.Ajax, 'request').andCallFake(
             function(params) {
                 params.success.call(fetcher, response);

--- a/src/test/javascript/portal/data/GeoNetworkRecordStoreSpec.js
+++ b/src/test/javascript/portal/data/GeoNetworkRecordStoreSpec.js
@@ -140,5 +140,11 @@ describe("Portal.data.GeoNetworkRecordStore", function() {
                 expect(Portal.cart.PythonDownloadHandler.prototype.getDownloadOptions).toHaveBeenCalled();
             });
         });
+
+        it('returns UUIDs array', function() {
+            expect(geoNetworkRecordStore.getUuids()).toEqual(['123456789']);
+
+        });
+
     });
 });

--- a/src/test/javascript/portal/data/UrlUpdaterSpec.js
+++ b/src/test/javascript/portal/data/UrlUpdaterSpec.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+
+describe("Portal.data.UrlUpdater", function() {
+
+    var updater;
+    var uuids = [];
+
+    beforeEach(function() {
+        updater = new Portal.data.UrlUpdater();
+        spyOn(Portal.data.ActiveGeoNetworkRecordStore.instance(), 'getUuids').andCallFake(function() {
+            return uuids;
+        });
+    });
+
+    describe('geonetwork record store events', function() {
+        beforeEach(function() {
+            spyOn(updater, '_updateUrl');
+        });
+
+        it('updates URL on record added', function() {
+            Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED);
+            expect(updater._updateUrl).toHaveBeenCalled();
+        });
+
+        it('updates URL on record removed', function() {
+            Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED);
+            expect(updater._updateUrl).toHaveBeenCalled();
+        });
+    });
+
+    describe('URL updates', function() {
+        it('gets collection IDs', function() {
+            updater._updateUrl();
+            expect(Portal.data.ActiveGeoNetworkRecordStore.instance().getUuids).toHaveBeenCalled();
+        });
+
+        it('updates UUID params', function() {
+            var baseUrl = document.URL;
+
+            uuids = ['1234'];
+            updater._updateUrl();
+            expect(window.history.pushState).toHaveBeenCalledWith(null, '', Ext.urlAppend(baseUrl, 'uuid=1234'));
+
+            uuids = [];
+            updater._updateUrl();
+            expect(window.history.pushState).toHaveBeenCalledWith(null, '', baseUrl);
+        });
+    });
+});

--- a/src/test/javascript/portal/ui/MainPanelSpec.js
+++ b/src/test/javascript/portal/ui/MainPanelSpec.js
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2012 IMOS
  *
@@ -15,6 +14,7 @@ describe("Portal.ui.MainPanel", function() {
 
     beforeEach(function() {
 
+        Portal.data.ActiveGeoNetworkRecordStore.instance().removeAll();
         spyOn(Portal.ui.MainToolbar.prototype, "_registerEvents").andCallFake(function() {});
 
         Portal.app.appConfig.portal = {footer: {}};

--- a/src/test/javascript/spec_helper.js
+++ b/src/test/javascript/spec_helper.js
@@ -18,6 +18,8 @@ Ext.Ajax.request = function(options) {
 // Ref: http://stackoverflow.com/questions/11942085/is-there-a-way-to-add-a-jasmine-matcher-to-the-whole-environment
 beforeEach(function() {
 
+    mockWindowHistoryPushState();
+
     setupTestConfigAndStubs();
     this.addMatchers({
         toBeSame: function(expected) {
@@ -170,4 +172,12 @@ var textToXML = function(text) {
     }
     catch (e) {
     }
+};
+
+var mockWindowHistoryPushState = function() {
+    // This only exists in HTML5 - which is not the case when jasmine tests are run as part of "mvn test".
+    if (!window.history.pushState) {
+        window.history.pushState = noOp;
+    }
+    spyOn(window.history, 'pushState');
 };

--- a/web-app/js/portal/data/GeoNetworkRecordFetcher.js
+++ b/web-app/js/portal/data/GeoNetworkRecordFetcher.js
@@ -34,10 +34,13 @@ Portal.data.GeoNetworkRecordFetcher = Ext.extend(Ext.util.Observable, {
             // Is there a more direct way to easily get a GeoNetworkRecord from XML?
             var store = new Portal.data.GeoNetworkRecordStore();
             store.loadData(response.responseXML);
-            var record = store.getAt(0);
 
-            Portal.data.ActiveGeoNetworkRecordStore.instance().add(record);
-            Ext.MsgBus.publish(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, record);
+            if (store.getCount() > 0) {
+                var record = store.getAt(0);
+
+                Portal.data.ActiveGeoNetworkRecordStore.instance().add(record);
+                Ext.MsgBus.publish(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, record);
+            }
         });
     },
 

--- a/web-app/js/portal/data/GeoNetworkRecordStore.js
+++ b/web-app/js/portal/data/GeoNetworkRecordStore.js
@@ -18,5 +18,9 @@ Portal.data.GeoNetworkRecordStore = Ext.extend(Ext.data.XmlStore, {
         };
 
         Portal.data.GeoNetworkRecordStore.superclass.constructor.call(this, config);
+    },
+
+    getUuids: function() {
+        return this.collect('uuid');
     }
 });

--- a/web-app/js/portal/data/UrlUpdater.js
+++ b/web-app/js/portal/data/UrlUpdater.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+Ext.namespace('Portal.data');
+
+Portal.data.UrlUpdater = Ext.extend(Ext.util.Observable, {
+
+    constructor: function() {
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, function() { this._updateUrl(); }, this);
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED, function() { this._updateUrl(); }, this);
+
+        Portal.data.UrlUpdater.superclass.constructor.call(this, arguments);
+    },
+
+   _updateUrl: function() {
+       var uuids = Portal.data.ActiveGeoNetworkRecordStore.instance().getUuids();
+
+       var urlParts = document.URL.split("?");
+       var urlBase = urlParts[0];
+       var urlParams = Ext.urlDecode(urlParts[1]);
+
+       if (uuids.length > 0) {
+           urlParams.uuid = uuids;
+       }
+       else {
+           delete urlParams.uuid;
+       }
+
+       var updatedUrl = Ext.urlAppend(urlBase, Ext.urlEncode(urlParams));
+
+       window.history.pushState(null, '', updatedUrl);
+   }
+});

--- a/web-app/js/portal/ui/Viewport.js
+++ b/web-app/js/portal/ui/Viewport.js
@@ -39,6 +39,8 @@ Portal.ui.Viewport = Ext.extend(Ext.Viewport, {
             ]
         });
 
+        this.urlUpdater = new Portal.data.UrlUpdater();
+
         this.downloadCartWidget = new Portal.ui.DownloadCartWidget({});
 
         var config = Ext.apply(


### PR DESCRIPTION
This is to make it easier for people to share links which will result in a portal with already loaded collections.

Some more 10% action - this *could* be extended further to include serialisation of filter state etc, but anyway, I think this would provide a bit of value to users.
