### PR TITLE
Validate download requests to external geoserver url before download

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/DownloadController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/DownloadController.groovy
@@ -92,6 +92,21 @@ class DownloadController extends RequestProxyingController {
         }
     }
 
+    def validateRequest = {
+
+        def url = params.url
+
+        if (!hostVerifier.allowedHost(url)) {
+
+            log.error "Host for address '$url' not allowed"
+            render text: "Host for address '$url' not allowed", contentType: "text/html", encoding: "UTF-8", status: HTTP_400_BAD_REQUEST
+        }
+        else {
+            render text: url, contentType: "text/html", encoding: "UTF-8", status: HTTP_200_OK
+        }
+        return
+    }
+
     def estimateSizeForLayer = {
 
         def urlFieldName = params.urlFieldName

--- a/test/unit/au/org/emii/portal/DownloadControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/DownloadControllerTests.groovy
@@ -108,6 +108,24 @@ class DownloadControllerTests extends ControllerUnitTestCase {
         assertEquals "Host for address 'http://www.example.com/?PROPERTYNAME=relativeFilePath' not allowed", mockResponse.contentAsString
     }
 
+    void testValidateRequestInvalidHost() {
+
+        _setHostShouldBeValid(false)
+
+        controller.validateRequest()
+
+        assertEquals "Host for address 'http://www.example.com/' not allowed", mockResponse.contentAsString
+    }
+
+    void testValidateRequestValidHost() {
+
+        _setHostShouldBeValid(true)
+
+        controller.validateRequest()
+
+        assertEquals "http://www.example.com/", mockResponse.contentAsString
+    }
+
     void testDownloadNetCdfFilesForLayer() {
 
         mockParams.downloadFilename = 'somedata.txt'

--- a/web-app/js/portal/cart/Downloader.js
+++ b/web-app/js/portal/cart/Downloader.js
@@ -22,18 +22,18 @@ Portal.cart.Downloader = Ext.extend(Object, {
         }
     },
 
-    _downloadSynchronously: function(collection, downloadUrl, params) {
-        log.debug('downloading synchronously', downloadUrl);
+    _downloadSynchronously: function(collection, url, params) {
+        log.debug('downloading synchronously ' +  url);
 
-        var proxyUrl = this._constructProxyUrl(collection, downloadUrl, params);
-        this._openDownload(proxyUrl);
+        var proxyUrl = this._constructProxyUrl(collection, url, params);
+        this._requestDownload(url, proxyUrl);
     },
 
-    _constructProxyUrl: function(collection, downloadUrl, params) {
+    _constructProxyUrl: function(collection, url, params) {
 
         var filename = this._constructFilename(collection, params);
         var encodedFilename = encodeURIComponent(this._sanitiseFilename(filename));
-        var encodedDownloadUrl = encodeURIComponent(downloadUrl);
+        var encodedDownloadUrl = encodeURIComponent(url);
         var additionalQueryString = this._additionalQueryStringFrom(params.downloadControllerArgs);
 
         return String.format('download?url={0}&downloadFilename={1}{2}', encodedDownloadUrl, encodedFilename, additionalQueryString);
@@ -59,16 +59,20 @@ Portal.cart.Downloader = Ext.extend(Object, {
         return queryString;
     },
 
-    _openDownload: function(proxyUrl) {
-        log.debug('Downloading using URL: ' + proxyUrl);
+    _requestDownload: function(url, proxyUrl) {
+        log.debug('Downloading synchronously using request: ' + url);
 
-        // Download function shamelessly stolen from:
-        // http://stackoverflow.com/a/12671023/1920729
-        if ($downloaderLink && $downloaderLink.length > 0) {
-            $downloaderLink.attr('src', proxyUrl);
-        } else {
-            $downloaderLink = $('<iframe>', { id:'downloaderLink', src:proxyUrl }).hide().appendTo('body');
-        }
+        this.proxyUrl = proxyUrl;
+
+        Ext.Ajax.request({
+            url: 'download/validateRequest',
+            params: {
+                url: url
+            },
+            scope: this,
+            success: this._onDownloadRequestSuccess,
+            failure: this._onDownloadRequestFailure
+        });
     },
 
     _downloadAsynchronously: function(collection, downloadUrl, params) {
@@ -82,6 +86,25 @@ Portal.cart.Downloader = Ext.extend(Object, {
             success: this._onAsyncDownloadRequestSuccess,
             failure: this._onAsyncDownloadRequestFailure
         });
+    },
+
+    _onDownloadRequestSuccess: function(response, request) {
+
+        var url = request.scope.proxyUrl;
+
+        if ($downloaderLink && $downloaderLink.length > 0) {
+            $downloaderLink.attr('src', url);
+        } else {
+            $downloaderLink = $('<iframe>', { id:'downloaderLink', src: url }).hide().appendTo('body');
+        }
+    },
+
+    _onDownloadRequestFailure: function(resp) {
+        log.error("Synchronous download request has failed with the following error " + resp.responseText);
+        Ext.Msg.alert(
+            OpenLayers.i18n('errorDialogTitle'),
+            OpenLayers.i18n('downloadErrorText')
+        )
     },
 
     _onAsyncDownloadRequestSuccess: function() {

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -158,6 +158,7 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     downloadConfirmationDownloadText: 'I understand, download',
     downloadConfirmationCancelText: 'Cancel',
     challengeInstructions: 'Type the characters you see in the image above',
+    downloadErrorText: 'There is a problem with the availability of your selected data download.',
 
     // mainMapPanel
     layerExistsTitle: 'Add data collection',


### PR DESCRIPTION
Provide response to user if download is not available, rather than hiding the error and doing nothing.

Fixes issue #1623 

