### PR TITLE
Stacktraces in logging output

### DIFF
--- a/src/groovy/au/org/emii/portal/wms/GeoserverServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/GeoserverServer.groovy
@@ -40,9 +40,6 @@ class GeoserverServer extends WmsServer {
                 ])
             }
         }
-        catch (org.xml.sax.SAXParseException e) {
-            log.error "Cannot parse XML filters for server '${server}', layer '${layer}'"
-        }
         catch (e) {
             log.error "Unable to parse filters for server '${server}', layer '${layer}'", e
         }
@@ -83,9 +80,6 @@ class GeoserverServer extends WmsServer {
             def xml = new XmlSlurper().parseText(_getFilterValuesXml(server, layer, filter))
 
             values = xml.value.collect { it.text() }
-        }
-        catch (org.xml.sax.SAXParseException e) {
-            log.error "Cannot parse XML filter values for server '${server}', layer '${layer}', filter '${filter}'"
         }
         catch (e) {
             log.error "Unable to parse filters values for server '${server}', layer '${layer}', filter '${filter}'", e

--- a/test/unit/au/org/emii/portal/wms/GeoserverServerTests.groovy
+++ b/test/unit/au/org/emii/portal/wms/GeoserverServerTests.groovy
@@ -18,6 +18,9 @@ class GeoserverServerTests extends GrailsUnitTestCase {
 
     protected void setUp() {
         super.setUp()
+
+        mockLogging(GeoserverServer)
+
         geoserverServer = new GeoserverServer(true)
 
         validGeoserverResponse =


### PR DESCRIPTION
@danfruehauf a suggestion for how we can clean up the stack traces in the GeoserverServer tests.

We don't have the logging output and we don't have to add an extra code path.