### PR TITLE
Proper handling of undefined filters

### DIFF
--- a/src/test/javascript/portal/cart/WmsInjectorSpec.js
+++ b/src/test/javascript/portal/cart/WmsInjectorSpec.js
@@ -18,9 +18,7 @@ describe('Portal.cart.WmsInjector', function() {
         }
     };
     var collectionWithNoFilters = {
-        wmsLayer: {
-            filters: []
-        }
+        wmsLayer: {}
     };
 
     beforeEach(function() {

--- a/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
@@ -111,8 +111,7 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
 
             testCollection = {
                 wmsLayer: {
-                    _buildGetFeatureRequestUrl: function() { return 'the_url' },
-                    filters: []
+                    _buildGetFeatureRequestUrl: function() { return 'the_url' }
                 }
             };
         });

--- a/web-app/js/portal/filter/combiner/BaseFilterCombiner.js
+++ b/web-app/js/portal/filter/combiner/BaseFilterCombiner.js
@@ -18,7 +18,7 @@ Portal.filter.combiner.BaseFilterCombiner = Ext.extend(Object, {
 
     _allFilters: function() {
 
-        return this.layer.filters;
+        return this.layer.filters || [];
     },
 
     _filtersWithValues: function() {


### PR DESCRIPTION
My recent changes in 12112494ccd99db9c5db113e045d3f92c734c60e and 142a278872f1be59a604bdcdf0c6307ac7e191d1 meant that they are no longer null-safe. I updated tests so they'd work but it turns out this also happens during normal operation so instead I'll substitute in an empty array if filters are undefined.