### PR TITLE
Issue #1675

### DIFF
--- a/src/test/javascript/portal/filter/FilterServiceSpec.js
+++ b/src/test/javascript/portal/filter/FilterServiceSpec.js
@@ -115,6 +115,41 @@ describe("Portal.filter.FilterService", function() {
         });
     });
 
+    describe('_determinePrimaryFilters', function() {
+
+        it('marks single time filter as primary', function() {
+
+            var testFilters = [
+                new Portal.filter.NumberFilter(),
+                new Portal.filter.DateFilter(),
+                new Portal.filter.BooleanFilter()
+            ];
+
+            service._determinePrimaryFilters(testFilters);
+
+            expect(testFilters[0].isPrimary()).not.toBeTruthy();
+            expect(testFilters[1].isPrimary()).toBeTruthy();
+            expect(testFilters[2].isPrimary()).not.toBeTruthy();
+        });
+
+        it('leaves multiple date filters unchanged', function() {
+
+            var testFilters = [
+                new Portal.filter.NumberFilter(),
+                new Portal.filter.DateFilter(),
+                new Portal.filter.BooleanFilter(),
+                new Portal.filter.DateFilter()
+            ];
+
+            service._determinePrimaryFilters(testFilters);
+
+            expect(testFilters[0].isPrimary()).not.toBeTruthy();
+            expect(testFilters[1].isPrimary()).not.toBeTruthy();
+            expect(testFilters[2].isPrimary()).not.toBeTruthy();
+            expect(testFilters[3].isPrimary()).not.toBeTruthy();
+        });
+    });
+
     var spyOnAjaxAndReturn = function(responseText, status) {
         spyOn(Ext.Ajax, 'request').andCallFake(function(opts) {
 

--- a/web-app/js/portal/filter/Filter.js
+++ b/web-app/js/portal/filter/Filter.js
@@ -56,6 +56,11 @@ Portal.filter.Filter = Ext.extend(Object, {
         return this.visualised;
     },
 
+    isPrimary: function() {
+
+        return this.primaryFilter;
+    },
+
     getWmsStartDateName: function() {
 
         return this.wmsStartDateName;

--- a/web-app/js/portal/filter/FilterService.js
+++ b/web-app/js/portal/filter/FilterService.js
@@ -58,6 +58,8 @@ Portal.filter.FilterService = Ext.extend(Object, {
             }
         });
 
+        this._determinePrimaryFilters(filterObjects);
+
         layer.filters = filterObjects;
 
         callbackFunction.call(callbackScope, filterObjects);
@@ -121,5 +123,18 @@ Portal.filter.FilterService = Ext.extend(Object, {
         }
 
         return filterLayer;
+    },
+
+    _determinePrimaryFilters: function(filters) {
+
+        var dateFilters = filters.filter(function(filter) {
+
+            return filter.constructor == Portal.filter.DateFilter;
+        });
+
+        if (dateFilters.length == 1) {
+
+            dateFilters[0].primaryFilter = true;
+        }
     }
 });

--- a/web-app/js/portal/filter/ui/BaseFilterPanel.js
+++ b/web-app/js/portal/filter/ui/BaseFilterPanel.js
@@ -39,10 +39,6 @@ Portal.filter.ui.BaseFilterPanel = Ext.extend(Ext.Panel, {
         this._createControls();
     },
 
-    _fireAddEvent: function() {
-        this.fireEvent('addFilter', this);
-    },
-
     _createControls: function() {
         throw "Subclasses must implement the _createControls function";
     },
@@ -57,5 +53,9 @@ Portal.filter.ui.BaseFilterPanel = Ext.extend(Ext.Panel, {
 
     setFilterRange: function() {
         throw "Subclasses must implement the setFilterRange function if needsFilterRange() returns true";
+    },
+
+    _fireAddEvent: function() {
+        this.fireEvent('addFilter', this);
     }
 });

--- a/web-app/js/portal/filter/ui/BaseFilterPanel.js
+++ b/web-app/js/portal/filter/ui/BaseFilterPanel.js
@@ -57,5 +57,11 @@ Portal.filter.ui.BaseFilterPanel = Ext.extend(Ext.Panel, {
 
     _fireAddEvent: function() {
         this.fireEvent('addFilter', this);
+    },
+
+    _addLabel: function() {
+        this.add(new Ext.form.Label({
+            html: "<label>" + this.filter.getLabel() + "</label>"
+        }));
     }
 });

--- a/web-app/js/portal/filter/ui/ComboFilterPanel.js
+++ b/web-app/js/portal/filter/ui/ComboFilterPanel.js
@@ -18,9 +18,7 @@ Portal.filter.ui.ComboFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel,
     },
 
     _createControls: function() {
-        this.add(new Ext.form.Label({
-            html: "<label>" + this.filter.getLabel() + "</label>"
-        }));
+        this._addLabel();
 
         this.combo = new Ext.form.ComboBox({
             disabled: true,

--- a/web-app/js/portal/filter/ui/DateFilterPanel.js
+++ b/web-app/js/portal/filter/ui/DateFilterPanel.js
@@ -27,9 +27,15 @@ Portal.filter.ui.DateFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel, 
         this.fromDate = this._createResettableDate('fromDate', OpenLayers.i18n('fromDateLabel'), OpenLayers.i18n('fromDateEmptyText'));
         this.toDate = this._createResettableDate('toDate', OpenLayers.i18n('toDateLabel'), OpenLayers.i18n('toDateEmptyText'));
 
+        if (this._shouldIncludeLabel()) {
+            this._addLabel();
+            this._addVerticalSpacer(5);
+        }
+
         this.add(this.fromDate);
         this._addVerticalSpacer(5);
         this.add(this.toDate);
+        this._addVerticalSpacer(15);
 
         if (this.filter.values != undefined) {
             this._setMinMax(this.fromDate, this.filter.values);
@@ -56,6 +62,11 @@ Portal.filter.ui.DateFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel, 
                 height: sizeInPixels
             })
         );
+    },
+
+    _shouldIncludeLabel: function() {
+
+        return !this.filter.isPrimary();
     },
 
     _createResettableDate: function(name, fieldLabel, emptyText) {

--- a/web-app/js/portal/filter/ui/NumberFilterPanel.js
+++ b/web-app/js/portal/filter/ui/NumberFilterPanel.js
@@ -27,9 +27,7 @@ Portal.filter.ui.NumberFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel
     },
 
     _createControls: function() {
-        var label = new Ext.form.Label({
-            html: "<label>" + this.filter.getLabel() + "</label>"
-        });
+        this._addLabel();
 
         this.operators = new Ext.form.ComboBox({
             triggerAction: 'all',


### PR DESCRIPTION
This addresses issue #1675

It introduces a new concept of a primary filter. This is based on some upcoming work where the geographic filter will be above and outside all layers (aka accordion) as will the temporal extent. However, we support more than one temporal extent so when that work happens we'll need a way to determine which is the primary temporal filter (which should therefore go outside the normal list of filters). For now a time filter is the primary if it is the only one for that layer. I'm happy to talk about this if my idea needs clarification.