### PR TITLE
Step 3 filter tidy (#1626)

### DIFF
--- a/src/test/javascript/portal/cart/NcwmsInjectorSpec.js
+++ b/src/test/javascript/portal/cart/NcwmsInjectorSpec.js
@@ -12,6 +12,8 @@ describe('Portal.cart.NcwmsInjector', function() {
     var startDate;
     var endDate;
 
+    var dateLabel = OpenLayers.i18n('temporalExtentHeading');
+
     beforeEach(function() {
         injector = new Portal.cart.NcwmsInjector();
         startDate = moment.utc(Date.UTC(2013, 10, 20, 0, 30, 0, 0)); // NB.Months are zero indexed
@@ -49,10 +51,12 @@ describe('Portal.cart.NcwmsInjector', function() {
             geoNetworkRecord.ncwmsParams.dateRangeEnd = moment.utc(Date.UTC(2014, 11, 21, 10, 30, 30, 500));
 
             var entry = injector._getDataFilterEntry(geoNetworkRecord);
-            expect(entry).toContain(OpenLayers.i18n('parameterDateLabel'));
+            expect(entry).toContain(dateLabel);
 
-            entry = injector._formatHumanDateInfo('parameterDateLabel', 'startdate', 'enddate');
+            entry = injector._formatHumanDateInfo('temporalExtentHeading', 'startdate', 'enddate');
+            expect(entry).toContain(dateLabel);
             expect(entry).toContain('startdate');
+            expect(entry).toContain('enddate');
         });
     });
 

--- a/src/test/javascript/portal/cart/NcwmsInjectorSpec.js
+++ b/src/test/javascript/portal/cart/NcwmsInjectorSpec.js
@@ -41,7 +41,7 @@ describe('Portal.cart.NcwmsInjector', function() {
         it('indicates bounds properly created', function() {
 
             var entry = injector._getDataFilterEntry(geoNetworkRecord);
-            expect(entry).toContain(OpenLayers.i18n("boundingBoxDescriptionNcWms"));
+            expect(entry).toContain(OpenLayers.i18n("spatialExtentHeading"));
         });
 
         it('indicates temporal range', function() {

--- a/src/test/javascript/portal/filter/BooleanFilterSpec.js
+++ b/src/test/javascript/portal/filter/BooleanFilterSpec.js
@@ -30,7 +30,7 @@ describe("Portal.filter.BooleanFilter", function() {
 
         it('returns correct description', function() {
 
-            expect(filter.getHumanReadableForm()).toBe('The thing = true');
+            expect(filter.getHumanReadableForm()).toBe('The thing: true');
         });
     });
 });

--- a/src/test/javascript/portal/filter/DateFilterSpec.js
+++ b/src/test/javascript/portal/filter/DateFilterSpec.js
@@ -8,6 +8,7 @@
 describe("Portal.filter.DateFilter", function() {
 
     var filter;
+    var dateLabel = OpenLayers.i18n('temporalExtentHeading');
     var exampleFromDate = ['1999-01-01T00:00:00Z', '1999/Jan/01-11:00-UTC'];
     var exampleToDate = ['2006-06-06T01:00:00Z', '2006/Jun/06-11:00-UTC'];
 
@@ -42,7 +43,7 @@ describe("Portal.filter.DateFilter", function() {
 
         it('gives human readble form', function() {
 
-            expect(filter.getHumanReadableForm()).toBe("End Date >= 1999/Jan/01-11:00-UTC");
+            expect(filter.getHumanReadableForm()).toBe(dateLabel + ": >= 1999/Jan/01-11:00-UTC");
         });
     });
 
@@ -67,7 +68,7 @@ describe("Portal.filter.DateFilter", function() {
 
         it('gives human readble form', function() {
 
-            expect(filter.getHumanReadableForm()).toBe("Start Date <= 2006/Jun/06-11:00-UTC");
+            expect(filter.getHumanReadableForm()).toBe(dateLabel + ": <= 2006/Jun/06-11:00-UTC");
         });
     });
 
@@ -93,7 +94,7 @@ describe("Portal.filter.DateFilter", function() {
 
         it('gives human readble form', function() {
 
-            expect(filter.getHumanReadableForm()).toBe("End Date >= 1999/Jan/01-11:00-UTC and Start Date <= 2006/Jun/06-11:00-UTC");
+            expect(filter.getHumanReadableForm()).toBe(dateLabel + ": >= 1999/Jan/01-11:00-UTC and <= 2006/Jun/06-11:00-UTC");
         });
     });
 
@@ -123,7 +124,7 @@ describe("Portal.filter.DateFilter", function() {
 
         it('gives human readble form', function() {
 
-            expect(filter.getHumanReadableForm()).toBe("End Date >= 1999/Jan/01-11:00-UTC and Start Date <= 2006/Jun/06-11:00-UTC");
+            expect(filter.getHumanReadableForm()).toBe(dateLabel + ": >= 1999/Jan/01-11:00-UTC and <= 2006/Jun/06-11:00-UTC");
         });
     });
 });

--- a/src/test/javascript/portal/filter/DateFilterSpec.js
+++ b/src/test/javascript/portal/filter/DateFilterSpec.js
@@ -26,10 +26,7 @@ describe("Portal.filter.DateFilter", function() {
 
         beforeEach(function() {
 
-            filter = new Portal.filter.DateFilter({
-                name: 'column_name',
-                value: {}
-            });
+            filter.setValue({});
         });
 
         describe('hasValue', function() {
@@ -123,7 +120,6 @@ describe("Portal.filter.DateFilter", function() {
 
             filter.wmsStartDateName = 'range_start_column_name';
             filter.wmsEndDateName = 'range_end_column_name';
-
             filter.setValue({
                 fromDate: exampleFromDate,
                 toDate: exampleToDate

--- a/src/test/javascript/portal/filter/DateFilterSpec.js
+++ b/src/test/javascript/portal/filter/DateFilterSpec.js
@@ -43,7 +43,7 @@ describe("Portal.filter.DateFilter", function() {
 
         it('gives human readble form', function() {
 
-            expect(filter.getHumanReadableForm()).toBe(dateLabel + ": >= 1999/Jan/01-11:00-UTC");
+            expect(filter.getHumanReadableForm()).toBe(dateLabel + ": after 1999/Jan/01-11:00-UTC");
         });
     });
 
@@ -68,7 +68,7 @@ describe("Portal.filter.DateFilter", function() {
 
         it('gives human readble form', function() {
 
-            expect(filter.getHumanReadableForm()).toBe(dateLabel + ": <= 2006/Jun/06-11:00-UTC");
+            expect(filter.getHumanReadableForm()).toBe(dateLabel + ": before 2006/Jun/06-11:00-UTC");
         });
     });
 
@@ -94,7 +94,7 @@ describe("Portal.filter.DateFilter", function() {
 
         it('gives human readble form', function() {
 
-            expect(filter.getHumanReadableForm()).toBe(dateLabel + ": >= 1999/Jan/01-11:00-UTC and <= 2006/Jun/06-11:00-UTC");
+            expect(filter.getHumanReadableForm()).toBe(dateLabel + ": 1999/Jan/01-11:00-UTC to 2006/Jun/06-11:00-UTC");
         });
     });
 
@@ -124,7 +124,7 @@ describe("Portal.filter.DateFilter", function() {
 
         it('gives human readble form', function() {
 
-            expect(filter.getHumanReadableForm()).toBe(dateLabel + ": >= 1999/Jan/01-11:00-UTC and <= 2006/Jun/06-11:00-UTC");
+            expect(filter.getHumanReadableForm()).toBe(dateLabel + ": 1999/Jan/01-11:00-UTC to 2006/Jun/06-11:00-UTC");
         });
     });
 });

--- a/src/test/javascript/portal/filter/DateFilterSpec.js
+++ b/src/test/javascript/portal/filter/DateFilterSpec.js
@@ -11,6 +11,7 @@ describe("Portal.filter.DateFilter", function() {
     var dateLabel = OpenLayers.i18n('temporalExtentHeading');
     var exampleFromDate = ['1999-01-01T00:00:00Z', '1999/Jan/01-11:00-UTC'];
     var exampleToDate = ['2006-06-06T01:00:00Z', '2006/Jun/06-11:00-UTC'];
+    var errorCode = 'NOT SET';
 
     beforeEach(function() {
 
@@ -18,8 +19,8 @@ describe("Portal.filter.DateFilter", function() {
             name: 'column_name'
         });
 
-        filter._getDateString = function(d) { return d[0] };
-        filter._getDateHumanString = function(d) { return d[1] };
+        filter._getDateString = function(d) { return d ? d[0] : errorCode };
+        filter._getDateHumanString = function(d) { return d ? d[1] : errorCode };
     });
 
     describe('no dates (but not-null value)', function() {

--- a/src/test/javascript/portal/filter/DateFilterSpec.js
+++ b/src/test/javascript/portal/filter/DateFilterSpec.js
@@ -22,6 +22,25 @@ describe("Portal.filter.DateFilter", function() {
         filter._getDateHumanString = function(d) { return d[1] };
     });
 
+    describe('no dates (but not-null value)', function() {
+
+        beforeEach(function() {
+
+            filter = new Portal.filter.DateFilter({
+                name: 'column_name',
+                value: {}
+            });
+        });
+
+        describe('hasValue', function() {
+
+            it('returns false', function() {
+
+                expect(filter.hasValue()).not.toBeTruthy();
+            });
+        });
+    });
+
     describe('only start date', function() {
 
         beforeEach(function() {

--- a/src/test/javascript/portal/filter/GeometryFilterSpec.js
+++ b/src/test/javascript/portal/filter/GeometryFilterSpec.js
@@ -8,7 +8,6 @@
 describe("Portal.filter.GeometryFilter", function() {
 
     var filter;
-    var map;
 
     describe('polygon drawn', function() {
 
@@ -38,7 +37,11 @@ describe("Portal.filter.GeometryFilter", function() {
 
             it('returns a description', function() {
 
-                expect(filter.getHumanReadableForm()).toBe('Max extent of polygon: bounds');
+                var humanReadableForm = filter.getHumanReadableForm();
+
+                expect(humanReadableForm).toContain(OpenLayers.i18n("spatialExtentHeading"));
+                expect(humanReadableForm).toContain(OpenLayers.i18n("spatialExtentPolygonNote"));
+                expect(humanReadableForm).toContain('bounds');
             });
         });
     });
@@ -71,7 +74,10 @@ describe("Portal.filter.GeometryFilter", function() {
 
             it('returns a description', function() {
 
-                expect(filter.getHumanReadableForm()).toBe('Bounding Box: bounds');
+                var humanReadableForm = filter.getHumanReadableForm();
+
+                expect(humanReadableForm).toContain(OpenLayers.i18n("spatialExtentHeading"));
+                expect(humanReadableForm).toContain('bounds');
             });
         });
     });

--- a/src/test/javascript/portal/filter/NumberFilterSpec.js
+++ b/src/test/javascript/portal/filter/NumberFilterSpec.js
@@ -39,7 +39,9 @@ describe("Portal.filter.NumberFilter", function() {
 
             filter.setValue({
                 firstField: 5,
-                operator: '>='
+                operator: {
+                    cql: '>='
+                }
             });
         });
 
@@ -66,7 +68,9 @@ describe("Portal.filter.NumberFilter", function() {
 
             filter.setValue({
                 firstField: 5,
-                operator: 'between',
+                operator: {
+                    cql: 'between'
+                },
                 secondField: 99
             });
         });

--- a/src/test/javascript/portal/filter/NumberFilterSpec.js
+++ b/src/test/javascript/portal/filter/NumberFilterSpec.js
@@ -40,7 +40,7 @@ describe("Portal.filter.NumberFilter", function() {
             filter.setValue({
                 firstField: 5,
                 operator: {
-                    cql: '>='
+                    cql: '>= {0}'
                 }
             });
         });
@@ -69,7 +69,7 @@ describe("Portal.filter.NumberFilter", function() {
             filter.setValue({
                 firstField: 5,
                 operator: {
-                    cql: 'between'
+                    cql: 'between {0} AND {1}'
                 },
                 secondField: 99
             });

--- a/src/test/javascript/portal/filter/NumberFilterSpec.js
+++ b/src/test/javascript/portal/filter/NumberFilterSpec.js
@@ -57,7 +57,7 @@ describe("Portal.filter.NumberFilter", function() {
 
             it('returns description', function() {
 
-                expect(filter.getHumanReadableForm()).toBe('Important number >= 5');
+                expect(filter.getHumanReadableForm()).toBe('Important number: >= 5');
             });
         });
     });
@@ -87,7 +87,7 @@ describe("Portal.filter.NumberFilter", function() {
 
             it('returns description', function() {
 
-                expect(filter.getHumanReadableForm()).toBe('Important number between 5 AND 99');
+                expect(filter.getHumanReadableForm()).toBe('Important number: between 5 AND 99');
             });
         });
     });

--- a/src/test/javascript/portal/filter/NumberFilterSpec.js
+++ b/src/test/javascript/portal/filter/NumberFilterSpec.js
@@ -15,6 +15,7 @@ describe("Portal.filter.NumberFilter", function() {
             name: 'column_name',
             label: 'Important number'
         });
+        filter._generateOperatorHtml = function() { return 'html' };
     });
 
     describe('empty value entered', function() {
@@ -57,7 +58,7 @@ describe("Portal.filter.NumberFilter", function() {
 
             it('returns description', function() {
 
-                expect(filter.getHumanReadableForm()).toBe('Important number: >= 5');
+                expect(filter.getHumanReadableForm()).toBe('Important number:  html 5');
             });
         });
     });
@@ -87,8 +88,28 @@ describe("Portal.filter.NumberFilter", function() {
 
             it('returns description', function() {
 
-                expect(filter.getHumanReadableForm()).toBe('Important number: between 5 AND 99');
+                expect(filter.getHumanReadableForm()).toBe('Important number: 5 html 99');
             });
+        });
+    });
+
+    describe('_generateOperatorHtml', function() {
+
+        it('contains required information', function() {
+
+            var operator = {
+                text: 'less than',
+                symbol: '<'
+            };
+
+            filter = new Portal.filter.NumberFilter({
+                value: { operator: operator }
+            });
+
+            var html = filter._generateOperatorHtml(operator);
+
+            expect(html).toContain(operator.text);
+            expect(html).toContain(operator.symbol);
         });
     });
 });

--- a/src/test/javascript/portal/filter/NumberFilterSpec.js
+++ b/src/test/javascript/portal/filter/NumberFilterSpec.js
@@ -17,6 +17,22 @@ describe("Portal.filter.NumberFilter", function() {
         });
     });
 
+    describe('empty value entered', function() {
+
+        beforeEach(function() {
+
+            filter.setValue({});
+        });
+
+        describe('hasValue', function() {
+
+            it('returns false', function() {
+
+                expect(filter.hasValue()).not.toBeTruthy();
+            });
+        });
+    });
+
     describe('one value entered', function() {
 
         beforeEach(function() {

--- a/src/test/javascript/portal/filter/StringFilterSpec.js
+++ b/src/test/javascript/portal/filter/StringFilterSpec.js
@@ -30,7 +30,7 @@ describe("Portal.filter.StringFilter", function() {
 
         it('returns correct description', function() {
 
-            expect(filter.getHumanReadableForm()).toBe("Boat name like L'astrolabe");
+            expect(filter.getHumanReadableForm()).toBe("Boat name: L'astrolabe");
         });
     });
 });

--- a/src/test/javascript/portal/filter/ui/NumberFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/NumberFilterPanelSpec.js
@@ -53,6 +53,8 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
                 lastSelectionText: 'less than',
                 getValue: noOp
             };
+
+            spyOn(numberFilter, '_getSelectedOperatorObject');
         });
 
         it('sends correct tracking data  when operator is not between', function() {

--- a/web-app/js/portal/cart/NcwmsInjector.js
+++ b/web-app/js/portal/cart/NcwmsInjector.js
@@ -32,7 +32,7 @@ Portal.cart.NcwmsInjector = Ext.extend(Portal.cart.BaseInjector, {
         if (params.dateRangeStart != undefined) {
             var startDateString = this._formatDate(params.dateRangeStart);
             var endDateString = this._formatDate(params.dateRangeEnd);
-            dateString = this._formatHumanDateInfo('parameterDateLabel', startDateString, endDateString);
+            dateString = this._formatHumanDateInfo('temporalExtentHeading', startDateString, endDateString);
         }
 
         if (areaString == "" && dateString == "") {

--- a/web-app/js/portal/cart/NcwmsInjector.js
+++ b/web-app/js/portal/cart/NcwmsInjector.js
@@ -26,7 +26,7 @@ Portal.cart.NcwmsInjector = Ext.extend(Portal.cart.BaseInjector, {
             );
             var bbox = Portal.utils.geo.bboxAsStringToBounds(bboxString);
             // differs from WMS layers. It will always be a bbox even when a polygon was used by the user
-            areaString = String.format('{0}:&nbsp;  {1}<br>', OpenLayers.i18n("boundingBoxDescriptionNcWms"), bbox.toString());
+            areaString = String.format('{0}:&nbsp;{1}<br>', OpenLayers.i18n("spatialExtentHeading"), bbox.toString());
         }
 
         if (params.dateRangeStart != undefined) {
@@ -43,7 +43,7 @@ Portal.cart.NcwmsInjector = Ext.extend(Portal.cart.BaseInjector, {
     },
 
     _formatHumanDateInfo: function(labelKey, value1, value2) {
-        return String.format('{0}:&nbsp;  {1} to {2}<br>', OpenLayers.i18n(labelKey), value1, value2);
+        return String.format('{0}:&nbsp;{1} to {2}<br>', OpenLayers.i18n(labelKey), value1, value2);
     },
 
     _formatDate: function(date) {

--- a/web-app/js/portal/filter/BooleanFilter.js
+++ b/web-app/js/portal/filter/BooleanFilter.js
@@ -21,19 +21,17 @@ Portal.filter.BooleanFilter = Ext.extend(Portal.filter.Filter, {
 
     getCql: function() {
 
-        return this._getCql(this.getName());
+        return String.format(
+            '{0} = true',
+            this.getName()
+        );
     },
 
     getHumanReadableForm: function() {
 
-        return this._getCql(this.getLabel());
-    },
-
-    _getCql: function(fieldName) {
-
         return String.format(
-            '{0} = true',
-            fieldName
+            '{0}: true',
+            this.getLabel()
         );
     }
 });

--- a/web-app/js/portal/filter/DateFilter.js
+++ b/web-app/js/portal/filter/DateFilter.js
@@ -75,21 +75,27 @@ Portal.filter.DateFilter = Ext.extend(Portal.filter.Filter, {
 
     getHumanReadableForm: function() {
 
-        var description = OpenLayers.i18n('temporalExtentHeading') + ': ';
-
-        if (this._getFromDate()) {
-            description += String.format(">= {0}", this._getDateHumanString(this._getFromDate()));
-        }
+        var formatKey;
 
         if (this._getFromDate() && this._getToDate()) {
-            description += ' and ';
+
+            formatKey = 'dateFilterBetweenFormat';
+        }
+        else if (this._getFromDate()) {
+
+            formatKey = 'dateFilterAfterFormat';
+        }
+        else {
+
+            formatKey = 'dateFilterBeforeFormat';
         }
 
-        if (this._getToDate()) {
-            description += String.format("<= {0}", this._getDateHumanString(this._getToDate()));
-        }
-
-        return description;
+        return String.format(
+            OpenLayers.i18n(formatKey),
+            OpenLayers.i18n('temporalExtentHeading'),
+            this._getDateHumanString(this._getFromDate()),
+            this._getDateHumanString(this._getToDate())
+        );
     },
 
     _getFromDate: function() {

--- a/web-app/js/portal/filter/DateFilter.js
+++ b/web-app/js/portal/filter/DateFilter.js
@@ -75,21 +75,21 @@ Portal.filter.DateFilter = Ext.extend(Portal.filter.Filter, {
 
     getHumanReadableForm: function() {
 
-        var cql = '';
+        var description = OpenLayers.i18n('temporalExtentHeading') + ': ';
 
         if (this._getFromDate()) {
-            cql = String.format("{0} >= {1}", "End Date", this._getDateHumanString(this._getFromDate()));
+            description += String.format(">= {0}", this._getDateHumanString(this._getFromDate()));
         }
 
         if (this._getFromDate() && this._getToDate()) {
-            cql += ' and ';
+            description += ' and ';
         }
 
         if (this._getToDate()) {
-            cql += String.format("{0} <= {1}", "Start Date", this._getDateHumanString(this._getToDate()));
+            description += String.format("<= {0}", this._getDateHumanString(this._getToDate()));
         }
 
-        return cql;
+        return description;
     },
 
     _getFromDate: function() {

--- a/web-app/js/portal/filter/DateFilter.js
+++ b/web-app/js/portal/filter/DateFilter.js
@@ -17,6 +17,11 @@ Portal.filter.DateFilter = Ext.extend(Portal.filter.Filter, {
         Portal.filter.DateFilter.superclass.constructor.call(this, cfg);
     },
 
+    hasValue: function() {
+
+        return this.getValue() && (this._getFromDate() || this._getToDate());
+    },
+
     getSupportedGeoserverTypes: function() {
 
         return ['date', 'datetime'];

--- a/web-app/js/portal/filter/GeometryFilter.js
+++ b/web-app/js/portal/filter/GeometryFilter.js
@@ -30,11 +30,13 @@ Portal.filter.GeometryFilter = Ext.extend(Portal.filter.Filter, {
 
     getHumanReadableForm: function() {
 
-        var explanation = this._isRealPolygon() ? OpenLayers.i18n("maxExtentOfPolygon") : OpenLayers.i18n("boundingBoxDescription");
+        var label = OpenLayers.i18n("spatialExtentHeading");
+        var note = this._isRealPolygon() ? OpenLayers.i18n("spatialExtentPolygonNote") : "";
 
         return String.format(
-            '{0}: {1}',
-            explanation,
+            '{0}: {1}{2}',
+            label,
+            note,
             this.getValue().getBounds()
         );
     },

--- a/web-app/js/portal/filter/NumberFilter.js
+++ b/web-app/js/portal/filter/NumberFilter.js
@@ -21,7 +21,23 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
 
     getCql: function() {
 
-        return this._getCql();
+        var cql = String.format(
+            '{0} {1} {2}',
+            this.getName(),
+            this._getOperator(),
+            this._getFirstField()
+        );
+
+        if (this._getSecondField()) {
+
+            cql = String.format(
+                '{0} AND {1}',
+                cql,
+                this._getSecondField()
+            );
+        }
+
+        return cql;
     },
 
     hasValue: function() {
@@ -31,14 +47,9 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
 
     getHumanReadableForm: function() {
 
-        return this._getCql(this.getLabel());
-    },
-
-    _getCql: function(alternateLabel) {
-
         var cql = String.format(
             '{0} {1} {2}',
-            alternateLabel || this.getName(),
+            this.getLabel(),
             this._getOperator(),
             this._getFirstField()
         );

--- a/web-app/js/portal/filter/NumberFilter.js
+++ b/web-app/js/portal/filter/NumberFilter.js
@@ -48,7 +48,7 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
         );
 
         return String.format(
-            '{0} {1}',
+            '{0}: {1}',
             this.getLabel(),
             cql
         );

--- a/web-app/js/portal/filter/NumberFilter.js
+++ b/web-app/js/portal/filter/NumberFilter.js
@@ -41,16 +41,20 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
 
     getHumanReadableForm: function() {
 
-        var cql = String.format(
-            this._getOperatorObject().cql,
-            this._getFirstField(),
-            this._getSecondField()
+        var firstOperand = this._getSecondField() ? this._getFirstField() : '';
+        var secondOperand = this._getSecondField() ? this._getSecondField() : this._getFirstField();
+
+        var value = String.format(
+            '{0} {1} {2}',
+            firstOperand,
+            this._generateOperatorHtml(),
+            secondOperand
         );
 
         return String.format(
             '{0}: {1}',
             this.getLabel(),
-            cql
+            value
         );
     },
 
@@ -67,5 +71,15 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
     _getSecondField: function() {
 
         return this.getValue().secondField;
+    },
+
+    _generateOperatorHtml: function() {
+
+        var operator = this._getOperatorObject();
+        return String.format(
+            '<abbr title="{0}">{1}</abbr>',
+            operator.text,
+            operator.symbol
+        );
     }
 });

--- a/web-app/js/portal/filter/NumberFilter.js
+++ b/web-app/js/portal/filter/NumberFilter.js
@@ -24,6 +24,11 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
         return this._getCql();
     },
 
+    hasValue: function() {
+
+        return this.getValue() && (this._getFirstField() || this._getSecondField());
+    },
+
     getHumanReadableForm: function() {
 
         return this._getCql(this.getLabel());

--- a/web-app/js/portal/filter/NumberFilter.js
+++ b/web-app/js/portal/filter/NumberFilter.js
@@ -24,7 +24,7 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
         var cql = String.format(
             '{0} {1} {2}',
             this.getName(),
-            this._getOperatorObject(),
+            this._getOperatorObject().cql,
             this._getFirstField()
         );
 
@@ -50,7 +50,7 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
         var cql = String.format(
             '{0} {1} {2}',
             this.getLabel(),
-            this._getOperatorObject(),
+            this._getOperatorObject().cql,
             this._getFirstField()
         );
 

--- a/web-app/js/portal/filter/NumberFilter.js
+++ b/web-app/js/portal/filter/NumberFilter.js
@@ -24,7 +24,7 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
         var cql = String.format(
             '{0} {1} {2}',
             this.getName(),
-            this._getOperator(),
+            this._getOperatorObject(),
             this._getFirstField()
         );
 
@@ -50,7 +50,7 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
         var cql = String.format(
             '{0} {1} {2}',
             this.getLabel(),
-            this._getOperator(),
+            this._getOperatorObject(),
             this._getFirstField()
         );
 
@@ -71,7 +71,7 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
         return this.getValue().firstField;
     },
 
-    _getOperator: function() {
+    _getOperatorObject: function() {
 
         return this.getValue().operator;
     },

--- a/web-app/js/portal/filter/NumberFilter.js
+++ b/web-app/js/portal/filter/NumberFilter.js
@@ -22,22 +22,16 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
     getCql: function() {
 
         var cql = String.format(
-            '{0} {1} {2}',
-            this.getName(),
             this._getOperatorObject().cql,
-            this._getFirstField()
+            this._getFirstField(),
+            this._getSecondField()
         );
 
-        if (this._getSecondField()) {
-
-            cql = String.format(
-                '{0} AND {1}',
-                cql,
-                this._getSecondField()
-            );
-        }
-
-        return cql;
+        return String.format(
+            '{0} {1}',
+            this.getName(),
+            cql
+        );
     },
 
     hasValue: function() {
@@ -48,22 +42,16 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
     getHumanReadableForm: function() {
 
         var cql = String.format(
-            '{0} {1} {2}',
-            this.getLabel(),
             this._getOperatorObject().cql,
-            this._getFirstField()
+            this._getFirstField(),
+            this._getSecondField()
         );
 
-        if (this._getSecondField()) {
-
-            cql = String.format(
-                '{0} AND {1}',
-                cql,
-                this._getSecondField()
-            );
-        }
-
-        return cql;
+        return String.format(
+            '{0} {1}',
+            this.getLabel(),
+            cql
+        );
     },
 
     _getFirstField: function() {

--- a/web-app/js/portal/filter/StringFilter.js
+++ b/web-app/js/portal/filter/StringFilter.js
@@ -31,7 +31,7 @@ Portal.filter.StringFilter = Ext.extend(Portal.filter.Filter, {
     getHumanReadableForm: function() {
 
         return String.format(
-            '{0} like {1}',
+            '{0}: {1}',
             this.getLabel(),
             this.getValue()
         );

--- a/web-app/js/portal/filter/ui/NumberFilterPanel.js
+++ b/web-app/js/portal/filter/ui/NumberFilterPanel.js
@@ -134,20 +134,18 @@ Portal.filter.ui.NumberFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel
     },
 
     _onOperationSelected: function() {
-        var shouldUpdate;
         var useSecondField = this._operatorIsBetween();
-        var noneSelected = this._operatorIsNone();
+        var clearSelected = this._operatorIsClear();
         var hasFirstValue = this._hasFirstValue();
         var hasSecondValue = this._hasSecondValue();
 
         this.secondField.setVisible(useSecondField);
 
-        shouldUpdate = useSecondField ? hasFirstValue && hasSecondValue : hasFirstValue;
+        var shouldUpdate = useSecondField ? hasFirstValue && hasSecondValue : hasFirstValue;
 
-        // Only change map if first value has a value
         if (shouldUpdate) {
-            // clear the filter if "none" is selected
-            if (noneSelected) {
+
+            if (clearSelected) {
                 this.handleRemoveFilter();
             }
 
@@ -159,7 +157,7 @@ Portal.filter.ui.NumberFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel
         return this.operators.getValue() == "BETWEEN";
     },
 
-    _operatorIsNone: function() {
+    _operatorIsClear: function() {
         return this.operators.getValue() == "0";
     }
 });

--- a/web-app/js/portal/filter/ui/NumberFilterPanel.js
+++ b/web-app/js/portal/filter/ui/NumberFilterPanel.js
@@ -36,19 +36,8 @@ Portal.filter.ui.NumberFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel
             editable: false,
             fieldLabel: "Value",
             store: new Ext.data.ArrayStore({
-                fields: [
-                    'display', 'value'
-                ],
-                data: [
-                    ['none', '0'],
-                    ['greater than', '>'],
-                    ['greater than or equal to', '>='],
-                    ['equal to', '='],
-                    ['not equal to', '<>'],
-                    ['less than', '<'],
-                    ['less than or equal to', '<='],
-                    ['between', 'BETWEEN']
-                ]
+                fields: OpenLayers.i18n('numberFilterOptionsFields'),
+                data: OpenLayers.i18n('numberFilterDropdownOptions')
             }),
             valueField: 'value',
             displayField: 'display',

--- a/web-app/js/portal/filter/ui/NumberFilterPanel.js
+++ b/web-app/js/portal/filter/ui/NumberFilterPanel.js
@@ -9,6 +9,9 @@ Ext.namespace('Portal.filter.ui');
 
 Portal.filter.ui.NumberFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel, {
 
+    OPERATOR_CLEAR: 'CLR',
+    OPERATOR_BETWEEN: 'BTWN',
+
     constructor: function(cfg) {
 
         var config = Ext.apply({
@@ -39,8 +42,8 @@ Portal.filter.ui.NumberFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel
                 fields: OpenLayers.i18n('numberFilterOptionsFields'),
                 data: OpenLayers.i18n('numberFilterDropdownOptions')
             }),
-            valueField: 'value',
-            displayField: 'display',
+            valueField: 'code',
+            displayField: 'text',
             listeners:{
                 scope: this,
                 select: this._onOperationSelected
@@ -103,9 +106,7 @@ Portal.filter.ui.NumberFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel
 
             this.filter.setValue({
                 firstField: this.firstField.getValue(),
-                operator: {
-                    cql: this.operators.getValue()
-                },
+                operator: this._getSelectedOperatorObject(),
                 secondField: this.secondField.getValue()
             });
 
@@ -156,10 +157,19 @@ Portal.filter.ui.NumberFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel
     },
 
     _operatorIsBetween: function() {
-        return this.operators.getValue() == "BETWEEN";
+        return this.operators.getValue() == this.OPERATOR_BETWEEN;
     },
 
     _operatorIsClear: function() {
-        return this.operators.getValue() == "0";
+        return this.operators.getValue() == this.OPERATOR_CLEAR;
+    },
+
+    _getSelectedOperatorObject: function() {
+
+        var store = this.operators.getStore();
+        var selectedValue = this.operators.getValue();
+        var index = store.find('code', selectedValue);
+        var record = store.getAt(index);
+        return record.data;
     }
 });

--- a/web-app/js/portal/filter/ui/NumberFilterPanel.js
+++ b/web-app/js/portal/filter/ui/NumberFilterPanel.js
@@ -103,7 +103,9 @@ Portal.filter.ui.NumberFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel
 
             this.filter.setValue({
                 firstField: this.firstField.getValue(),
-                operator: this.operators.getValue(),
+                operator: {
+                    cql: this.operators.getValue()
+                },
                 secondField: this.secondField.getValue()
             });
 

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -83,9 +83,6 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     mapTabTitle: 'Map',
 
     // Search form
-    boundingBoxDescription: 'Bounding Box',
-    boundingBoxDescriptionNcWms: 'Bounding Area',
-    maxExtentOfPolygon: "Max extent of polygon",
     northBL: 'N',
     eastBL: 'E',
     westBL: 'W',
@@ -193,6 +190,7 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     temporalExtentHeading: 'Temporal Extent',
     generalFilterHeading: 'Filters',
     currentDateTimeLabel: 'Displaying',
+    spatialExtentPolygonNote: 'Polygon with max extent ',
 
     emptyDownloadPlaceholder: "The full data collection will be downloaded. Consider filtering the collection.",
 

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -192,6 +192,10 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     currentDateTimeLabel: 'Displaying',
     spatialExtentPolygonNote: 'Polygon with max extent ',
 
+    dateFilterBeforeFormat: '{0}: before {2}',
+    dateFilterAfterFormat: '{0}: after {1}',
+    dateFilterBetweenFormat: '{0}: {1} to {2}',
+
     emptyDownloadPlaceholder: "The full data collection will be downloaded. Consider filtering the collection.",
 
     // FeatureInfoPopup.js

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -197,17 +197,17 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     dateFilterBetweenFormat: '{0}: {1} to {2}',
 
     numberFilterOptionsFields: [
-         'display',                   'value'
+         'code', 'text',                     'cql',                 'symbol'
     ],
     numberFilterDropdownOptions: [
-        ['none',                      '0'], // This option is in the dropdown to clear the number filter
-        ['greater than',              '>'],
-        ['greater than or equal to', '>='],
-        ['equal to',                  '='],
-        ['not equal to',             '<>'],
-        ['less than',                 '<'],
-        ['less than or equal to',    '<='],
-        ['between',                  'BETWEEN']
+        ['CLR',  'none'], // This option is in the dropdown to clear the number filter
+        ['GT',   'greater than',             '> {0}',               '>' ],
+        ['GTE',  'greater than or equal to', '>= {0}',              '>='],
+        ['EQ',   'equal to',                 '= {0}',               '=' ],
+        ['NEQ',  'not equal to',             '<> {0}',              '≠' ],
+        ['LT',   'less than',                '< {0}',               '<' ],
+        ['LTE',  'less than or equal to',    '<= {0}',              '<='],
+        ['BTWN', 'between (inclusive)',      'BETWEEN {0} AND {1}', '–' ]
     ],
 
     emptyDownloadPlaceholder: "The full data collection will be downloaded. Consider filtering the collection.",

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -196,6 +196,20 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     dateFilterAfterFormat: '{0}: after {1}',
     dateFilterBetweenFormat: '{0}: {1} to {2}',
 
+    numberFilterOptionsFields: [
+         'display',                   'value'
+    ],
+    numberFilterDropdownOptions: [
+        ['none',                      '0'], // This option is in the dropdown to clear the number filter
+        ['greater than',              '>'],
+        ['greater than or equal to', '>='],
+        ['equal to',                  '='],
+        ['not equal to',             '<>'],
+        ['less than',                 '<'],
+        ['less than or equal to',    '<='],
+        ['between',                  'BETWEEN']
+    ],
+
     emptyDownloadPlaceholder: "The full data collection will be downloaded. Consider filtering the collection.",
 
     // FeatureInfoPopup.js


### PR DESCRIPTION
This is a tidy-up of filters display in step 3.  It stems from #1626 but goes a lot further.

The main changes are:
- On step 3 all filters are displayed as `label: value`. (There was inconsistency with this.)
- The labels for spatial and temporal extent are now consistent between step 2 and step 3. (Previously they weren't).
- Regarding displaying of filter values on step 3 there was a mix of word-type display and raw CQL. This has now been made more consistent.
- There was inconsistency with labelling between ncWMS spatial filters and WMS spatial filters
- There was inconsistency with labelling between ncWMS temporal filters and WMS temporal filters
- Moved some text to the i18n dictionary
- Added a tooltip to symbols in the number filter so you can see in words what the symbol means