### PR TITLE
Allow filters to be loaded from DB, GeoServer, or filesystem

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -128,7 +128,7 @@ openId {
 }
 
 featureToggles {
-    dynamicGeoserverFilters = false
+    filterSource = 'database' // Todo - DN: This can go back to being a boolean when we've removed loading filters from the DB
 }
 
 // Google Analytics

--- a/grails-app/controllers/au/org/emii/portal/LayerController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/LayerController.groovy
@@ -637,7 +637,7 @@ class LayerController {
             return new NcwmsServer()
         }
         else {
-            return new GeoserverServer(grailsApplication.config.featureToggles.dynamicGeoserverFilters)
+            return new GeoserverServer(grailsApplication.config.featureToggles.filterSource)
         }
     }
 

--- a/web-app/js/portal/filter/FilterService.js
+++ b/web-app/js/portal/filter/FilterService.js
@@ -81,7 +81,9 @@ Portal.filter.FilterService = Ext.extend(Object, {
 
         var filterLayer = layer.wmsName;
 
-        var shouldUseDownloadLayerIfPossible = Portal.app.appConfig.featureToggles.dynamicGeoserverFilters == true; // Todo - DN: Can be removed when DB/GeoServer feature toggle is removed
+        // Todo - DN: The filterSource and shouldUseDownloadLayerIfPossible variables will be redundant when we go stateless and can be removed
+        var filterSource = Portal.app.appConfig.featureToggles.filterSource;
+        var shouldUseDownloadLayerIfPossible = filterSource !== 'database';
 
         if (shouldUseDownloadLayerIfPossible && layer.getDownloadLayer) {
             filterLayer = layer.getDownloadLayer();


### PR DESCRIPTION
This is for the time being until we get filters out of the DB. At that point we can change this back to a boolean setting to choose between GeoServer (normal behaviour) and loading from filesystem (for development, troubleshooting) if needed.