### PR TITLE
Multiple substitutions for download URLs can now be configured.

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -209,15 +209,18 @@ knownServers = [
         wmsVersion: '1.1.1',
         type: 'GeoServer',
         csvDownloadFormat: 'csv-with-metadata-header',
-        urlListDownloadPrefixToRemove: '/mnt/imos-t3/',
-        urlListDownloadPrefixToSubstitue: 'http://data.aodn.org.au/'
+        urlListDownloadSubstitutions: [
+            '/mnt/imos-t3/': 'http://data.aodn.org.au/',
+            '/mnt/opendap/2/SRS': 'http://thredds.aodn.org.au/thredds/fileServer/srs'
+        ]
     ],
     [
         uri: 'http://ncwms.aodn.org.au/ncwms/wms',
         wmsVersion: '1.1.1',
         type: 'ncWMS',
-        urlListDownloadPrefixToRemove: '/mnt/imos-t3/IMOS/opendap/',
-        urlListDownloadPrefixToSubstitue: 'http://thredds.aodn.org.au/thredds/fileServer/IMOS/'
+        urlListDownloadSubstitutions: [
+            '/mnt/imos-t3/IMOS/opendap/': 'http://thredds.aodn.org.au/thredds/fileServer/IMOS/'
+        ]
     ],
     [
         uri: 'http://rs-data1-mel.csiro.au/ncWMS/wms',

--- a/grails-app/domain/au/org/emii/portal/Server.groovy
+++ b/grails-app/domain/au/org/emii/portal/Server.groovy
@@ -224,7 +224,7 @@ class Server {
     }
 
     def getUrlListDownloadSubstitutions() {
-        return grailsApplication?.config?.knownServers?.find {
+        return grailsApplication.config.knownServers.find {
             this.uri.startsWith(it.uri)
         }?.urlListDownloadSubstitutions ?: [:]
     }

--- a/grails-app/domain/au/org/emii/portal/Server.groovy
+++ b/grails-app/domain/au/org/emii/portal/Server.groovy
@@ -13,6 +13,8 @@ import groovy.time.TimeCategory
 import org.apache.commons.codec.binary.Base64
 
 class Server {
+    def grailsApplication
+
     Long id
     String uri
     String shortAcron
@@ -28,9 +30,6 @@ class Server {
     String username
     String password
 
-    String urlListDownloadPrefixToRemove
-    String urlListDownloadPrefixToSubstitue
-
     Date lastScanDate
     Integer scanFrequency = 120 // 2 hours
 
@@ -44,6 +43,8 @@ class Server {
 
         operations cascade: 'all-delete-orphan'
     }
+
+    static transients = [ 'urlListDownloadSubstitutions' ]
 
     static constraints = {
         uri(unique: true, url: true)
@@ -78,8 +79,6 @@ class Server {
         comments(nullable: true)
         username(nullable: true)
         password(nullable: true)
-        urlListDownloadPrefixToRemove(nullable: true)
-        urlListDownloadPrefixToSubstitue(nullable: true)
         owners(nullable: true, validator: {
             //This is totally not a great way to do things
             def ownerRole = UserRole.findByName(UserRole.SERVEROWNER)
@@ -222,5 +221,11 @@ class Server {
 
             operations << operation
         }
+    }
+
+    def getUrlListDownloadSubstitutions() {
+        return grailsApplication?.config?.knownServers?.find {
+            this.uri.startsWith(it.uri)
+        }?.urlListDownloadSubstitutions ?: [:]
     }
 }

--- a/grails-app/migrations/20150310-JB-DropUrlSubstitution.groovy
+++ b/grails-app/migrations/20150310-JB-DropUrlSubstitution.groovy
@@ -1,0 +1,10 @@
+databaseChangeLog = {
+
+    changeSet(author: "jkburges", id: "1425952041-1") {
+        [ 'url_list_download_prefix_to_remove', 'url_list_download_prefix_to_substitue' ].each {
+            colName ->
+
+            dropColumn(columnName: colName, tableName: "server")
+        }
+    }
+}

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -88,6 +88,7 @@ databaseChangeLog = {
     include file: '20140718-DN-RemoveWfsLayer.groovy'
     include file: '20140901-DF-RemoveNameConfig.groovy'
     include file: '20140924-DF-RemoveMetadataUrls.groovy'
+    include file: '20150310-JB-DropUrlSubstitution.groovy'
 
     // Changes that apply to all instances must be included here, above the calls to instance-specific change logs
 

--- a/test/unit/au/org/emii/portal/DownloadControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/DownloadControllerTests.groovy
@@ -240,7 +240,6 @@ http://data.imos.org.au/IMOS/Q9900541.nc\n\
         def inputStream = new ByteArrayInputStream(input.bytes)
         def outputStream = new ByteArrayOutputStream()
 
-        //def sp = controller.urlListStreamProcessor('relativeFilePath', '/mnt/imos-t4/', 'http://data.imos.org.au/')
         def sp = controller.urlListStreamProcessor(
             'relativeFilePath',
             [

--- a/test/unit/au/org/emii/portal/DownloadControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/DownloadControllerTests.groovy
@@ -54,10 +54,9 @@ class DownloadControllerTests extends ControllerUnitTestCase {
         }
 
         def testStreamProcessor = new Object()
-        controller.metaClass.urlListStreamProcessor = { fieldName, prefixToRemove, newUrlBase ->
+        controller.metaClass.urlListStreamProcessor = { fieldName, urlSubstitutions ->
             assertEquals 'relativeFilePath', fieldName
-            assertEquals testServer.urlListDownloadPrefixToRemove, prefixToRemove
-            assertEquals testServer.urlListDownloadPrefixToSubstitue, newUrlBase
+            assertEquals testServer.urlListDownloadSubstitutions, urlSubstitutions
 
             return testStreamProcessor
         }
@@ -84,7 +83,7 @@ class DownloadControllerTests extends ControllerUnitTestCase {
             renderParams = theRenderParams
         }
         controller.downloadPythonSnippet()
-        
+
 
         assertEquals("text/plain", mockResponse.contentType)
         assertEquals("pythonSnippet.py", renderParams.template)
@@ -117,10 +116,9 @@ class DownloadControllerTests extends ControllerUnitTestCase {
         mockParams.downloadFilename = 'somedata.txt'
 
         def archiveGenerated = false
-        controller.metaClass.urlListStreamProcessor = { fieldName, prefixToRemove, newUrlBase ->
+        controller.metaClass.urlListStreamProcessor = { fieldName, urlSubstitutions ->
             assertEquals 'relativeFilePath', fieldName
-            assertEquals testServer.urlListDownloadPrefixToRemove, prefixToRemove
-            assertEquals testServer.urlListDownloadPrefixToSubstitue, newUrlBase
+            assertEquals testServer.urlListDownloadSubstitutions, urlSubstitutions
 
             { inputStream, outputStream ->
                 outputStream << """\
@@ -227,6 +225,7 @@ class DownloadControllerTests extends ControllerUnitTestCase {
             aatams_sattag_nrt_wfs.331442,/mnt/imos-t4/IMOS/Q9900541.nc
             aatams_sattag_nrt_wfs.331443,/mnt/imos-t4/IMOS/Q9900542.nc
             aatams_sattag_nrt_wfs.331445,/mnt/imos-t4/IMOS/Q9900543.nc
+            some_cool_data,/some_path/foo/123.nc
 
         """
 
@@ -235,12 +234,20 @@ http://data.imos.org.au/IMOS/Q9900542.nc\n\
 http://data.imos.org.au/IMOS/Q9900543.nc\n\
 http://data.imos.org.au/IMOS/Q9900540.nc\n\
 http://data.imos.org.au/IMOS/Q9900541.nc\n\
+/some_path/bar/123.nc\n\
 """
 
         def inputStream = new ByteArrayInputStream(input.bytes)
         def outputStream = new ByteArrayOutputStream()
 
-        def sp = controller.urlListStreamProcessor('relativeFilePath', '/mnt/imos-t4/', 'http://data.imos.org.au/')
+        //def sp = controller.urlListStreamProcessor('relativeFilePath', '/mnt/imos-t4/', 'http://data.imos.org.au/')
+        def sp = controller.urlListStreamProcessor(
+            'relativeFilePath',
+            [
+                '/mnt/imos-t4/': 'http://data.imos.org.au/',
+                'foo': 'bar'
+            ]
+        )
         sp(inputStream, outputStream)
 
         def output = outputStream.toString("UTF-8")
@@ -271,7 +278,20 @@ http://data.imos.org.au/IMOS/Q9900541.nc\n\
 
     void _setUpExampleObjects() {
 
-        testServer = new Server(name: 'My Server', uri: "http://www.google.com/", urlListDownloadPrefixToRemove: "/mnt/imos-t4", urlListDownloadPrefixToSubstitue: "http://data.imos.org.au")
+        testServer = new Server(name: 'My Server', uri: "http://www.google.com/")
+
+        testServer.grailsApplication = [
+            config: [
+                knownServers: [
+                    [
+                        uri: 'http://www.google.com/',
+                        urlListDownloadSubstitutions: [
+                            '/mnt/imos-t4': 'http://data.aodn.org.au'
+                        ]
+                    ]
+                ]
+            ]
+        ]
 
         mockDomain Server, [testServer]
 

--- a/test/unit/au/org/emii/portal/LayerControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/LayerControllerTests.groovy
@@ -52,7 +52,6 @@ class LayerControllerTests extends ControllerUnitTestCase {
         mockDomain Server, [server]
         mockDomain Config, [validConfig]
 
-
         def mockLayer = new Layer()
         def layerServiceControl = mockFor(LayerService)
         layerServiceControl.demand.updateWithNewData(1..1){ JSONElement e, Server s, String ds -> mockLayer }
@@ -209,8 +208,7 @@ class LayerControllerTests extends ControllerUnitTestCase {
     }
 
     void testShowLayerByItsId() {
-        def server1 = new Server()
-        server1.id = 1
+        def server1 = _getNewServer()
 
         def layer2 = new Layer()
         layer2.id = 4
@@ -219,10 +217,9 @@ class LayerControllerTests extends ControllerUnitTestCase {
 
         def layer1 = new Layer()
         layer1.id = 5
-        layer1.name = "maplayer"
+        layer1.name = "layer"
         layer1.server = server1
 
-        mockDomain(Server, [server1])
         mockDomain(Layer, [layer1, layer2])
 
         this.controller.params.layerId = 5
@@ -231,15 +228,14 @@ class LayerControllerTests extends ControllerUnitTestCase {
         def layerAsJson = JSON.parse(controller.response.contentAsString)
 
         assertEquals 5, layerAsJson.id
-        assertEquals "maplayer", layerAsJson.name
+        assertEquals "layer", layerAsJson.name
     }
 
     void testShowLayerByItsIdWhenLayerReferencesItself() {
-        def server1 = new Server(id: 1)
+        def server1 = _getNewServer()
 
         def layer1 = new Layer(id: 5, name: 'layer', server: server1)
 
-        mockDomain(Server, [server1])
         mockDomain(Layer, [layer1])
 
         this.controller.params.layerId = 5
@@ -251,6 +247,14 @@ class LayerControllerTests extends ControllerUnitTestCase {
         assertEquals "layer", layerAsJson.name
     }
 
+    def _getNewServer() {
+        def server = new Server(id: 1)
+        server.grailsApplication = [ config: [:] ]
+
+        mockDomain(Server, [server])
+
+        return server
+    }
     void testUpdateNoViewParams() {
         _updateViewParamsSetup(null)
         def updatedLayer = Layer.get(controller.redirectArgs['id'])

--- a/test/unit/au/org/emii/portal/ServerControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/ServerControllerTests.groovy
@@ -29,17 +29,15 @@ class ServerControllerTests extends ControllerUnitTestCase {
         ]
     }
 
-    protected void tearDown() {
-        super.tearDown()
-    }
-
     void testIndex() {
         this.controller.index()
         assertEquals "list", this.controller.redirectArgs["action"]
     }
 
     void testShowServerByItsId() {
-        mockDomain(Server, [new Server(id: 10, uri: "uri1", shortAcron: "A", name: "name1", type: "WMS-1.1.1", lastScanDate: null, scanFrequency: 0, disable: false, allowDiscoveries: true, opacity: 3, imageFormat: "image/png", comments: "", username: null, password: null)])
+        def server = new Server(id: 10, uri: "uri1", shortAcron: "A", name: "name1", type: "WMS-1.1.1", lastScanDate: null, scanFrequency: 0, disable: false, allowDiscoveries: true, opacity: 3, imageFormat: "image/png", comments: "", username: null, password: null)
+        server.grailsApplication = [ config: [:] ]
+        mockDomain(Server, [server])
         this.controller.params.serverId = "10_10"
         this.controller.showServerByItsId()
 


### PR DESCRIPTION
This is a requirement for some SRS collections.

Depends on https://github.com/aodn/chef-private-sample/pull/9