### PR TITLE
Unique values from WMS

### DIFF
--- a/get_filters.rb
+++ b/get_filters.rb
@@ -144,7 +144,7 @@ def convert_filter_type(filter_type, filter_name)
   return return_filter_type
 end
 
-def write_filters(filters_dir, filters, opts)
+def write_filters(map_filters_dir, data_filters_dir, filters, opts)
   builder = Nokogiri::XML::Builder.new do |xml|
     xml.filters {
       filters.each do |filter|
@@ -166,13 +166,13 @@ def write_filters(filters_dir, filters, opts)
           end
 
           # Output values to a separate file
-          write_filter_values(filters_dir, filter['name'], filter['possibleValues'])
+          write_filter_values(map_filters_dir, filter['name'], filter['possibleValues'])
         }
       end
     }
   end
 
-  layer_xml_path = File.join(filters_dir, "filters.xml")
+  layer_xml_path = File.join(data_filters_dir, "filters.xml")
   $logger.info "Dumping filters XML to '#{layer_xml_path}'"
   $logger.info "------------------------------------------"
   file = File.open(layer_xml_path, "w")
@@ -209,11 +209,13 @@ def get_filters_main(opts)
     layer_id = get_layer_id(opts[:portal], opts[:geoserver], wms_layer)
     if layer_id
       if output_dir
-        filters_dir = get_layer_directory(output_dir, wfs_layer)
-        FileUtils.mkdir_p filters_dir
+        map_filters_dir = get_layer_directory(output_dir, wms_layer)
+        data_filters_dir = get_layer_directory(output_dir, wfs_layer)
+        FileUtils.mkdir_p map_filters_dir
+        FileUtils.mkdir_p data_filters_dir
 
         filters = get_filters(opts[:portal], layer_id)
-        write_filters(filters_dir, filters, opts)
+        write_filters(map_filters_dir, data_filters_dir, filters, opts)
       end
     else
       $logger.error "Could not get ID of layer '#{wms_layer}'"
@@ -230,9 +232,9 @@ opts = Trollop::options do
 
     Examples:
         Get filters from catalogue-123.aodn.org.au and imos.aodn.org.au:
-           get_filters.rb -u https://catalogue-123.aodn.org.au/geonetwork
-             -g http://geoserver-123.aodn.org.au/geoserver/wms
-             -p https://imos.aodn.org.au/imos123
+           get_filters.rb -u https://catalogue-123.aodn.org.au/geonetwork \\
+             -g http://geoserver-123.aodn.org.au/geoserver/wms \\
+             -p https://imos.aodn.org.au/imos123 \\
              -d filters
 
     Options:

--- a/src/test/javascript/portal/common/LayerDescriptorSpec.js
+++ b/src/test/javascript/portal/common/LayerDescriptorSpec.js
@@ -172,4 +172,56 @@ describe("Portal.common.LayerDescriptor", function() {
             expect(openLayer.bboxMaxY).toEqual(4);
         });
     });
+
+    describe('_initialiseDownloadLayer', function() {
+
+        var openLayer;
+        var descriptor;
+
+        beforeEach(function() {
+
+            openLayer = {
+                wmsName: 'aodn:other_layer'
+            };
+            descriptor = new Portal.common.LayerDescriptor({
+                geonetworkRecord: { data: {} }
+            });
+        });
+
+        it('uses a data layer if present', function() {
+
+            spyOn(descriptor, '_findFirst').andReturn('imos:data_layer_name');
+
+            descriptor._initialiseDownloadLayer(openLayer);
+
+            expect(openLayer.getDownloadLayer()).toBe('imos:data_layer_name');
+        });
+
+        it('falls back to a map layer', function() {
+
+            var isFirstCall = true;
+
+            spyOn(descriptor, '_findFirst').andCallFake(function() {
+
+                if (!isFirstCall) {
+                    return 'imos:map_layer_name';
+                }
+
+                isFirstCall = false;
+            });
+
+            descriptor._initialiseDownloadLayer(openLayer);
+
+            expect(openLayer.getDownloadLayer()).toBe('imos:map_layer_name');
+        });
+
+        it('falls back to current layer workspace', function() {
+
+            spyOn(descriptor, '_findFirst').andReturn('data_layer_name');
+
+            descriptor._initialiseDownloadLayer(openLayer);
+
+            expect(openLayer.getDownloadLayer()).toBe('aodn:data_layer_name');
+        });
+     });
 });

--- a/web-app/js/portal/filter/FilterService.js
+++ b/web-app/js/portal/filter/FilterService.js
@@ -68,7 +68,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
         var params = {
             filter: filterId,
             server: layer.server.uri,
-            layer: this._filterLayerName(layer)
+            layer: layer.wmsName
         };
 
         Ext.Ajax.request({


### PR DESCRIPTION
With this PR the Portal now loads the unique values for a filter from the map layer (instead of the data layer). The map layer should contain all the unique values represented anyway but will be much more performant.

This also fixes a bug where we were determining the download layer from the wrong field in the GeoNetwork record. It worked most of the time but failed in some cases (noticed on IMOS - Australian National Mooring Network (ANMN) Facility - Current velocity time-series).