### PR TITLE
fixes #1604

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/HomeController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/HomeController.groovy
@@ -42,6 +42,6 @@ class HomeController {
     }
 
     def css = {
-        render text: portalBranding.css
+        render text: portalBranding.css, contentType: "text/css"
     }
 }


### PR DESCRIPTION
Hides link to empty css file when PortalBranding is not used