### PR TITLE
reset dates in NcWmsPanel (fix #1673)

### DIFF
--- a/web-app/js/portal/details/NcWmsPanel.js
+++ b/web-app/js/portal/details/NcWmsPanel.js
@@ -410,8 +410,8 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Container, {
         }
         else {
             // Initialize/modify pickers
-            this._initializeDateTimePicker(this.startDateTimePicker, this.layer.getSubsetExtentMin());
-            this._initializeDateTimePicker(this.endDateTimePicker, this.layer.getSubsetExtentMax());
+            this._initializeDateTimePicker(this.startDateTimePicker, this.layer.getTemporalExtentMin());
+            this._initializeDateTimePicker(this.endDateTimePicker, this.layer.getTemporalExtentMax());
 
             var extent = this.layer.getTemporalExtent();
             this._setDateTimePickerExtent(this.startDateTimePicker, extent, this.startDateTimePicker.initvalue, false);


### PR DESCRIPTION
reset dates to real min and max and not the current subset that's
displayed. bug was probably carried over from my work on stateless
ncwms