### PR TITLE
Renamed layer controller methods for filters and styles

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/LayerController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/LayerController.groovy
@@ -72,7 +72,7 @@ class LayerController {
         }
     }
 
-    def getStylesAsJSON = {
+    def getStyles = {
         def (server, layer, serverType) = parseParams(params)
 
         if (hostVerifier.allowedHost(server)) {
@@ -86,7 +86,7 @@ class LayerController {
         }
     }
 
-    def getFilterValuesAsJSON = {
+    def getFilterValues = {
         def (server, layer, serverType, filter) = parseParams(params)
 
         if (hostVerifier.allowedHost(server)) {
@@ -99,7 +99,7 @@ class LayerController {
         }
     }
 
-    def getFiltersAsJSON = {
+    def getFilters = {
         def (server, layer, serverType) = parseParams(params)
 
         if (hostVerifier.allowedHost(server)) {

--- a/src/test/javascript/OpenLayers/Layer/NcWMSSpec.js
+++ b/src/test/javascript/OpenLayers/Layer/NcWMSSpec.js
@@ -66,15 +66,15 @@ describe("OpenLayers.Layer.NcWMS", function() {
         });
 
         it("_getFiltersUrl ", function() {
-            expect(cachedLayer._getFiltersUrl()).toBe('layer/getFiltersAsJSON?serverType=ncwms&server=encoded%20url%20prefix&layer=test_layer');
+            expect(cachedLayer._getFiltersUrl()).toBe('layer/getFilters?serverType=ncwms&server=encoded%20url%20prefix&layer=test_layer');
         });
 
         it("_getStylesUrl ", function() {
-            expect(cachedLayer._getStylesUrl()).toBe('layer/getStylesAsJSON?serverType=ncwms&server=encoded%20url%20prefix&layer=test_layer');
+            expect(cachedLayer._getStylesUrl()).toBe('layer/getStyles?serverType=ncwms&server=encoded%20url%20prefix&layer=test_layer');
         });
 
         it("_getTimeSeriesUrl ", function() {
-            expect(cachedLayer._getTimeSeriesUrl(moment.utc('2011-07-02T01:32:45Z'))).toBe('layer/getFilterValuesAsJSON?serverType=ncwms&server=encoded%20url%20prefix&layer=test_layer&filter=2011-07-02T00:00:00.000Z');
+            expect(cachedLayer._getTimeSeriesUrl(moment.utc('2011-07-02T01:32:45Z'))).toBe('layer/getFilterValues?serverType=ncwms&server=encoded%20url%20prefix&layer=test_layer&filter=2011-07-02T00:00:00.000Z');
         });
     });
 
@@ -82,7 +82,7 @@ describe("OpenLayers.Layer.NcWMS", function() {
         it("returns correct url", function() {
             cachedLayer.url = "encoded url prefix";
             cachedLayer.params.LAYERS = "test_layer";
-            expect(cachedLayer._getTimeSeriesUrl(moment.utc('2011-07-02T01:32:45Z'))).toBe('layer/getFilterValuesAsJSON?serverType=ncwms&server=encoded%20url%20prefix&layer=test_layer&filter=2011-07-02T00:00:00.000Z');
+            expect(cachedLayer._getTimeSeriesUrl(moment.utc('2011-07-02T01:32:45Z'))).toBe('layer/getFilterValues?serverType=ncwms&server=encoded%20url%20prefix&layer=test_layer&filter=2011-07-02T00:00:00.000Z');
         });
     });
 

--- a/test/unit/au/org/emii/portal/LayerControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/LayerControllerTests.groovy
@@ -9,7 +9,6 @@ package au.org.emii.portal
 
 import grails.converters.JSON
 import grails.test.ControllerUnitTestCase
-import org.codehaus.groovy.grails.web.json.JSONElement
 
 class LayerControllerTests extends ControllerUnitTestCase {
 
@@ -39,7 +38,7 @@ class LayerControllerTests extends ControllerUnitTestCase {
             return []
         }
 
-        this.controller.getFiltersAsJSON()
+        this.controller.getFilters()
 
         // Restore original wms.GeoserverServer class
         wms.GeoserverServer.metaClass = null
@@ -58,7 +57,7 @@ class LayerControllerTests extends ControllerUnitTestCase {
             return []
         }
 
-        this.controller.getFiltersAsJSON()
+        this.controller.getFilters()
 
         // Restore original wms.NcwmsServer class
         wms.NcwmsServer.metaClass = null
@@ -77,7 +76,7 @@ class LayerControllerTests extends ControllerUnitTestCase {
             return []
         }
 
-        this.controller.getStylesAsJSON()
+        this.controller.getStyles()
 
         // Restore original wms.NcwmsServer class
         wms.NcwmsServer.metaClass = null

--- a/web-app/js/portal/filter/FilterService.js
+++ b/web-app/js/portal/filter/FilterService.js
@@ -11,8 +11,8 @@ Portal.filter.FilterService = Ext.extend(Object, {
 
     constructor: function() {
 
-        this.GET_FILTER = "layer/getFiltersAsJSON";
-        this.GET_FILTER_VALUES = "layer/getFilterValuesAsJSON";
+        this.GET_FILTER = "layer/getFilters";
+        this.GET_FILTER_VALUES = "layer/getFilterValues";
     },
 
     loadFilters: function(layer, successCallback, failureCallback, callbackScope) {

--- a/web-app/js/portal/ui/openlayers/layer/NcWMS.js
+++ b/web-app/js/portal/ui/openlayers/layer/NcWMS.js
@@ -306,7 +306,7 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
 
     _getFiltersUrl: function() {
         return String.format(
-            "layer/getFiltersAsJSON?serverType=ncwms&server={0}&layer={1}",
+            "layer/getFilters?serverType=ncwms&server={0}&layer={1}",
             encodeURIComponent(this.url),
             this.params.LAYERS
         );
@@ -314,7 +314,7 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
 
     _getStylesUrl: function() {
         return String.format(
-            "layer/getStylesAsJSON?serverType=ncwms&server={0}&layer={1}",
+            "layer/getStyles?serverType=ncwms&server={0}&layer={1}",
             encodeURIComponent(this.url),
             this.params.LAYERS
         );
@@ -322,7 +322,7 @@ OpenLayers.Layer.NcWMS = OpenLayers.Class(OpenLayers.Layer.WMS, {
 
     _getTimeSeriesUrl: function(date) {
         return String.format(
-            "layer/getFilterValuesAsJSON?serverType=ncwms&server={0}&layer={1}&filter={2}",
+            "layer/getFilterValues?serverType=ncwms&server={0}&layer={1}&filter={2}",
             encodeURIComponent(this.url),
             this.params.LAYERS,
             date.clone().startOf('day').toISOString()


### PR DESCRIPTION
getStylesAsJSON -> getStyles
getFiltersAsJSON -> getFilters
getFilterValuesAsJSON -> getFilterValues

I don't *think* anyone will object to this change. Including 'asJSON' in the name seems redundant. Maybe it was needed as a clarification at some point.

This will break get_filters.rb eventually (when this change makes it to prod) but I think that'll be easy to pick up and fix when it happen.