### PR TITLE
Remove development mode landing page switch

### DIFF
--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -16,9 +16,7 @@ class UrlMappings {
             }
         }
 
-        "/" {
-            controller = (Environment.current == Environment.DEVELOPMENT) ? "home" : "landing"
-        }
+        "/" { controller = "landing" }
 
         "500"(view:'/error')
 


### PR DESCRIPTION
I'm suggesting we remove this switch as there have now been two bugs (that I know of) which have made it to master which wouldn't have if this switch hadn't been in place. Sorry, @pmbohm, I know why we added this but I don't think it's worth the clicks it saves any more.