### PR TITLE
Update ResettableDate

### DIFF
--- a/src/test/javascript/portal/filter/DateFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/DateFilterPanelSpec.js
@@ -10,9 +10,9 @@ describe("Portal.filter.ui.DateFilterPanel", function() {
     var component;
 
     beforeEach(function() {
-        Portal.filter.ui.DateFilterPanel.prototype._createField = function() {};
+        Portal.filter.ui.DateFilterPanel.prototype._createField = noOp;
 
-        Portal.filter.ui.DateFilterPanel.prototype._getDateString = function() {};
+        Portal.filter.ui.DateFilterPanel.prototype._getDateString = noOp;
 
         filterPanel = new Portal.filter.ui.DateFilterPanel({
             filter: {
@@ -45,7 +45,6 @@ describe("Portal.filter.ui.DateFilterPanel", function() {
             // uses time zone so cant test for equality in Travis
             expect(filterPanel._getDateHumanString(filterPanel.combo)).toNotEqual(undefined);
         });
-
     });
 
     describe('handleRemoveFilter', function() {
@@ -81,9 +80,9 @@ describe("Portal.filter.ui.DateFilterPanel", function() {
         });
 
         it('fires events when required fields are set', function() {
-            component._dateField.getValue = function() { return '12-02-1990'};
-            filterPanel._applyDateFilterPanel(component);
-            expect(window.trackUsage).toHaveBeenCalledWith("Filters", "Date", "atestname reset 12-02-1990", "layerName");
+            component._dateField.getValue = function() { return '12-02-1990' };
+            filterPanel._applyDateFilter(component);
+            expect(window.trackUsage).toHaveBeenCalledWith("Filters", "Date", "atestname user set 12-02-1990", "layerName");
             expect(filterPanel._fireAddEvent).toHaveBeenCalled();
         });
     });
@@ -128,15 +127,15 @@ describe("Portal.filter.ui.DateFilterPanel", function() {
 
         var setTestValue = function(resettableDate, value) {
             spyOn(resettableDate, 'getValue').andReturn(value);
-            spyOn(resettableDate, 'hasValue').andReturn(true);
         };
     });
 
     function _mockFilterFields(filterPanel) {
-        Ext.each(['fromDate', 'toDate'], function(property, index, all) {
+        Ext.each(['fromDate', 'toDate'], function(property) {
             this[property] = {
                 getValue: noOp,
-                hasValue: noOp,
+                setMinValue: noOp,
+                setMaxValue: noOp,
                 applyDefaultValueLimits: noOp
             }
         }, filterPanel);

--- a/web-app/js/portal/filter/ui/DateFilterPanel.js
+++ b/web-app/js/portal/filter/ui/DateFilterPanel.js
@@ -79,7 +79,7 @@ Portal.filter.ui.DateFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel, 
             emptyText: emptyText,
             listeners: {
                 scope: this,
-                change: this._applyDateFilterPanel
+                change: this._applyDateFilter
             }
         });
     },
@@ -118,28 +118,18 @@ Portal.filter.ui.DateFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel, 
         return moment(date).format(OpenLayers.i18n('dateTimeDisplayFormat'));
     },
 
-    _applyDateFilterPanel: function(component) {
+    _applyDateFilter: function(component) {
 
-        var usageLabel = OpenLayers.i18n('trackingDefaultValueReset');
-        if (this.fromDate.hasValue()) {
-            this.toDate.setMinValue(this.fromDate.getValue());
-            usageLabel = OpenLayers.i18n('trackingUserSet');
-        }
-        else {
-            this.toDate.applyDefaultValueLimits();
-        }
+        var changedField = component._dateField;
 
-        if (this.toDate.hasValue()) {
-            this.fromDate.setMaxValue(this.toDate.getValue());
-            usageLabel = OpenLayers.i18n('trackingUserSet');
-        }
-        else {
-            this.fromDate.applyDefaultValueLimits();
-        }
+        this.toDate.setMinValue(this.fromDate.getValue());
+        this.fromDate.setMaxValue(this.toDate.getValue());
 
-        var val = component._dateField.name + " " + usageLabel + " " + component._dateField.getValue();
-        trackFiltersUsage('filtersTrackingDateAction', val, this.layer.name);
         this._fireAddEvent();
+
+        var usageLabelKey = changedField.getValue() ? 'trackingUserSet' : 'trackingDefaultValueReset';
+        var val = changedField.name + " " + OpenLayers.i18n(usageLabelKey) + " " + changedField.getValue();
+        trackFiltersUsage('filtersTrackingDateAction', val, this.layer.name);
     },
 
     _isFromFieldUsed: function() {

--- a/web-app/js/portal/filter/ui/ResettableDate.js
+++ b/web-app/js/portal/filter/ui/ResettableDate.js
@@ -42,7 +42,9 @@ Portal.filter.ui.ResettableDate = Ext.extend(Ext.Container, {
     },
 
     getValue: function() {
-        return this._dateField.getValue();
+
+        var value = this._dateField.getValue();
+        return value == '' ? null : value;
     },
 
     setValue: function(value) {
@@ -57,20 +59,16 @@ Portal.filter.ui.ResettableDate = Ext.extend(Ext.Container, {
     },
 
     setMinValue: function(value) {
-        return this._dateField.setMinValue(value);
+        this._dateField.setMinValue(value ? value : new Date(0));
     },
 
     setMaxValue: function(value) {
-        return this._dateField.setMaxValue(value);
+        this._dateField.setMaxValue(value ? value : new Date());
     },
 
     applyDefaultValueLimits: function() {
-        this.setMinValue(new Date(0));
-        this.setMaxValue(new Date());
-    },
-
-    hasValue: function() {
-        return this._dateField.getValue() != '';
+        this.setMinValue();
+        this.setMaxValue();
     },
 
     _createDateField: function(cfg) {


### PR DESCRIPTION
ResettableDate used to have hasValue() and getValue() functions. hasValue() took into account the fact that an empty date field had a value of the empty string. This meant that DateFilterPanel had to use hasValue() before it used getValue() which made code a bit messier than needed.

This suggested change removes hasValue() function and make getValue() return null instead of an empty string. This means that DateFilterPanel can have a cleaner interface because getValue() can be used in boolean conditionals as well.