### PR TITLE
alert user to unsuccessful download caused by disallowed geoserver

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/DownloadController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/DownloadController.groovy
@@ -58,7 +58,7 @@ class DownloadController extends RequestProxyingController {
         def url = UrlUtils.urlWithQueryString(params.url, "PROPERTYNAME=$fieldName")
 
         if (!hostVerifier.allowedHost(url)) {
-            render text: "Host for address '$url' not allowed", contentType: "text/html", encoding: "UTF-8", status: HTTP_400_BAD_REQUEST
+            render text: "Host for address '$url' not allowed", contentType: "text/html", encoding: "UTF-8", status: HTTP_403_FORBIDDEN
             return
         }
 

--- a/grails-app/utils/au/org/emii/portal/HttpUtils.groovy
+++ b/grails-app/utils/au/org/emii/portal/HttpUtils.groovy
@@ -13,6 +13,7 @@ final class HttpUtils {
         static final HTTP_200_OK = 200
         static final HTTP_400_BAD_REQUEST = 400
         static final HTTP_401_UNAUTHORISED = 401
+        static final HTTP_403_FORBIDDEN = 403
         static final HTTP_404_NOT_FOUND = 404
         static final HTTP_500_INTERNAL_SERVER_ERROR = 500
         static final HTTP_502_BAD_GATEWAY = 502

--- a/src/groovy/au/org/emii/portal/proxying/RequestProxyingController.groovy
+++ b/src/groovy/au/org/emii/portal/proxying/RequestProxyingController.groovy
@@ -32,7 +32,7 @@ abstract class RequestProxyingController {
         }
         else if (!hostVerifier.allowedHost(url)) {
             log.info "Proxy: The url $url was not allowed"
-            render text: "Host for address '$url' not allowed", contentType: "text/html", encoding: "UTF-8", status: HTTP_400_BAD_REQUEST
+            render text: "Host for address '$url' not allowed", contentType: "text/html", encoding: "UTF-8", status: HTTP_403_FORBIDDEN
         }
         else {
             _performProxying(paramProcessor, streamProcessor)

--- a/test/unit/au/org/emii/portal/DownloadControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/DownloadControllerTests.groovy
@@ -10,6 +10,7 @@ package au.org.emii.portal
 import grails.test.ControllerUnitTestCase
 
 import static au.org.emii.portal.DownloadController.SIZE_ESTIMATE_ERROR
+import static au.org.emii.portal.HttpUtils.Status.*
 
 class DownloadControllerTests extends ControllerUnitTestCase {
 
@@ -106,6 +107,7 @@ class DownloadControllerTests extends ControllerUnitTestCase {
         controller.downloadNetCdfFilesForLayer()
 
         assertEquals "Host for address 'http://www.example.com/?PROPERTYNAME=relativeFilePath' not allowed", mockResponse.contentAsString
+        assertEquals HTTP_403_FORBIDDEN, controller.renderArgs.status
     }
 
     void testDownloadNetCdfFilesForLayer() {

--- a/web-app/js/portal/cart/DownloadPanelBody.js
+++ b/web-app/js/portal/cart/DownloadPanelBody.js
@@ -119,9 +119,19 @@ Portal.cart.DownloadPanelBody = Ext.extend(Ext.Panel, {
         params.onAccept = function(callbackParams) {
             var downloader = new Portal.cart.Downloader({
                 listeners: {
-                    'downloadrequested': function(downloadUrl) { log.debug('Download requested', downloadUrl); },
-                    'downloadstarted': function(downloadUrl) { log.debug('Download started', downloadUrl); },
-                    'downloadfailed': function(downloadUrl, msg) { log.debug('Download failed', downloadUrl, msg); }
+                    'downloadrequested': function(downloadUrl) {
+                        log.debug('Download requested', downloadUrl);
+                    },
+                    'downloadstarted': function(downloadUrl) {
+                        log.debug('Download started', downloadUrl);
+                    },
+                    'downloadfailed': function(downloadUrl, msg) {
+                        Ext.Msg.alert(
+                            OpenLayers.i18n('errorDialogTitle'),
+                            OpenLayers.i18n('downloadErrorText')
+                        );
+                        log.error('Download failed', downloadUrl, msg);
+                    }
                 }
             });
 

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -135,6 +135,7 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     downloadConfirmationDownloadText: 'I understand, download',
     downloadConfirmationCancelText: 'Cancel',
     challengeInstructions: 'Type the characters you see in the image above',
+    downloadErrorText: 'There is a problem with the availability of your selected data download.',
 
     // mainMapPanel
     layerExistsTitle: 'Add data collection',


### PR DESCRIPTION
Decision to use ext.alert was done in consultation with @pblain. 

Fixes issue #1623. 

This PR introduces error messaging to the the user on the client side. Currently handles disallowed geoserver urls (without any necessary changes to the server side after https://github.com/aodn/aodn-portal/pull/1684), and will be expanded on for my fix for #1624  