### PR TITLE
Removed temporary code for database handling of filters

### DIFF
--- a/src/test/javascript/portal/filter/BaseFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/BaseFilterPanelSpec.js
@@ -24,20 +24,16 @@ describe("Portal.filter.BaseFilterPanel", function() {
             expectNewFilterPanelForString('DateFilterPanel', 'Date');
         });
 
-        it("should create DateFilterPanel", function() {
-            expectNewFilterPanelForString('DateFilterPanel', 'DateRange');
-        });
-
         it("should create BooleanFilterPanel", function() {
             expectNewFilterPanelForString('BooleanFilterPanel', 'Boolean');
         });
 
         it("should create GeometryFilterPanel", function() {
-            expectNewFilterPanelForString('GeometryFilterPanel', 'BoundingBox');
+            expectNewFilterPanelForString('GeometryFilterPanel', 'geometrypropertytype');
         });
 
         it("should create NumberFilterPanel", function() {
-            expectNewFilterPanelForString('NumberFilterPanel', 'Number');
+            expectNewFilterPanelForString('NumberFilterPanel', 'decimal');
         });
 
         var expectNewFilterPanelForString = function(filterPanelType, filterTypeAsString) {

--- a/web-app/js/portal/filter/BaseFilterPanel.js
+++ b/web-app/js/portal/filter/BaseFilterPanel.js
@@ -84,19 +84,6 @@ Portal.filter.BaseFilterPanel.newFilterPanelFor = function(cfg) {
 
     var type = cfg.filter.getType().toLowerCase();
 
-    // Todo - DN: Remove when loading filters from DBis removed
-    // Portal types --> GeoServer types (temporary)
-    if (type == "daterange") {
-        type = 'datetime'
-    }
-    else if (type === "boundingbox") {
-        type = 'geometrypropertytype'
-    }
-    else if (type === "number") {
-        type = 'decimal'
-    }
-    // Todo - DN: End of temp code
-
     var typeMatches = function(toMatch) {
         var anyMatch = false;
 

--- a/web-app/js/portal/filter/FilterService.js
+++ b/web-app/js/portal/filter/FilterService.js
@@ -106,11 +106,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
 
         var filterLayer = layer.wmsName;
 
-        // Todo - DN: The filterSource and shouldUseDownloadLayerIfPossible variables will be redundant when we go stateless and can be removed
-        var filterSource = Portal.app.appConfig.featureToggles.filterSource;
-        var shouldUseDownloadLayerIfPossible = filterSource !== 'database';
-
-        if (shouldUseDownloadLayerIfPossible && layer.getDownloadLayer) {
+        if (layer.getDownloadLayer) {
             filterLayer = layer.getDownloadLayer();
         }
 


### PR DESCRIPTION
This was temporary code that was in there to handle DB-configured filters alongside GeoServer/Filesystem-configured filters.