### PR TITLE
MARVL urlListForFeatureRequest endpoint accepts list of URL substitutions

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -311,8 +311,9 @@ portal {
 // MARVL project integration
 marvl {
     urlList {
-        prefixToRemove = "/mnt/imos-t3/"
-        newUrlBase = "http://data.aodn.org.au/"
+        substitutions = [
+            '/mnt/imos-t3/': 'http://data.aodn.org.au/'
+        ]
     }
 }
 

--- a/grails-app/controllers/au/org/emii/portal/MarvlController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/MarvlController.groovy
@@ -10,12 +10,11 @@ class MarvlController extends DownloadController {
         }
 
         def propertyName = params.propertyName
-        def prefixToRemove = grailsApplication.config.marvl.urlList.prefixToRemove
-        def newUrlBase = grailsApplication.config.marvl.urlList.newUrlBase
+        def substitutions = grailsApplication.config.marvl.urlList.substitutions
 
         _performProxying(
             requestSingleFieldParamProcessor(propertyName),
-            urlListStreamProcessor(propertyName, prefixToRemove, newUrlBase)
+            urlListStreamProcessor(propertyName, substitutions)
         )
     }
 }


### PR DESCRIPTION
This brings it in line with BODAAC.

These tests didn't fail when the BODAAC changes were made because an important function was mocked out. So I have updated the test so that changes to that function (including to it's method signature) will now break the tests.