### PR TITLE
Remove redundant functions

### DIFF
--- a/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
@@ -111,7 +111,8 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
 
             testCollection = {
                 wmsLayer: {
-                    _buildGetFeatureRequestUrl: function() { return 'the_url' }
+                    _buildGetFeatureRequestUrl: function() { return 'the_url' },
+                    filters: []
                 }
             };
         });

--- a/web-app/js/portal/filter/combiner/BaseFilterCombiner.js
+++ b/web-app/js/portal/filter/combiner/BaseFilterCombiner.js
@@ -25,23 +25,15 @@ Portal.filter.combiner.BaseFilterCombiner = Ext.extend(Object, {
 
         var hasValue = function(filter) { return filter.hasValue() };
 
-        return this._matchingFilters(this._allFilters(), hasValue);
+        return this._allFilters().filter(hasValue);
     },
 
     _visualisedFiltersWithValues: function() {
 
         var isVisualised = function(filter) { return filter.isVisualised() };
 
-        return this._matchingFilters(this._filtersWithValues(), isVisualised);
+        return this._filtersWithValues().filter(isVisualised);
     },
-
-    _matchingFilters: function(filters, matcher) {
-
-        return this._collect(filters, function(filter) {
-
-            return matcher(filter) ? filter : null;
-        });
-     },
 
     _collect: function(filters, fn) {
 

--- a/web-app/js/portal/filter/combiner/BaseFilterCombiner.js
+++ b/web-app/js/portal/filter/combiner/BaseFilterCombiner.js
@@ -35,23 +35,6 @@ Portal.filter.combiner.BaseFilterCombiner = Ext.extend(Object, {
         return this._filtersWithValues().filter(isVisualised);
     },
 
-    _collect: function(filters, fn) {
-
-        var values = [];
-
-        Ext.each(filters, function(filter) {
-
-            var value = fn(filter);
-
-            if (value) {
-
-                values.push(value);
-            }
-        });
-
-        return values;
-    },
-
     _join: function(parts, joiner) {
 
         return parts.length > 0 ? parts.join(joiner) : null;

--- a/web-app/js/portal/filter/combiner/BodaacCqlBuilder.js
+++ b/web-app/js/portal/filter/combiner/BodaacCqlBuilder.js
@@ -11,7 +11,7 @@ Portal.filter.combiner.BodaacCqlBuilder = Ext.extend(Portal.filter.combiner.Filt
 
     buildCql: function() {
 
-        var cqlParts = this._collect(this._visualisedFiltersWithValues(), function(filter) {
+        var cqlParts = this._visualisedFiltersWithValues().map(function(filter) {
 
             return filter.getCql();
         });

--- a/web-app/js/portal/filter/combiner/DataDownloadCqlBuilder.js
+++ b/web-app/js/portal/filter/combiner/DataDownloadCqlBuilder.js
@@ -11,7 +11,7 @@ Portal.filter.combiner.DataDownloadCqlBuilder = Ext.extend(Portal.filter.combine
 
     buildCql: function() {
 
-        var cqlParts = this._collect(this._filtersWithValues(), function(filter) {
+        var cqlParts = this._filtersWithValues().map(function(filter) {
 
             var isDateFilter = (filter.constructor == Portal.filter.DateFilter);
 

--- a/web-app/js/portal/filter/combiner/HumanReadableFilterDescriber.js
+++ b/web-app/js/portal/filter/combiner/HumanReadableFilterDescriber.js
@@ -11,7 +11,7 @@ Portal.filter.combiner.HumanReadableFilterDescriber = Ext.extend(Portal.filter.c
 
     buildDescription: function(joiner) {
 
-        var filterDescriptions = this._collect(this._filtersWithValues(), function(filter) {
+        var filterDescriptions = this._filtersWithValues().map(function(filter) {
 
             return filter.getHumanReadableForm();
         });

--- a/web-app/js/portal/filter/combiner/MapCqlBuilder.js
+++ b/web-app/js/portal/filter/combiner/MapCqlBuilder.js
@@ -11,7 +11,7 @@ Portal.filter.combiner.MapCqlBuilder = Ext.extend(Portal.filter.combiner.FilterC
 
     _appropriateFilters: function() {
 
-        return this._matchingFilters(this._visualisedFiltersWithValues(), function(filter) {
+        return this._visualisedFiltersWithValues().filter(function(filter) {
 
             var isGeomemtryFilter = (filter.constructor == Portal.filter.GeometryFilter);
 

--- a/web-app/js/portal/filter/combiner/MapCqlBuilder.js
+++ b/web-app/js/portal/filter/combiner/MapCqlBuilder.js
@@ -21,7 +21,7 @@ Portal.filter.combiner.MapCqlBuilder = Ext.extend(Portal.filter.combiner.FilterC
 
     buildCql: function() {
 
-        var cqlParts = this._collect(this._appropriateFilters(), function(filter) {
+        var cqlParts = this._appropriateFilters().map(function(filter) {
 
             return filter.getCql();
         });


### PR DESCRIPTION
This replaces a couple of custom functions I'd written because I couldn't find the behaviour that I wanted (I was looking in Ext docs not thinking that they might be pure JS).

`_matchingFilters(array, fn)` is replaced with `array.filter(fn)` (Unfortunately, this name is confusing given that I am using it in the code for the Portal filters)

`_collect(array, fn)` is replaced with `array.map(fn)`