### PR TITLE
New filter type mapping

### DIFF
--- a/grails-app/views/_js_includes.gsp
+++ b/grails-app/views/_js_includes.gsp
@@ -103,7 +103,7 @@
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'ConfigPage.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'ResettableDate.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'DateFilterPanel.js')}"></script>
-    <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'BoundingBoxFilterPanel.js')}"></script>
+    <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'GeometryFilterPanel.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'BooleanFilterPanel.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'NumberFilterPanel.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'FilterGroupPanel.js')}"></script>

--- a/src/test/javascript/portal/filter/BaseFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/BaseFilterPanelSpec.js
@@ -21,7 +21,7 @@ describe("Portal.filter.BaseFilterPanel", function() {
 
         it("should return undefined", function() {
 
-            filter.getType = function() { return null };
+            filter.getType = function() { return '' };
 
             panel = newFilterPanelFor({
                 layer: {},

--- a/src/test/javascript/portal/filter/BaseFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/BaseFilterPanelSpec.js
@@ -47,8 +47,8 @@ describe("Portal.filter.BaseFilterPanel", function() {
             expectNewFilterPanelForString('BooleanFilterPanel', 'Boolean');
         });
 
-        it("should create BoundingBoxFilterPanel", function() {
-            expectNewFilterPanelForString('BoundingBoxFilterPanel', 'BoundingBox');
+        it("should create GeometryFilterPanel", function() {
+            expectNewFilterPanelForString('GeometryFilterPanel', 'BoundingBox');
         });
 
         it("should create NumberFilterPanel", function() {

--- a/src/test/javascript/portal/filter/BaseFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/BaseFilterPanelSpec.js
@@ -11,21 +11,14 @@ describe("Portal.filter.BaseFilterPanel", function() {
     describe("newFilterPanelFor()", function() {
 
         var newFilterPanelFor = Portal.filter.BaseFilterPanel.newFilterPanelFor;
-        var filter;
-        var panel;
-
-        beforeEach(function() {
-
-            filter = {};
-        });
 
         it("should return undefined", function() {
 
-            filter.getType = function() { return '' };
-
-            panel = newFilterPanelFor({
+            var panel = newFilterPanelFor({
                 layer: {},
-                filter: filter
+                filter: {
+                    getType: function() { return '' }
+                }
             });
 
             expect(panel).toBeUndefined();
@@ -57,12 +50,13 @@ describe("Portal.filter.BaseFilterPanel", function() {
 
         var expectNewFilterPanelForString = function(filterPanelType, filterTypeAsString) {
 
-            filter.getType = function() { return filterTypeAsString };
             var constructorSpy = spyOn(Portal.filter, filterPanelType);
 
             newFilterPanelFor({
                 layer: {},
-                filter: filter
+                filter: {
+                    getType: function() { return filterTypeAsString }
+                }
             });
 
             expect(constructorSpy).toHaveBeenCalled();

--- a/src/test/javascript/portal/filter/BoundingBoxFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/BoundingBoxFilterPanelSpec.js
@@ -5,7 +5,7 @@
  *
  */
 
-describe("Portal.filter.BoundingBoxFilterPanel", function() {
+describe("Portal.filter.GeometryFilterPanel", function() {
 
     var filterPanel;
     var map;
@@ -15,9 +15,9 @@ describe("Portal.filter.BoundingBoxFilterPanel", function() {
         map.navigationControl = {};
         map.navigationControl.deactivate = function() { return null };
 
-        spyOn(Portal.filter.BoundingBoxFilterPanel.prototype, 'setLayerAndFilter');
-        spyOn(Portal.filter.BoundingBoxFilterPanel.prototype, '_updateWithGeometry');
-        filterPanel = new Portal.filter.BoundingBoxFilterPanel({
+        spyOn(Portal.filter.GeometryFilterPanel.prototype, 'setLayerAndFilter');
+        spyOn(Portal.filter.GeometryFilterPanel.prototype, '_updateWithGeometry');
+        filterPanel = new Portal.filter.GeometryFilterPanel({
             layer: {
                 map: map
             },

--- a/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
@@ -4,6 +4,7 @@
  * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
  *
  */
+
 describe("Portal.filter.FilterGroupPanel", function() {
 
     var filterGroupPanel;
@@ -23,12 +24,6 @@ describe("Portal.filter.FilterGroupPanel", function() {
         });
     });
 
-    describe('responds to expected methods', function() {
-        it('has a _clearFilters method', function() {
-            expect(filterGroupPanel._clearFilters).toBeDefined();
-        });
-    });
-
     describe('_filtersLoaded', function() {
 
         beforeEach(function() {
@@ -45,7 +40,7 @@ describe("Portal.filter.FilterGroupPanel", function() {
 
             cfg = {
                 layer: layer
-            }
+            };
 
             filterPanel = {
                 needsFilterRange: function() {
@@ -98,7 +93,7 @@ describe("Portal.filter.FilterGroupPanel", function() {
 
             cfg = {
                 layer: layer
-            }
+            };
 
             filterConfigs = [
                 {type: 'Boolean', label: 'A', name: 'A', visualised: true},
@@ -204,7 +199,6 @@ describe("Portal.filter.FilterGroupPanel", function() {
             spyOn(filterGroupPanel, '_updateLayerFilters');
             spyOn(filterGroupPanel, 'addErrorMessage');
             spyOn(filterGroupPanel, '_createFilterPanel').andReturn(filterPanel);
-            //spyOn(filterGroupPanel, '_filtersSort').andReturn(layer);
             spyOn(filterGroupPanel, '_isLayerActive').andReturn(true);
         });
 
@@ -219,7 +213,7 @@ describe("Portal.filter.FilterGroupPanel", function() {
         });
 
         it('addErrorMessage function not called when filters are configured', function() {
-            
+
             layer.filters = ["Boolean","Combo"];
 
             spyOn(filterGroupPanel, '_filtersSort').andReturn(layer);

--- a/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
@@ -81,6 +81,7 @@ describe("Portal.filter.FilterGroupPanel", function() {
             spyOn(Portal.filter.BooleanFilterPanel.prototype, '_createField');
             spyOn(Portal.filter.BooleanFilterPanel.prototype, '_setExistingFilters');
             spyOn(Portal.filter.NumberFilterPanel.prototype, '_setExistingFilters');
+            spyOn(Portal.filter.NumberFilterPanel.prototype, 'setLayerAndFilter');
             spyOn(Portal.filter.GeometryFilterPanel.prototype, '_createField');
             spyOn(Portal.filter.GeometryFilterPanel.prototype, 'setLayerAndFilter');
             spyOn(Portal.filter.DateFilterPanel.prototype, '_setExistingFilters');

--- a/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
@@ -147,7 +147,7 @@ describe("Portal.filter.FilterGroupPanel", function() {
 
             spyOn(filterGroupPanel, '_clearFilters');
             spyOn(filterGroupPanel, '_updateLayerFilters');
-            spyOn(filterGroupPanel, 'addErrorMessage');
+            spyOn(filterGroupPanel, '_addErrorMessage');
             spyOn(filterGroupPanel, '_isLayerActive').andReturn(true);
             spyOn(filterGroupPanel, '_sortPanels').andReturn([{}]);
             spyOn(filterGroupPanel, '_createFilterPanel').andReturn(filterPanel);
@@ -183,21 +183,21 @@ describe("Portal.filter.FilterGroupPanel", function() {
             };
 
             spyOn(filterGroupPanel, '_updateLayerFilters');
-            spyOn(filterGroupPanel, 'addErrorMessage');
+            spyOn(filterGroupPanel, '_addErrorMessage');
             spyOn(filterGroupPanel, '_createFilterPanel').andReturn(filterPanel);
             spyOn(filterGroupPanel, '_isLayerActive').andReturn(true);
         });
 
-        it('calls the addErrorMessage function when filters set but has no filters configured', function() {
+        it('calls the _addErrorMessage function when filters set but has no filters configured', function() {
 
             layer.filters = [];
 
             filterGroupPanel._filtersLoaded(layer.filters);
 
-            expect(filterGroupPanel.addErrorMessage).toHaveBeenCalled();
+            expect(filterGroupPanel._addErrorMessage).toHaveBeenCalled();
         });
 
-        it('addErrorMessage function not called when filters are configured', function() {
+        it('_addErrorMessage function not called when filters are configured', function() {
 
             layer.filters = ["Boolean", "Combo"];
 
@@ -205,7 +205,7 @@ describe("Portal.filter.FilterGroupPanel", function() {
 
             filterGroupPanel._filtersLoaded(layer.filters);
 
-            expect(filterGroupPanel.addErrorMessage).not.toHaveBeenCalled();
+            expect(filterGroupPanel._addErrorMessage).not.toHaveBeenCalled();
         });
     });
 

--- a/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
@@ -284,7 +284,8 @@ describe("Portal.filter.FilterGroupPanel", function() {
     describe('_organiseFilterPanels', function() {
 
         var filterPanels;
-        var numGroupsExpected = 3;
+        var numGroups = 3;
+        var numHeadings = numGroups - 1; // Number filters won't have a heading
         var numComponentsPerGroup = 2;
 
         beforeEach(function() {
@@ -292,13 +293,13 @@ describe("Portal.filter.FilterGroupPanel", function() {
             spyOn(Portal.filter.NumberFilterPanel.prototype, '_createField');
             spyOn(Portal.filter.DateFilterPanel.prototype, '_setExistingFilters');
             spyOn(Portal.filter.DateFilterPanel.prototype, '_createField');
-            spyOn(Portal.filter.ComboFilterPanel.prototype, '_setExistingFilters');
-            spyOn(Portal.filter.ComboFilterPanel.prototype, '_createField');
+            spyOn(Portal.filter.BooleanFilterPanel.prototype, '_setExistingFilters');
+            spyOn(Portal.filter.BooleanFilterPanel.prototype, '_createField');
 
             filterPanels = [
                 new Portal.filter.DateFilterPanel(),
-                new Portal.filter.ComboFilterPanel(),
-                new Portal.filter.ComboFilterPanel(),
+                new Portal.filter.BooleanFilterPanel(),
+                new Portal.filter.BooleanFilterPanel(),
                 new Portal.filter.NumberFilterPanel(),
                 new Portal.filter.NumberFilterPanel()
             ];
@@ -313,9 +314,9 @@ describe("Portal.filter.FilterGroupPanel", function() {
 
         it('creates a new groups as required', function() {
 
-            expect(filterGroupPanel._createFilterGroupHeading.callCount).toBe(numGroupsExpected);
-            expect(filterGroupPanel._createVerticalSpacer.callCount).toBe(numGroupsExpected);
-            expect(filterGroupPanel.add.callCount).toBe(numGroupsExpected * numComponentsPerGroup);
+            expect(filterGroupPanel._createFilterGroupHeading.callCount).toBe(numHeadings);
+            expect(filterGroupPanel._createVerticalSpacer.callCount).toBe(numGroups);
+            expect(filterGroupPanel.add.callCount).toBe(numGroups * numComponentsPerGroup);
         });
     });
 });

--- a/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
@@ -214,7 +214,7 @@ describe("Portal.filter.FilterGroupPanel", function() {
 
         var removeFilterSpy = jasmine.createSpy('handleRemoveFilter');
 
-        var _mockFilterPanel = function(name) {
+        var _mockFilterPanel = function() {
 
             return {
                 handleRemoveFilter: removeFilterSpy
@@ -278,6 +278,44 @@ describe("Portal.filter.FilterGroupPanel", function() {
 
                 expect(filterGroupPanel._getVisualisationCQLFilters(filterDescriptorData)).toEqual('pardon my French');
             });
+        });
+    });
+
+    describe('_organiseFilterPanels', function() {
+
+        var filterPanels;
+        var numGroupsExpected = 3;
+        var numComponentsPerGroup = 2;
+
+        beforeEach(function() {
+            spyOn(Portal.filter.NumberFilterPanel.prototype, '_setExistingFilters');
+            spyOn(Portal.filter.NumberFilterPanel.prototype, '_createField');
+            spyOn(Portal.filter.DateFilterPanel.prototype, '_setExistingFilters');
+            spyOn(Portal.filter.DateFilterPanel.prototype, '_createField');
+            spyOn(Portal.filter.ComboFilterPanel.prototype, '_setExistingFilters');
+            spyOn(Portal.filter.ComboFilterPanel.prototype, '_createField');
+
+            filterPanels = [
+                new Portal.filter.DateFilterPanel(),
+                new Portal.filter.ComboFilterPanel(),
+                new Portal.filter.ComboFilterPanel(),
+                new Portal.filter.NumberFilterPanel(),
+                new Portal.filter.NumberFilterPanel()
+            ];
+
+            spyOn(filterGroupPanel, '_createGroupContainer').andCallThrough();
+            spyOn(filterGroupPanel, '_createFilterGroupHeading').andCallThrough();
+            spyOn(filterGroupPanel, '_createVerticalSpacer');
+            spyOn(filterGroupPanel, 'add');
+
+            filterGroupPanel._organiseFilterPanels(filterPanels);
+        });
+
+        it('creates a new groups as required', function() {
+
+            expect(filterGroupPanel._createFilterGroupHeading.callCount).toBe(numGroupsExpected);
+            expect(filterGroupPanel._createVerticalSpacer.callCount).toBe(numGroupsExpected);
+            expect(filterGroupPanel.add.callCount).toBe(numGroupsExpected * numComponentsPerGroup);
         });
     });
 });

--- a/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/FilterGroupPanelSpec.js
@@ -51,7 +51,7 @@ describe("Portal.filter.FilterGroupPanel", function() {
             filterGroupPanel = new Portal.filter.FilterGroupPanel(cfg);
 
             spyOn(filterGroupPanel, '_updateAndShow');
-            spyOn(filterGroupPanel, '_filtersSort').andReturn(layer);
+            spyOn(filterGroupPanel, '_sortPanels').andReturn([{}]);
             spyOn(filterGroupPanel, '_isLayerActive').andReturn(true);
             spyOn(filterGroupPanel, '_createFilterPanel').andReturn(filterPanel);
 
@@ -65,7 +65,7 @@ describe("Portal.filter.FilterGroupPanel", function() {
 
         it('sorts the filters according to sort order', function() {
 
-            expect(filterGroupPanel._filtersSort).toHaveBeenCalled();
+            expect(filterGroupPanel._sortPanels).toHaveBeenCalled();
         });
 
         it('calls _updateAndShow', function() {
@@ -75,65 +75,52 @@ describe("Portal.filter.FilterGroupPanel", function() {
     });
 
     describe('filter sorting', function() {
-        var expectedReturn;
-        var filterConfigs;
-        var testBooleanFilterA;
-        var testDateFilter;
-        var testDateRangeFilter;
-        var testBooleanFilterE;
-        var testBboxFilter;
-        var testStringFilter;
 
-        beforeEach(function() {
-            layer = {
-                server: {
-                    uri: {}
-                }
-            };
+        it('sorts panels in expected order', function() {
 
-            cfg = {
-                layer: layer
-            };
+            spyOn(Portal.filter.BooleanFilterPanel.prototype, '_createField');
+            spyOn(Portal.filter.BooleanFilterPanel.prototype, '_setExistingFilters');
+            spyOn(Portal.filter.NumberFilterPanel.prototype, '_setExistingFilters');
+            spyOn(Portal.filter.GeometryFilterPanel.prototype, '_createField');
+            spyOn(Portal.filter.GeometryFilterPanel.prototype, 'setLayerAndFilter');
+            spyOn(Portal.filter.DateFilterPanel.prototype, '_setExistingFilters');
+            spyOn(Portal.filter.DateFilterPanel.prototype, '_createField');
+            spyOn(Portal.filter.ComboFilterPanel.prototype, '_setExistingFilters');
 
-            filterConfigs = [
-                {type: 'Boolean', label: 'A', name: 'A', visualised: true},
-                {type: 'Date', label: 'B', name: 'B', visualised: true},
-                {type: 'DateRange', label: 'Z', name: 'Z', visualised: true},
-                {type: 'Boolean', label: 'E', name: 'E', visualised: true},
-                {type: 'BoundingBox', label: 'C', name: 'C', visualised: true},
-                {type: 'String', label: 'D', name: 'D', visualised: true}
+            var booleanPanelA = new Portal.filter.BooleanFilterPanel({
+                filter: { getDisplayLabel: function() { return 'A' } }
+            });
+            var booleanPanelB = new Portal.filter.BooleanFilterPanel({
+                filter: { getDisplayLabel: function() { return 'B' } }
+            });
+            var numberPanel =  new Portal.filter.NumberFilterPanel();
+            var geometryPanel = new Portal.filter.GeometryFilterPanel({
+                layer: { map: getMockMap() }
+            });
+            var datePanel = new Portal.filter.DateFilterPanel();
+            var comboPanel = new Portal.filter.ComboFilterPanel();
+
+            var panels = [
+                booleanPanelB,
+                comboPanel,
+                datePanel,
+                booleanPanelA,
+                geometryPanel,
+                numberPanel
             ];
 
-            testBooleanFilterA = new Portal.filter.Filter(filterConfigs[0]);
-            testDateFilter = new Portal.filter.Filter(filterConfigs[1]);
-            testDateRangeFilter = new Portal.filter.Filter(filterConfigs[2]);
-            testBooleanFilterE = new Portal.filter.Filter(filterConfigs[3]);
-            testBboxFilter = new Portal.filter.Filter(filterConfigs[4]);
-            testStringFilter = new Portal.filter.Filter(filterConfigs[5]);
-
-            layer.filters = [
-                testBooleanFilterA,
-                testDateFilter,
-                testDateRangeFilter,
-                testBooleanFilterE,
-                testBboxFilter,
-                testStringFilter
-            ];
-
-            expectedReturn = [
-                testBboxFilter,
-                testDateFilter,
-                testDateRangeFilter,
-                testBooleanFilterA,
-                testBooleanFilterE,
-                testStringFilter
+            var expectedPanelOrder = [
+                geometryPanel,
+                datePanel,
+                booleanPanelA,
+                booleanPanelB,
+                numberPanel,
+                comboPanel
             ];
 
             filterGroupPanel = new Portal.filter.FilterGroupPanel(cfg);
-        });
 
-        it('sorts by specified order', function() {
-            expect(filterGroupPanel._filtersSort(layer.filters)).toEqual(expectedReturn);
+            expect(filterGroupPanel._sortPanels(panels)).toEqual(expectedPanelOrder);
         });
     });
 
@@ -162,10 +149,9 @@ describe("Portal.filter.FilterGroupPanel", function() {
             spyOn(filterGroupPanel, '_updateLayerFilters');
             spyOn(filterGroupPanel, 'addErrorMessage');
             spyOn(filterGroupPanel, '_isLayerActive').andReturn(true);
-            spyOn(filterGroupPanel, '_filtersSort').andReturn(layer);
+            spyOn(filterGroupPanel, '_sortPanels').andReturn([{}]);
             spyOn(filterGroupPanel, '_createFilterPanel').andReturn(filterPanel);
         });
-
 
         it('calls the _clearFilters method', function() {
 
@@ -202,7 +188,6 @@ describe("Portal.filter.FilterGroupPanel", function() {
             spyOn(filterGroupPanel, '_isLayerActive').andReturn(true);
         });
 
-
         it('calls the addErrorMessage function when filters set but has no filters configured', function() {
 
             layer.filters = [];
@@ -214,9 +199,9 @@ describe("Portal.filter.FilterGroupPanel", function() {
 
         it('addErrorMessage function not called when filters are configured', function() {
 
-            layer.filters = ["Boolean","Combo"];
+            layer.filters = ["Boolean", "Combo"];
 
-            spyOn(filterGroupPanel, '_filtersSort').andReturn(layer);
+            spyOn(filterGroupPanel, '_sortPanels').andReturn([{},{}]);
 
             filterGroupPanel._filtersLoaded(layer.filters);
 
@@ -286,14 +271,12 @@ describe("Portal.filter.FilterGroupPanel", function() {
                     type: 'Boolean',
                     visualised: true
                 }
-
             });
 
             it('calls getVisualisationCQL when options.downloadOnly is false', function() {
 
                 expect(filterGroupPanel._getVisualisationCQLFilters(filterDescriptorData)).toEqual('pardon my French');
             });
-
         });
     });
 });

--- a/src/test/javascript/portal/filter/GeometryFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/GeometryFilterPanelSpec.js
@@ -29,14 +29,6 @@ describe("Portal.filter.GeometryFilterPanel", function() {
         spyOn(window, 'trackUsage');
     });
 
-    it('filter name should be undefined', function() {
-        filterPanel.filter = {
-            getName: function() { return 'this name should be ignored' }
-        };
-
-        expect(filterPanel.getFilterName()).toEqual(undefined);
-    });
-
     it("isVisualised() should return false", function() {
         expect(filterPanel.isVisualised()).toBe(false);
     });

--- a/src/test/javascript/portal/form/PolygonTypeComboSpec.js
+++ b/src/test/javascript/portal/form/PolygonTypeComboSpec.js
@@ -11,13 +11,7 @@ describe('Portal.form.PolygonTypeCombo', function() {
     var polygonTypeCombo;
 
     beforeEach(function() {
-        mockMap = {
-            setSpatialConstraintStyle: jasmine.createSpy(),
-            getSpatialConstraintType: jasmine.createSpy(),
-            events: {
-                on: jasmine.createSpy()
-            }
-        };
+        mockMap = getMockMap();
 
         polygonTypeCombo = new Portal.form.PolygonTypeComboBox({
             map: mockMap
@@ -32,7 +26,6 @@ describe('Portal.form.PolygonTypeCombo', function() {
         it('has a polygon item', function() {
             expect(polygonTypeCombo.store.find('value', Portal.ui.openlayers.SpatialConstraintType.POLYGON)).toBeGreaterThan(-1);
         });
-
     });
 
     describe('polygon combo box', function() {

--- a/src/test/javascript/spec_helper.js
+++ b/src/test/javascript/spec_helper.js
@@ -112,9 +112,14 @@ var mockLayoutForMainPanel = function(mainPanel) {
     };
 };
 
-var mockMap = function() {
+var getMockMap = function() {
     return {
-        events: { register: function(event, scope, fn) {}}
+        events: {
+            register: jasmine.createSpy(),
+            on: jasmine.createSpy()
+        },
+        setSpatialConstraintStyle: jasmine.createSpy(),
+        getSpatialConstraintType: jasmine.createSpy()
     };
 };
 

--- a/web-app/js/portal/filter/BaseFilterPanel.js
+++ b/web-app/js/portal/filter/BaseFilterPanel.js
@@ -114,7 +114,7 @@ Portal.filter.BaseFilterPanel.newFilterPanelFor = function(cfg) {
         newFilterPanel = new Portal.filter.BooleanFilterPanel(cfg);
     }
     else if (type === "BoundingBox") {
-        newFilterPanel = new Portal.filter.BoundingBoxFilterPanel(cfg);
+        newFilterPanel = new Portal.filter.GeometryFilterPanel(cfg);
     }
     else if (type === "Number") {
         newFilterPanel = new Portal.filter.NumberFilterPanel(cfg);

--- a/web-app/js/portal/filter/BaseFilterPanel.js
+++ b/web-app/js/portal/filter/BaseFilterPanel.js
@@ -101,23 +101,47 @@ Portal.filter.BaseFilterPanel = Ext.extend(Ext.Panel, {
 
 Portal.filter.BaseFilterPanel.newFilterPanelFor = function(cfg) {
 
-    var newFilterPanel;
-    var type = cfg.filter.getType();
+    var type = cfg.filter.getType().toLowerCase();
 
-    if (type === "String") {
+    // Todo - DN: Remove when loading filters from DBis removed
+    // Portal types --> GeoServer types (temporary)
+    if (type == "daterange") {
+        type = 'datetime'
+    }
+    else if (type === "boundingbox") {
+        type = 'geometrypropertytype'
+    }
+    else if (type === "number") {
+        type = 'decimal'
+    }
+    // Todo - DN: End of temp code
+
+    var typeMatches = function(toMatch) {
+        var anyMatch = false;
+
+        Ext.each(toMatch, function(currentMatch) {
+            anyMatch |= type === currentMatch;
+        });
+
+        return anyMatch;
+    };
+
+    var newFilterPanel;
+
+    if (typeMatches('string')) {
         newFilterPanel = new Portal.filter.ComboFilterPanel(cfg);
     }
-    else if (type == "Date" || type == "DateRange") {
-        newFilterPanel = new Portal.filter.DateFilterPanel(cfg);
-    }
-    else if (type === "Boolean") {
+    else if (typeMatches('boolean')) {
         newFilterPanel = new Portal.filter.BooleanFilterPanel(cfg);
     }
-    else if (type === "BoundingBox") {
-        newFilterPanel = new Portal.filter.GeometryFilterPanel(cfg);
+    else if (typeMatches(['date', 'datetime'])) {
+        newFilterPanel = new Portal.filter.DateFilterPanel(cfg);
     }
-    else if (type === "Number") {
+    else if (typeMatches(['double', 'float', 'integer', 'int', 'long', 'short', 'decimal'])) {
         newFilterPanel = new Portal.filter.NumberFilterPanel(cfg);
+    }
+    else if (typeMatches(['pointpropertytype', 'geometrypropertytype', 'multilinepropertytype', 'surfacepropertytype', 'curvepropertytype'])) {
+        newFilterPanel = new Portal.filter.GeometryFilterPanel(cfg);
     }
     else {
         //Filter hasn't been defined

--- a/web-app/js/portal/filter/BaseFilterPanel.js
+++ b/web-app/js/portal/filter/BaseFilterPanel.js
@@ -102,27 +102,26 @@ Portal.filter.BaseFilterPanel = Ext.extend(Ext.Panel, {
 Portal.filter.BaseFilterPanel.newFilterPanelFor = function(cfg) {
 
     var newFilterPanel;
+    var type = cfg.filter.getType();
 
-    if (cfg.filter.getType() === "String") {
+    if (type === "String") {
         newFilterPanel = new Portal.filter.ComboFilterPanel(cfg);
     }
-    else if (cfg.filter.getType() == "Date") {
+    else if (type == "Date" || type == "DateRange") {
         newFilterPanel = new Portal.filter.DateFilterPanel(cfg);
     }
-    else if (cfg.filter.getType() == "DateRange") {
-        newFilterPanel = new Portal.filter.DateFilterPanel(cfg);
-    }
-    else if (cfg.filter.getType() === "Boolean") {
+    else if (type === "Boolean") {
         newFilterPanel = new Portal.filter.BooleanFilterPanel(cfg);
     }
-    else if (cfg.filter.getType() === "BoundingBox") {
+    else if (type === "BoundingBox") {
         newFilterPanel = new Portal.filter.BoundingBoxFilterPanel(cfg);
     }
-    else if (cfg.filter.getType() === "Number") {
+    else if (type === "Number") {
         newFilterPanel = new Portal.filter.NumberFilterPanel(cfg);
     }
     else {
         //Filter hasn't been defined
+        log.error("Could not create filter panel for type'" + type + "'");
     }
 
     return newFilterPanel;

--- a/web-app/js/portal/filter/BaseFilterPanel.js
+++ b/web-app/js/portal/filter/BaseFilterPanel.js
@@ -16,8 +16,7 @@ Portal.filter.BaseFilterPanel = Ext.extend(Ext.Panel, {
 
     constructor: function(cfg) {
         var config = Ext.apply({
-            emptyText: OpenLayers.i18n("pleasePickCondensed"),
-            typeLabel: OpenLayers.i18n('generalFilterHeading'),
+            typeLabel: '',
             listeners: {
                 beforeremove: function(panel, component) {
                     this.removeAll(true);

--- a/web-app/js/portal/filter/BaseFilterPanel.js
+++ b/web-app/js/portal/filter/BaseFilterPanel.js
@@ -50,16 +50,8 @@ Portal.filter.BaseFilterPanel = Ext.extend(Ext.Panel, {
         this._setExistingFilters();
     },
 
-    getFilterNameAsTitleCase: function() {
-        return this.filter.getDisplayLabel();
-    },
-
     getFilterData: function() {
         throw "subclasses must override this function";
-    },
-
-    getFilterName: function() {
-        return this.filter.getName();
     },
 
     isVisualised: function() {

--- a/web-app/js/portal/filter/BooleanFilterPanel.js
+++ b/web-app/js/portal/filter/BooleanFilterPanel.js
@@ -20,6 +20,7 @@ Portal.filter.BooleanFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
 
         Portal.filter.BooleanFilterPanel.superclass.constructor.call(this, config);
     },
+
     _createField: function() {
         this.checkbox = new Ext.form.Checkbox({
             name: this.filter.getName(),

--- a/web-app/js/portal/filter/BooleanFilterPanel.js
+++ b/web-app/js/portal/filter/BooleanFilterPanel.js
@@ -11,6 +11,7 @@ Portal.filter.BooleanFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
 
     constructor: function(cfg) {
         var config = Ext.apply({
+            typeLabel: OpenLayers.i18n('generalFilterHeading'),
             layout: 'menu',
             layoutConfig: {
                 align: 'centre'

--- a/web-app/js/portal/filter/BooleanFilterPanel.js
+++ b/web-app/js/portal/filter/BooleanFilterPanel.js
@@ -36,11 +36,6 @@ Portal.filter.BooleanFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
         this.add(this.checkbox);
     },
 
-    getFilterName: function() {
-        // No titles for booleans
-        return null;
-    },
-
     _formatBoxLabel: function() {
         return this.filter.getDisplayLabel();
     },
@@ -63,7 +58,7 @@ Portal.filter.BooleanFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
 
     _getCQLHumanValue: function() {
         if (this.checkbox.getValue()) {
-            return this.getFilterNameAsTitleCase() + " = true";
+            return this.filter.getDisplayLabel() + " = true";
         }
         else {
             return undefined;

--- a/web-app/js/portal/filter/ComboFilterPanel.js
+++ b/web-app/js/portal/filter/ComboFilterPanel.js
@@ -18,6 +18,10 @@ Portal.filter.ComboFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
     },
 
     _createField: function() {
+        this.add(new Ext.form.Label({
+            html: "<label>" + this.filter.getDisplayLabel() + "</label>"
+        }));
+
         this.combo = new Ext.form.ComboBox({
             disabled: true,
             triggerAction: 'all',
@@ -40,8 +44,8 @@ Portal.filter.ComboFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
                 valid: this._onSelected
             }
         });
-
         this.add(this.combo);
+
         this.add(
             new Ext.Spacer({
                 cls: 'block',

--- a/web-app/js/portal/filter/DateFilterPanel.js
+++ b/web-app/js/portal/filter/DateFilterPanel.js
@@ -34,7 +34,6 @@ Portal.filter.DateFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
         this.add(this.fromDate);
         this._addVerticalSpacer(5);
         this.add(this.toDate);
-        this._addVerticalSpacer(15);
 
         if (this.filter.values != undefined) {
             this._setMinMax(this.fromDate, this.filter.values);

--- a/web-app/js/portal/filter/DateFilterPanel.js
+++ b/web-app/js/portal/filter/DateFilterPanel.js
@@ -63,11 +63,6 @@ Portal.filter.DateFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
         });
     },
 
-    getFilterName: function() {
-        // No titles for DateFilter
-        return null;
-    },
-
     _setMinMax: function(resettableDate, vals) {
         resettableDate.setMinValue(this.TIME_UTIL._parseIso8601Date(vals[0]));
 

--- a/web-app/js/portal/filter/FilterGroupPanel.js
+++ b/web-app/js/portal/filter/FilterGroupPanel.js
@@ -11,7 +11,7 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
     constructor: function(cfg) {
 
         this.layer = cfg.layer;
-        this.loadingMessage = this.createLoadingMessageContainer();
+        this.loadingMessage = this._createLoadingMessageContainer();
         var config = Ext.apply({
             autoDestroy: true,
             cls: 'filterGroupPanel',
@@ -32,24 +32,24 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
         this._initWithLayer();
     },
 
-    _getGroupContainer: function() {
+    _createGroupContainer: function() {
         return new Ext.Container({
             cls: 'filterGroupContainer'
         })
     },
 
-    _getVerticalSpacer: function(sizeInPixels) {
+    _createVerticalSpacer: function(sizeInPixels) {
         return new Ext.Spacer({
             cls: 'block',
             height: sizeInPixels
         })
     },
 
-    createLoadingMessageContainer: function() {
+    _createLoadingMessageContainer: function() {
         return new Ext.Container({
             autoEl: 'div',
             items: [
-                this._getVerticalSpacer(10),
+                this._createVerticalSpacer(10),
                 {
                     html: OpenLayers.i18n('loadingSpinner', {resource: OpenLayers.i18n('subsetParametersText')})
                 }
@@ -57,30 +57,30 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
         });
     },
 
-    createErrorMessageContainer: function() {
+    _createErrorMessageContainer: function() {
         return new Ext.Container({
             autoEl: 'div',
             html: ""
         })
     },
 
-    setErrorMessageText: function(msg, errorMsgContainer) {
+    _setErrorMessageText: function(msg, errorMsgContainer) {
         errorMsgContainer.html = "<i>" + msg + "</i>";
     },
 
-    removeLoadingMessage: function() {
+    _removeLoadingMessage: function() {
         this.remove(this.loadingMessage);
         delete this.loadingMessage;
     },
 
-    addErrorMessage: function(msg) {
+    _addErrorMessage: function(msg) {
         if (this.errorMessage) {
-            this.setErrorMessageText(msg, this.errorMessage);
+            this._setErrorMessageText(msg, this.errorMessage);
         }
         else {
-            this.removeLoadingMessage();
-            this.errorMessage = this.createErrorMessageContainer();
-            this.setErrorMessageText(msg, this.errorMessage);
+            this._removeLoadingMessage();
+            this.errorMessage = this._createErrorMessageContainer();
+            this._setErrorMessageText(msg, this.errorMessage);
             this.add(this.errorMessage);
             this.doLayout();
         }
@@ -138,7 +138,7 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
             this._updateAndShow();
         }
         else {
-            this.addErrorMessage(OpenLayers.i18n('subsetEmptyFiltersText'));
+            this._addErrorMessage(OpenLayers.i18n('subsetEmptyFiltersText'));
         }
     },
 
@@ -226,7 +226,7 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
 
             this.currentFilterTypeLabel = filterPanel.typeLabel;
 
-            this.currentGroupContainer = this._getGroupContainer();
+            this.currentGroupContainer = this._createGroupContainer();
             this.currentGroupContainer.add(label);
             this.add(this.currentGroupContainer);
         }
@@ -241,7 +241,7 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
     _addFilterTypeSpacer: function(filter) {
 
         if (this.currentFilterType != filter.getType()) {
-            this.currentGroupContainer.add(this._getVerticalSpacer(15));
+            this.currentGroupContainer.add(this._createVerticalSpacer(15));
         }
     },
 
@@ -261,9 +261,9 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
 
         this._updateLayerFilters();
 
-        this.add(this._getVerticalSpacer(15));
+        this.add(this._createVerticalSpacer(15));
         this.add(this.clearFiltersButton);
-        this.add(this._getVerticalSpacer(25));
+        this.add(this._createVerticalSpacer(25));
 
         if (this._isDisplayed()) {
             this.doLayout();

--- a/web-app/js/portal/filter/FilterGroupPanel.js
+++ b/web-app/js/portal/filter/FilterGroupPanel.js
@@ -45,6 +45,18 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
         })
     },
 
+    _createFilterLabel: function(labelText) {
+        return new Ext.form.Label({
+            html: "<label>" + labelText + "</label>"
+        });
+    },
+
+    _createFilterGroupHeading: function(headerText) {
+        return new Ext.Container({
+            html: "<h4>" + headerText + "</h4>"
+        });
+    },
+
     _createLoadingMessageContainer: function() {
         return new Ext.Container({
             autoEl: 'div',
@@ -98,9 +110,7 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
     _addLabelToFilterPanel: function(filter) {
 
         var labelText = filter.getDisplayLabel();
-        var label = new Ext.form.Label({
-            html: "<label>" + labelText + "</label>"
-        });
+        var label = this._createFilterLabel(labelText);
         this.currentGroupContainer.add(label);
     },
 
@@ -220,14 +230,12 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
     _createNewGroupContainer: function(filter, filterPanel) {
 
         if (filterPanel.typeLabel != this.currentFilterTypeLabel) {
-            var label = new Ext.Container({
-                html: "<h4>" + filterPanel.typeLabel + "</h4>"
-            });
+            var heading = this._createFilterGroupHeading(filterPanel.typeLabel);
 
             this.currentFilterTypeLabel = filterPanel.typeLabel;
 
             this.currentGroupContainer = this._createGroupContainer();
-            this.currentGroupContainer.add(label);
+            this.currentGroupContainer.add(heading);
             this.add(this.currentGroupContainer);
         }
         else {
@@ -316,7 +324,7 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
         return cql.join(this.AND_QUERY);
     },
 
-    _logFilterRequest: function(aFilter) {
+    _logFilterRequest: function() {
         var layer = this.layer;
         var filterData = layer.filterData;
 

--- a/web-app/js/portal/filter/FilterGroupPanel.js
+++ b/web-app/js/portal/filter/FilterGroupPanel.js
@@ -107,13 +107,6 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
         return active;
     },
 
-    _addLabelToFilterPanel: function(filter) {
-
-        var labelText = filter.getDisplayLabel();
-        var label = this._createFilterLabel(labelText);
-        this.currentGroupContainer.add(label);
-    },
-
     _initWithLayer: function() {
 
         var filterService = new Portal.filter.FilterService();
@@ -218,10 +211,7 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
             this.relayEvents(newFilterPanel, ['addFilter']);
             this._createNewGroupContainer(filter, newFilterPanel);
 
-            if (newFilterPanel.getFilterName()) {
-                this._addLabelToFilterPanel(filter);
-            }
-            this.currentGroupContainer.add(newFilterPanel);
+             this.currentGroupContainer.add(newFilterPanel);
 
             return newFilterPanel;
         }

--- a/web-app/js/portal/filter/FilterGroupPanel.js
+++ b/web-app/js/portal/filter/FilterGroupPanel.js
@@ -229,8 +229,10 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
         var groupContainer = this._createGroupContainer();
         this.add(groupContainer);
 
-        var heading = this._createFilterGroupHeading(panel.typeLabel);
-        groupContainer.add(heading);
+        if (panel.typeLabel != '') {
+            var heading = this._createFilterGroupHeading(panel.typeLabel);
+            groupContainer.add(heading);
+        }
 
         var spacer = this._createVerticalSpacer(15);
         this.add(spacer);

--- a/web-app/js/portal/filter/GeometryFilterPanel.js
+++ b/web-app/js/portal/filter/GeometryFilterPanel.js
@@ -7,7 +7,7 @@
 
 Ext.namespace('Portal.filter');
 
-Portal.filter.BoundingBoxFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
+Portal.filter.GeometryFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
 
     constructor: function(cfg) {
 
@@ -15,7 +15,7 @@ Portal.filter.BoundingBoxFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel,
             typeLabel: OpenLayers.i18n('spatialExtentHeading')
         }, cfg);
 
-        Portal.filter.BoundingBoxFilterPanel.superclass.constructor.call(this, config);
+        Portal.filter.GeometryFilterPanel.superclass.constructor.call(this, config);
 
         this.map = cfg.layer.map;
         this.map.events.on({
@@ -60,7 +60,7 @@ Portal.filter.BoundingBoxFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel,
     },
 
     setLayerAndFilter: function(layer, filter) {
-        Portal.filter.BoundingBoxFilterPanel.superclass.setLayerAndFilter.apply(this, arguments);
+        Portal.filter.GeometryFilterPanel.superclass.setLayerAndFilter.apply(this, arguments);
         if (layer.map.spatialConstraintControl) {
             this._updateWithGeometry(layer.map.spatialConstraintControl.getConstraint());
         }

--- a/web-app/js/portal/filter/GeometryFilterPanel.js
+++ b/web-app/js/portal/filter/GeometryFilterPanel.js
@@ -55,10 +55,6 @@ Portal.filter.GeometryFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
         return this.geometry != undefined;
     },
 
-    getFilterName: function() {
-        return undefined;
-    },
-
     setLayerAndFilter: function(layer, filter) {
         Portal.filter.GeometryFilterPanel.superclass.setLayerAndFilter.apply(this, arguments);
         if (layer.map.spatialConstraintControl) {

--- a/web-app/js/portal/filter/NumberFilterPanel.js
+++ b/web-app/js/portal/filter/NumberFilterPanel.js
@@ -24,6 +24,9 @@ Portal.filter.NumberFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
     },
 
     _createField: function() {
+        var label = new Ext.form.Label({
+            html: "<label>" + this.filter.getDisplayLabel() + "</label>"
+        });
 
         this.operators = new Ext.form.ComboBox({
             triggerAction: 'all',
@@ -76,6 +79,7 @@ Portal.filter.NumberFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
             }
         });
 
+        this.add(label);
         this.add(this.operators);
         this.add(this.firstField);
         this.add(this.secondField);


### PR DESCRIPTION
This change moves the choice of the correct UI component for a given GeoServer type to the client side. As it is it should be backwards compatible with the WFS scanner and server-side types which are used currently but which will disappear soon.