### PR TITLE
Filters error handling

### DIFF
--- a/grails-app/views/_js_includes.gsp
+++ b/grails-app/views/_js_includes.gsp
@@ -105,6 +105,7 @@
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'GeometryFilterPanel.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'BooleanFilterPanel.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'NumberFilterPanel.js')}"></script>
+    <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'EmptyFilterPanel.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'FilterGroupPanel.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/form', file: 'UtcExtentDateTime.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/form', file: 'PolygonTypeComboBox.js')}"></script>

--- a/src/test/javascript/portal/filter/BaseFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/BaseFilterPanelSpec.js
@@ -12,16 +12,8 @@ describe("Portal.filter.BaseFilterPanel", function() {
 
         var newFilterPanelFor = Portal.filter.BaseFilterPanel.newFilterPanelFor;
 
-        it("should return undefined", function() {
-
-            var panel = newFilterPanelFor({
-                layer: {},
-                filter: {
-                    getType: function() { return '' }
-                }
-            });
-
-            expect(panel).toBeUndefined();
+        it("should return EmptyFilterPanel", function() {
+            expectNewFilterPanelForString('EmptyFilterPanel', '');
         });
 
         it("should create ComboFilterPanel", function() {

--- a/src/test/javascript/portal/filter/BaseFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/BaseFilterPanelSpec.js
@@ -47,7 +47,8 @@ describe("Portal.filter.BaseFilterPanel", function() {
             newFilterPanelFor({
                 layer: {},
                 filter: {
-                    getType: function() { return filterTypeAsString }
+                    getType: function() { return filterTypeAsString },
+                    getName: function() { return 'filter name' }
                 }
             });
 

--- a/src/test/javascript/portal/filter/ComboFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ComboFilterPanelSpec.js
@@ -47,8 +47,9 @@ describe("Portal.filter.ComboFilterPanel", function() {
                 getName: function() { return "vessel_name" }
             };
 
-            filterPanel.combo = {};
-            filterPanel.combo.getValue = function() { return "L'Astrolabe"; };
+            filterPanel.combo = {
+                getValue: function() { return "L'Astrolabe" }
+            };
 
             expect(filterPanel.getCQL()).toEqual("vessel_name LIKE 'L''Astrolabe'");
         });

--- a/src/test/javascript/portal/filter/FilterServiceSpec.js
+++ b/src/test/javascript/portal/filter/FilterServiceSpec.js
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2015 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+
+describe("Portal.filter.FilterService", function() {
+
+    var service = new Portal.filter.FilterService();
+    var successCallback;
+    var failureCallback;
+    var callbackScope;
+    var testLayer;
+
+    beforeEach(function() {
+
+        successCallback = jasmine.createSpy('successCallback');
+        failureCallback = jasmine.createSpy('failureCallback');
+        callbackScope = {};
+        testLayer = {
+            server: {}
+        };
+    });
+
+    describe('loadFilters', function() {
+
+        it('calls success callback', function() {
+
+            spyOnAjaxAndReturn('[]', 200);
+
+            service.loadFilters(
+                testLayer,
+                successCallback,
+                failureCallback,
+                callbackScope
+            );
+
+            expect(successCallback).toHaveBeenCalledWith([]);
+            expect(failureCallback).not.toHaveBeenCalled();
+        });
+
+        it('calls failure callback', function() {
+
+            spyOnAjaxAndReturn(null, 500);
+
+            service.loadFilters(
+                testLayer,
+                successCallback,
+                failureCallback,
+                callbackScope
+            );
+
+            expect(successCallback).not.toHaveBeenCalled();
+            expect(failureCallback).toHaveBeenCalled();
+        });
+    });
+
+    describe('loadFilterRange', function() {
+
+        it('calls success callback', function() {
+
+            spyOnAjaxAndReturn('[]', 200);
+
+            service.loadFilterRange(
+                'some_filter',
+                testLayer,
+                successCallback,
+                failureCallback,
+                callbackScope
+            );
+
+            expect(successCallback).toHaveBeenCalledWith([]);
+            expect(failureCallback).not.toHaveBeenCalled();
+        });
+
+        it('calls failure callback', function() {
+
+            spyOnAjaxAndReturn(null, 500);
+
+            service.loadFilterRange(
+                'some_filter',
+                testLayer,
+                successCallback,
+                failureCallback,
+                callbackScope
+            );
+
+            expect(successCallback).not.toHaveBeenCalled();
+            expect(failureCallback).toHaveBeenCalled();
+        });
+    });
+
+    describe('_filterLayerName', function() {
+
+        var layer;
+
+        beforeEach(function() {
+
+            layer = {
+                wmsName: 'wmsName'
+            };
+        });
+
+        it('should use download layer if present', function() {
+
+            layer.getDownloadLayer = function() { return 'wfsName'; };
+
+            expect(service._filterLayerName(layer)).toBe('wfsName');
+        });
+
+        it('should use map layer otherwise', function() {
+
+            expect(service._filterLayerName(layer)).toBe('wmsName');
+        });
+    });
+
+    var spyOnAjaxAndReturn = function(responseText, status) {
+        spyOn(Ext.Ajax, 'request').andCallFake(function(opts) {
+
+            var response = {
+                responseText: responseText,
+                status: status
+            };
+
+            var callback = status == 200 ? opts.success : opts.failure;
+
+            callback.call(opts.scope, response, opts)
+        });
+    };
+});

--- a/web-app/js/portal/filter/BaseFilterPanel.js
+++ b/web-app/js/portal/filter/BaseFilterPanel.js
@@ -126,7 +126,8 @@ Portal.filter.BaseFilterPanel.newFilterPanelFor = function(cfg) {
     }
     else {
         //Filter hasn't been defined
-        log.error("Could not create filter panel for type'" + type + "'");
+        log.error("Could not find correct filter panel class for type'" + type + "'");
+        newFilterPanel = new Portal.filter.EmptyFilterPanel(cfg);
     }
 
     return newFilterPanel;

--- a/web-app/js/portal/filter/BaseFilterPanel.js
+++ b/web-app/js/portal/filter/BaseFilterPanel.js
@@ -125,8 +125,7 @@ Portal.filter.BaseFilterPanel.newFilterPanelFor = function(cfg) {
         newFilterPanel = new Portal.filter.GeometryFilterPanel(cfg);
     }
     else {
-        //Filter hasn't been defined
-        log.error("Could not find correct filter panel class for type'" + type + "'");
+        log.error("Unhandled filter type '" + type + "' for filter '" + cfg.filter.getName() + "' on layer '" + cfg.layer.wmsName + "'");
         newFilterPanel = new Portal.filter.EmptyFilterPanel(cfg);
     }
 

--- a/web-app/js/portal/filter/ComboFilterPanel.js
+++ b/web-app/js/portal/filter/ComboFilterPanel.js
@@ -46,6 +46,8 @@ Portal.filter.ComboFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
         });
         this.add(this.combo);
 
+        this._setComboMessage('loadingMessage');
+
         this.add(
             new Ext.Spacer({
                 cls: 'block',
@@ -87,7 +89,7 @@ Portal.filter.ComboFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
     },
 
     getCQL: function() {
-        if (this.combo.getValue()) {
+        if (!this.combo.disabled && this.combo.getValue()) {
             return String.format(
                 "{0} LIKE '{1}'",
                 this.filter.getName(),
@@ -121,12 +123,30 @@ Portal.filter.ComboFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
     },
 
     setFilterRange: function(range) {
+
+        if (range.length) {
+            this._loadDataIntoComboBox(range);
+        }
+        else {
+            this._setComboMessage('subsetNoOptionsText');
+        }
+    },
+
+    _setComboMessage: function(messageKey) {
+
+        this.combo.clearValue();
+        this.combo.setValue(OpenLayers.i18n(messageKey));
+        this.combo.disable();
+    },
+
+    _loadDataIntoComboBox: function(values) {
+
         var data = [];
         var clearFilter = [OpenLayers.i18n('clearFilterOption')];
         data.push(clearFilter);
 
-        for (var i = 0; i < range.length; i++) {
-            data.push([range[i]]);
+        for (var i = 0; i < values.length; i++) {
+            data.push([values[i]]);
         }
 
         this.combo.clearValue();

--- a/web-app/js/portal/filter/EmptyFilterPanel.js
+++ b/web-app/js/portal/filter/EmptyFilterPanel.js
@@ -20,7 +20,7 @@ Portal.filter.EmptyFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
 
         return {
             visualised: false
-        }
+        };
     },
 
     handleRemoveFilter: function() {},

--- a/web-app/js/portal/filter/EmptyFilterPanel.js
+++ b/web-app/js/portal/filter/EmptyFilterPanel.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+
+Ext.namespace('Portal.filter');
+
+Portal.filter.EmptyFilterPanel = Ext.extend(Portal.filter.BaseFilterPanel, {
+
+    constructor: function(cfg) {
+
+        Portal.filter.EmptyFilterPanel.superclass.constructor.call(this, cfg);
+    },
+
+    _createField: function() {},
+
+    getFilterData: function() {
+
+        return {
+            visualised: false
+        }
+    },
+
+    handleRemoveFilter: function() {},
+
+    needsFilterRange: function() {
+
+        return false;
+    }
+});

--- a/web-app/js/portal/filter/FilterGroupPanel.js
+++ b/web-app/js/portal/filter/FilterGroupPanel.js
@@ -121,9 +121,17 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
 
             if (filterPanel.needsFilterRange()) {
 
-                filterService.loadFilterRange(filter.getName(), this.layer, function(filterRange) {
-                    filterPanel.setFilterRange(filterRange);
-                }, this);
+                filterService.loadFilterRange(
+                    filter.getName(),
+                    this.layer,
+                    function(filterRange) {
+                        filterPanel.setFilterRange(filterRange);
+                    },
+                    function() {
+                        filterPanel.setFilterRange([]);
+                    },
+                    this
+                );
             }
 
         }, this);

--- a/web-app/js/portal/filter/FilterGroupPanel.js
+++ b/web-app/js/portal/filter/FilterGroupPanel.js
@@ -122,7 +122,7 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
             if (filterPanel.needsFilterRange()) {
 
                 filterService.loadFilterRange(filter.getName(), this.layer, function(filterRange) {
-                    this._filterRangeLoaded(filterRange, filterPanel)
+                    filterPanel.setFilterRange(filterRange);
                 }, this);
             }
 
@@ -143,11 +143,6 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
     _handleFilterLoadFailure: function() {
 
         this._addErrorMessage(OpenLayers.i18n('subsetEmptyFiltersText'));
-    },
-
-    _filterRangeLoaded: function(filterRange, filterPanel) {
-
-        filterPanel.setFilterRange(filterRange);
     },
 
     _sortPanels: function(panels) {

--- a/web-app/js/portal/filter/FilterGroupPanel.js
+++ b/web-app/js/portal/filter/FilterGroupPanel.js
@@ -105,7 +105,7 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
 
         var filterService = new Portal.filter.FilterService();
 
-        filterService.loadFilters(this.layer, this._filtersLoaded, this);
+        filterService.loadFilters(this.layer, this._filtersLoaded, this._handleFilterLoadFailure, this);
     },
 
     _filtersLoaded: function(filters) {
@@ -136,8 +136,13 @@ Portal.filter.FilterGroupPanel = Ext.extend(Ext.Container, {
             this._updateAndShow();
         }
         else {
-            this._addErrorMessage(OpenLayers.i18n('subsetEmptyFiltersText'));
+            this._handleFilterLoadFailure();
         }
+    },
+
+    _handleFilterLoadFailure: function() {
+
+        this._addErrorMessage(OpenLayers.i18n('subsetEmptyFiltersText'));
     },
 
     _filterRangeLoaded: function(filterRange, filterPanel) {

--- a/web-app/js/portal/filter/FilterService.js
+++ b/web-app/js/portal/filter/FilterService.js
@@ -15,7 +15,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
         this.GET_FILTER_VALUES = "layer/getFilterValuesAsJSON";
     },
 
-    loadFilters: function(layer, successCallback, callbackScope) {
+    loadFilters: function(layer, successCallback, failureCallback, callbackScope) {
 
         var params = {
             server: layer.server.uri,
@@ -29,6 +29,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
             success: this._filtersLoaded,
             failure: this._handleFilterLoadFailure,
             successCallback: successCallback,
+            failureCallback: failureCallback,
             callbackScope: callbackScope,
             layer: layer
         });
@@ -54,7 +55,12 @@ Portal.filter.FilterService = Ext.extend(Object, {
 
     _handleFilterLoadFailure: function(resp, opts) {
 
+        var callbackFunction = opts.failureCallback;
+        var callbackScope = opts.callbackScope;
+
         log.error('failed to load filters: ' + JSON.stringify(opts.params));
+
+        callbackFunction.call(callbackScope);
     },
 
     loadFilterRange: function(filterId, layer, successCallback, callbackScope) {

--- a/web-app/js/portal/filter/FilterService.js
+++ b/web-app/js/portal/filter/FilterService.js
@@ -63,7 +63,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
         callbackFunction.call(callbackScope);
     },
 
-    loadFilterRange: function(filterId, layer, successCallback, callbackScope) {
+    loadFilterRange: function(filterId, layer, successCallback, failureCallback, callbackScope) {
 
         var params = {
             filter: filterId,
@@ -75,6 +75,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
             url: this.GET_FILTER_VALUES,
             params: params,
             successCallback: successCallback,
+            failureCallback: failureCallback,
             callbackScope: callbackScope,
             success: this._filterRangeLoaded,
             failure: this._handleFilterRangeLoadFailure,
@@ -93,7 +94,12 @@ Portal.filter.FilterService = Ext.extend(Object, {
 
     _handleFilterRangeLoadFailure: function(resp, opts) {
 
+        var callbackFunction = opts.failureCallback;
+        var callbackScope = opts.callbackScope;
+
         log.error('failed to load filter range for filter: ' + JSON.stringify(opts.params));
+
+        callbackFunction.call(callbackScope);
     },
 
     _filterLayerName: function(layer) {

--- a/web-app/js/portal/filter/FilterService.js
+++ b/web-app/js/portal/filter/FilterService.js
@@ -65,16 +65,23 @@ Portal.filter.FilterService = Ext.extend(Object, {
         Ext.Ajax.request({
             url: this.GET_FILTER_VALUES,
             params: params,
-            scope: this,
+            callbackFunction: onLoadedCallback,
+            callbackScope: callbackScope,
+            success: this._filterRangeLoaded,
             failure: function() {
                 log.error('failed to load filter range for filter: ' + JSON.stringify(params));
             },
-            success: function(resp, opts) {
-                var filterRange = Ext.util.JSON.decode(resp.responseText);
-
-                onLoadedCallback.call(callbackScope, filterRange);
-            }
+            scope: this
         });
+    },
+
+    _filterRangeLoaded: function(resp, opts) {
+
+        var callbackFunction = opts.callbackFunction;
+        var callbackScope = opts.callbackScope;
+        var filterRange = Ext.util.JSON.decode(resp.responseText);
+
+        callbackFunction.call(callbackScope, filterRange);
     },
 
     _filterLayerName: function(layer) {

--- a/web-app/js/portal/filter/FilterService.js
+++ b/web-app/js/portal/filter/FilterService.js
@@ -15,7 +15,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
         this.GET_FILTER_VALUES = "layer/getFilterValuesAsJSON";
     },
 
-    loadFilters: function(layer, onLoadedCallback, callbackScope) {
+    loadFilters: function(layer, successCallback, callbackScope) {
 
         var params = {
             server: layer.server.uri,
@@ -28,7 +28,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
             scope: this,
             success: this._filtersLoaded,
             failure: this._handleFilterLoadFailure,
-            callbackFunction: onLoadedCallback,
+            successCallback: successCallback,
             callbackScope: callbackScope,
             layer: layer
         });
@@ -36,7 +36,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
 
     _filtersLoaded: function(response, opts) {
 
-        var callbackFunction = opts.callbackFunction;
+        var callbackFunction = opts.successCallback;
         var callbackScope = opts.callbackScope;
         var layer = opts.layer;
         var filterDetails = Ext.util.JSON.decode(response.responseText);
@@ -57,7 +57,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
         log.error('failed to load filters: ' + JSON.stringify(opts.params));
     },
 
-    loadFilterRange: function(filterId, layer, onLoadedCallback, callbackScope) {
+    loadFilterRange: function(filterId, layer, successCallback, callbackScope) {
 
         var params = {
             filter: filterId,
@@ -68,7 +68,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
         Ext.Ajax.request({
             url: this.GET_FILTER_VALUES,
             params: params,
-            callbackFunction: onLoadedCallback,
+            successCallback: successCallback,
             callbackScope: callbackScope,
             success: this._filterRangeLoaded,
             failure: this._handleFilterRangeLoadFailure,
@@ -78,7 +78,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
 
     _filterRangeLoaded: function(resp, opts) {
 
-        var callbackFunction = opts.callbackFunction;
+        var callbackFunction = opts.successCallback;
         var callbackScope = opts.callbackScope;
         var filterRange = Ext.util.JSON.decode(resp.responseText);
 

--- a/web-app/js/portal/filter/FilterService.js
+++ b/web-app/js/portal/filter/FilterService.js
@@ -26,10 +26,8 @@ Portal.filter.FilterService = Ext.extend(Object, {
             url: this.GET_FILTER,
             params: params,
             scope: this,
-            failure: function() {
-                log.error('failed to load filters: ' + JSON.stringify(params));
-            },
             success: this._filtersLoaded,
+            failure: this._handleFilterLoadFailure,
             callbackFunction: onLoadedCallback,
             callbackScope: callbackScope,
             layer: layer
@@ -54,6 +52,11 @@ Portal.filter.FilterService = Ext.extend(Object, {
         callbackFunction.call(callbackScope, filterObjects);
     },
 
+    _handleFilterLoadFailure: function(resp, opts) {
+
+        log.error('failed to load filters: ' + JSON.stringify(opts.params));
+    },
+
     loadFilterRange: function(filterId, layer, onLoadedCallback, callbackScope) {
 
         var params = {
@@ -68,9 +71,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
             callbackFunction: onLoadedCallback,
             callbackScope: callbackScope,
             success: this._filterRangeLoaded,
-            failure: function() {
-                log.error('failed to load filter range for filter: ' + JSON.stringify(params));
-            },
+            failure: this._handleFilterRangeLoadFailure,
             scope: this
         });
     },
@@ -82,6 +83,11 @@ Portal.filter.FilterService = Ext.extend(Object, {
         var filterRange = Ext.util.JSON.decode(resp.responseText);
 
         callbackFunction.call(callbackScope, filterRange);
+    },
+
+    _handleFilterRangeLoadFailure: function(resp, opts) {
+
+        log.error('failed to load filter range for filter: ' + JSON.stringify(opts.params));
     },
 
     _filterLayerName: function(layer) {

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -65,6 +65,7 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     subsetParametersText: 'subset parameters',
     subsetParametersErrorText: 'Filtering of this collection is not possible at this time.',
     subsetEmptyFiltersText: 'Filtering of this collection is not available at this time.',
+    subsetNoOptionsText: 'No options available',
 
     // map.js
     imageScaledDown: 'This image has been scaled down.',


### PR DESCRIPTION
These changes cover three possibilities from filter loading.
1) Getting the list of filters for a layer fails - 'Filtering unavailable' message is displayed
2) Getting possible values for a filter fails - (Only currently applicable for the combo picker) drop-down is disabled with a message
3) Any filter type is unrecognised - The problem is logged but an empty UI component is used so the UI does not break