### PR TITLE
Remove unused Filter getType() function

### DIFF
--- a/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
@@ -31,11 +31,9 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
                 server: {
                     uri: {}
                 },
-                filters: [{
-                    getType: function() {
-                        return Boolean;
-                    }
-                }]
+                filters: [
+                    { /* some filter */ }
+                ]
             };
 
             cfg = {

--- a/web-app/js/portal/filter/Filter.js
+++ b/web-app/js/portal/filter/Filter.js
@@ -46,11 +46,6 @@ Portal.filter.Filter = Ext.extend(Object, {
         return this.label;
     },
 
-    getType: function() {
-
-        return this.type;
-    },
-
     isVisualised: function() {
 
         return this.visualised;


### PR DESCRIPTION
This is left over from the filters prototype. Things have changed in such a way that this function isn't used anymore.