### PR TITLE
Determine filter source (GeoServer/files) from env var

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -84,7 +84,7 @@ downloadAuth {
 }
 
 featureToggles {
-    dynamicFilters = true
+    // someFeature = <boolean>
 }
 
 // Google Analytics
@@ -92,6 +92,10 @@ googleAnalytics.trackingId = null
 
 // set per-environment serverURL stem for creating absolute links
 def env = System.getenv()
+
+filtering {
+    filePath = env['FILTERS_PATH']
+}
 
 environments {
 

--- a/grails-app/controllers/au/org/emii/portal/LayerController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/LayerController.groovy
@@ -68,7 +68,7 @@ class LayerController {
             return new NcwmsServer()
         }
         else {
-            return new GeoserverServer(grailsApplication.config.featureToggles.dynamicFilters)
+            return new GeoserverServer(grailsApplication.config.filtering.filePath)
         }
     }
 

--- a/src/groovy/au/org/emii/portal/wms/GeoserverServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/GeoserverServer.groovy
@@ -8,13 +8,12 @@
 package au.org.emii.portal.wms
 
 import au.org.emii.portal.proxying.ExternalRequest
-import groovy.xml.MarkupBuilder
 
 class GeoserverServer extends WmsServer {
-    def dynamicFilters
+    def filePath
 
-    GeoserverServer(dynamicFilters) {
-        this.dynamicFilters = dynamicFilters
+    GeoserverServer(filePath) {
+        this.filePath = filePath
     }
 
     def getStyles(server, layer) {
@@ -49,18 +48,18 @@ class GeoserverServer extends WmsServer {
 
     def _getFiltersXml(server, layer) {
 
-        if (dynamicFilters) {
-            return _getFiltersXmlFromGeoserver(server, layer)
+        if (filePath) {
+            return _getFiltersXmlFromFile(layer)
         }
         else {
-            return _getFiltersXmlFromFile(layer)
+            return _getFiltersXmlFromGeoserver(server, layer)
         }
     }
 
     def _getFiltersXmlFromFile(layer) {
         def workspaceName = getLayerWorkspace(layer)
         def layerName = getLayerName(layer)
-        def inputFile = new File("filters/${workspaceName}/${layerName}/filters.xml")
+        def inputFile = new File("$filePath/${workspaceName}/${layerName}/filters.xml")
         return inputFile.text
     }
 
@@ -90,18 +89,18 @@ class GeoserverServer extends WmsServer {
 
     def _getFilterValuesXml(server, layer, filter) {
 
-        if (dynamicFilters) {
-            return _getFilterValuesXmlFromGeoserver(server, layer, filter)
+        if (filePath) {
+            return _getFilterValuesXmlFromFile(layer, filter)
         }
         else {
-            return _getFilterValuesXmlFromFile(layer, filter)
+            return _getFilterValuesXmlFromGeoserver(server, layer, filter)
         }
     }
 
     def _getFilterValuesXmlFromFile(layer, filter) {
         def workspaceName = getLayerWorkspace(layer)
         def layerName = getLayerName(layer)
-        def inputFile = new File("filters/${workspaceName}/${layerName}/${filter}.xml")
+        def inputFile = new File("$filePath/${workspaceName}/${layerName}/${filter}.xml")
         return inputFile.text
     }
 

--- a/src/groovy/au/org/emii/portal/wms/GeoserverServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/GeoserverServer.groovy
@@ -49,27 +49,11 @@ class GeoserverServer extends WmsServer {
     def _getFiltersXml(server, layer) {
 
         if (filePath) {
-            return _getFiltersXmlFromFile(layer)
+            _loadFile(layer, "filters.xml")
         }
         else {
-            return _getFiltersXmlFromGeoserver(server, layer)
+            _loadUrl(getFiltersUrl(server, layer))
         }
-    }
-
-    def _getFiltersXmlFromFile(layer) {
-        def workspaceName = getLayerWorkspace(layer)
-        def layerName = getLayerName(layer)
-        def inputFile = new File("$filePath/${workspaceName}/${layerName}/filters.xml")
-        return inputFile.text
-    }
-
-    def _getFiltersXmlFromGeoserver(server, layer) {
-        def filtersUrl = getFiltersUrl(server, layer)
-        def outputStream = new ByteArrayOutputStream()
-        def request = new ExternalRequest(outputStream, filtersUrl.toURL())
-
-        request.executeRequest()
-        return outputStream.toString("utf-8")
     }
 
     def getFilterValues(server, layer, filter) {
@@ -90,24 +74,23 @@ class GeoserverServer extends WmsServer {
     def _getFilterValuesXml(server, layer, filter) {
 
         if (filePath) {
-            return _getFilterValuesXmlFromFile(layer, filter)
+            _loadFile(layer, "${filter}.xml")
         }
         else {
-            return _getFilterValuesXmlFromGeoserver(server, layer, filter)
+            _loadUrl(getFilterValuesUrl(server, layer, filter))
         }
     }
 
-    def _getFilterValuesXmlFromFile(layer, filter) {
+    def _loadFile(layer, filename) {
         def workspaceName = getLayerWorkspace(layer)
         def layerName = getLayerName(layer)
-        def inputFile = new File("$filePath/${workspaceName}/${layerName}/${filter}.xml")
+        def inputFile = new File("$filePath/${workspaceName}/${layerName}/${filename}")
         return inputFile.text
     }
 
-    def _getFilterValuesXmlFromGeoserver(server, layer, filter) {
-        def filtersUrl = getFilterValuesUrl(server, layer, filter)
+    static def _loadUrl(address) {
         def outputStream = new ByteArrayOutputStream()
-        def request = new ExternalRequest(outputStream, filtersUrl.toURL())
+        def request = new ExternalRequest(outputStream, address.toURL())
 
         request.executeRequest()
         return outputStream.toString("utf-8")

--- a/test/unit/au/org/emii/portal/LayerControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/LayerControllerTests.groovy
@@ -28,7 +28,6 @@ class LayerControllerTests extends ControllerUnitTestCase {
     }
 
     void testGetFiltersAsJsonGeoserver() {
-        controller.grailsApplication.config.featureToggles.dynamicGeoserverFilters = false
         this.controller.params.server = 'some_server'
         this.controller.params.layer = 'some_layer'
 


### PR DESCRIPTION
I've accidentally committed the `dynamicFilters` setting a couple of times already today. :S

I've set it up so it can be loaded from an environment variable to make it easier when you're working from filesystem for an extended period. Default is 'false' which is to read from GeoServer.

I also took it out of the feature toggles section as per a previous discussion with @jkburges and @danfruehauf.