### PR TITLE
Only add new drilldown filters if the current panel has a drilldown

### DIFF
--- a/src/test/javascript/portal/search/FacetFilterPanelSpec.js
+++ b/src/test/javascript/portal/search/FacetFilterPanelSpec.js
@@ -10,6 +10,7 @@ describe("Portal.search.FacetFilterPanel", function() {
     var filterPanel;
     var testContainer;
     var mockSearchResponse = Portal.search.SearchSpecHelper.mockSearchResponse;
+    var mockDrilldownPanel;
 
     beforeEach(function() {
         searcher = new Portal.service.CatalogSearcher();
@@ -92,6 +93,36 @@ describe("Portal.search.FacetFilterPanel", function() {
             var drilldownPanels = filterPanel._getDrilldownPanels();
             expect(drilldownPanels.length).toEqual(1);
             expect(drilldownPanels[0].hasNoDrilldown()).toEqual(true);
+        });
+    });
+
+    describe('_addDrilldownFilters', function() {
+        beforeEach(function() {
+            mockDrilldownPanel = {
+                hasDrilldown: function() {
+                    return false;
+                },
+                getDrilldownPath: function() {
+                    return 'a shrubbery';
+                }
+            };
+
+            spyOn(filterPanel, '_getDrilldownPanels').andReturn(mockDrilldownPanel);
+            spyOn(searcher, 'addDrilldownFilter');
+        });
+
+        it('does not add a filter to the catalogue searcher if the panel has no drilldown', function() {
+            filterPanel._addDrilldownFilters();
+            expect(searcher.addDrilldownFilter).not.toHaveBeenCalled();
+        });
+
+        it('adds a filter if the panel has a drilldown', function() {
+            mockDrilldownPanel.hasDrilldown = function() {
+                return true;
+            };
+
+            filterPanel._addDrilldownFilters();
+            expect(searcher.addDrilldownFilter).toHaveBeenCalled();
         });
     });
 

--- a/web-app/js/portal/search/FacetFilterPanel.js
+++ b/web-app/js/portal/search/FacetFilterPanel.js
@@ -127,7 +127,9 @@ Portal.search.FacetFilterPanel = Ext.extend(Ext.Panel, {
 
     _addDrilldownFilters: function() {
         Ext.each(this._getDrilldownPanels(), function(drilldownPanel) {
-            this.searcher.addDrilldownFilter(drilldownPanel.getDrilldownPath());
+            if (drilldownPanel.hasDrilldown()) {
+                this.searcher.addDrilldownFilter(drilldownPanel.getDrilldownPath());
+            }
         }, this);
     },
 


### PR DESCRIPTION
Fixes issue #1596 
To clarify, the issue was the FilterPanel was trying to add new filters when an uncheck was occurring, even if there was no drilldown panel present (therefore causing the inconsistencies with page numbers).