### PR TITLE
Add multiple collections with ctrl+click

### DIFF
--- a/src/test/javascript/portal/cart/DownloadPanelSpec.js
+++ b/src/test/javascript/portal/cart/DownloadPanelSpec.js
@@ -27,14 +27,14 @@ describe("Portal.cart.DownloadPanel", function() {
         });
 
         describe('active geonetwork record events', function() {
-            it('listens for ACTIVE_GEONETWORK_RECORD_ADDED event', function() {
-                Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED);
+            it('listens for DATA_COLLECTION_ADDED event', function() {
+                Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_ADDED);
 
                 expect(downloadPanel.generateContent).toHaveBeenCalled();
             });
 
-            it('listens for ACTIVE_GEONETWORK_RECORD_REMOVED event', function() {
-                Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED);
+            it('listens for DATA_COLLECTION_REMOVED event', function() {
+                Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_REMOVED);
 
                 expect(downloadPanel.generateContent).toHaveBeenCalled();
             });

--- a/src/test/javascript/portal/data/ActiveGeoNetworkRecordStoreSpec.js
+++ b/src/test/javascript/portal/data/ActiveGeoNetworkRecordStoreSpec.js
@@ -69,14 +69,14 @@ describe("Portal.data.ActiveGeoNetworkRecordStore", function() {
             describe('when adding/removing records', function() {
                 it('geonetwork added message is fired', function() {
                     activeRecordStore.add(myRecord);
-                    expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, myRecord);
+                    expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.DATA_COLLECTION_ADDED, myRecord);
                 });
 
                 it('geonetwork removed message is fired', function() {
                     activeRecordStore.add(myRecord);
 
                     activeRecordStore.remove(myRecord);
-                    expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED, myRecord);
+                    expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.DATA_COLLECTION_REMOVED, myRecord);
                 });
             });
         });
@@ -234,7 +234,7 @@ describe("Portal.data.ActiveGeoNetworkRecordStore", function() {
                 it('published activegeonetworkrecordremoved', function() {
                     spyOn(Ext.MsgBus, 'publish');
                     activeRecordStore.removeAll();
-                    expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED);
+                    expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.DATA_COLLECTION_REMOVED);
                 });
 
                 it('publishes reset', function() {

--- a/src/test/javascript/portal/details/NcWmsPanelSpec.js
+++ b/src/test/javascript/portal/details/NcWmsPanelSpec.js
@@ -71,10 +71,10 @@ describe('Portal.details.NcWmsPanel', function() {
             expect(ncwmsPanel.geoNetworkRecord.updateNcwmsParams).toHaveBeenCalled();
         });
 
-        it('calls ACTIVE_GEONETWORK_RECORD_MODIFIED when the record changes', function() {
+        it('calls DATA_COLLECTION_MODIFIED when the record changes', function() {
             spyOn(Ext.MsgBus, 'publish');
             ncwmsPanel._applyFilterValuesToCollection();
-            expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_MODIFIED);
+            expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.DATA_COLLECTION_MODIFIED);
             delete ncwmsPanel.geoNetworkRecord;
         });
 

--- a/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
@@ -18,6 +18,7 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
         layer.server = { uri: "uri" };
         layer.getDownloadLayer = function() { return "downloadLayer"; };
         layer.isKnownToThePortal = function() { return true; };
+        layer.map = getMockMap();
 
         filterGroupPanel = new Portal.filter.ui.FilterGroupPanel({
             layer: layer
@@ -90,7 +91,7 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
             });
             var numberPanel =  new Portal.filter.ui.NumberFilterPanel();
             var geometryPanel = new Portal.filter.ui.GeometryFilterPanel({
-                layer: { map: getMockMap() }
+                map: getMockMap()
             });
             var datePanel = new Portal.filter.ui.DateFilterPanel();
             var comboPanel = new Portal.filter.ui.ComboFilterPanel();

--- a/src/test/javascript/portal/filter/ui/GeometryFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/GeometryFilterPanelSpec.js
@@ -18,9 +18,7 @@ describe("Portal.filter.ui.GeometryFilterPanel", function() {
         spyOn(Portal.filter.ui.GeometryFilterPanel.prototype, 'setLayerAndFilter');
         spyOn(Portal.filter.ui.GeometryFilterPanel.prototype, '_updateWithGeometry');
         filterPanel = new Portal.filter.ui.GeometryFilterPanel({
-            layer: {
-                map: map
-            },
+            map: map,
             filter: {
                 getName: function() { return 'geom_filter' },
                 setValue: noOp,

--- a/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
@@ -27,7 +27,7 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
             expect(facetedSearchDataView.getUniqueId(0,"1231-456-789")).toBe(facetedSearchDataView.MAP_ID_PREFIX + "-0-1231-456-789");
         });
         it('decodes correctly', function() {
-            expect(facetedSearchDataView.decodeSuperUuid("-0-1231-456-789")).toBe("1231-456-789");
+            expect(facetedSearchDataView.uuidFromElementId("-0-1231-456-789")).toBe("1231-456-789");
         });
     });
 
@@ -91,7 +91,7 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
                 hasWmsLink: noOp
             };
 
-            facetedSearchDataView.decodeSuperUuid = function() {
+            facetedSearchDataView.uuidFromElementId = function() {
                 return "my uuid";
             };
 

--- a/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
@@ -21,13 +21,6 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
         );
     });
 
-    describe ('TPL parameters', function() {
-        it('has TPL parameters set', function() {
-            expect(facetedSearchDataView.resultBodyHeight).not.toBeNull();
-            expect(facetedSearchDataView.textBodyLeftMargin).not.toBeNull();
-        });
-    });
-
     describe ('encoding and decoding', function() {
         it('encodes correctly', function() {
             expect(facetedSearchDataView.superEncodeUuid(0,"1231-456-789")).toBe("-0-1231-456-789");

--- a/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
@@ -105,12 +105,27 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
             facetedSearchDataView._getRecordFromUuid = function() {
                 return record;
             };
+
+            spyOn(window, 'trackUsage');
+            spyOn(Ext.MsgBus, 'publish');
         });
 
         it('sends correct tracking data', function() {
-            spyOn(window, 'trackUsage');
-            facetedSearchDataView.addRecordFromSuperUuid("my super uuid");
+
+            facetedSearchDataView.addRecordFromSuperUuid("my super uuid", false);
             expect(window.trackUsage).toHaveBeenCalledWith("Collection", "select", "Argo Australia Profiles");
+        });
+
+        it('sends view event for normal select', function() {
+
+            facetedSearchDataView.addRecordFromSuperUuid("my super uuid", false);
+            expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, record);
+        });
+
+        it('does not send view event when multi selecting', function() {
+
+            facetedSearchDataView.addRecordFromSuperUuid("my super uuid", true);
+            expect(Ext.MsgBus.publish).not.toHaveBeenCalled();
         });
     });
 

--- a/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
@@ -78,7 +78,7 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
         });
     });
 
-    describe('addRecordFromSuperUuid', function () {
+    describe('addRecordWithUuid', function () {
         var record;
 
         beforeEach(function() {
@@ -105,19 +105,19 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
 
         it('sends correct tracking data', function() {
 
-            facetedSearchDataView.addRecordFromSuperUuid("my super uuid", false);
+            facetedSearchDataView.addRecordWithUuid("my super uuid", false);
             expect(window.trackUsage).toHaveBeenCalledWith("Collection", "select", "Argo Australia Profiles");
         });
 
         it('sends view event for normal select', function() {
 
-            facetedSearchDataView.addRecordFromSuperUuid("my super uuid", false);
+            facetedSearchDataView.addRecordWithUuid("my super uuid", false);
             expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.VIEW_DATA_COLLECTION, record);
         });
 
         it('does not send view event when multi selecting', function() {
 
-            facetedSearchDataView.addRecordFromSuperUuid("my super uuid", true);
+            facetedSearchDataView.addRecordWithUuid("my super uuid", true);
             expect(Ext.MsgBus.publish).not.toHaveBeenCalled();
         });
     });

--- a/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
@@ -87,16 +87,15 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
 
     describe('addRecordFromSuperUuid', function () {
         var record;
-        var mockRecordStore;
 
         beforeEach(function() {
             record = {
                 data: {
                     title: "Argo Australia Profiles"
                 },
-                get: function() { noOp() },
-                join: function() { noOp() },
-                hasWmsLink: function() { noOp() }
+                get: noOp,
+                join: noOp,
+                hasWmsLink: noOp
             };
 
             facetedSearchDataView.decodeSuperUuid = function() {
@@ -126,7 +125,6 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
                 return params;
             };
         });
-
 
         it('with some parameters', function() {
             params = ['temp', 'salinity'];

--- a/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
@@ -112,7 +112,7 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
         it('sends view event for normal select', function() {
 
             facetedSearchDataView.addRecordFromSuperUuid("my super uuid", false);
-            expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, record);
+            expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.VIEW_DATA_COLLECTION, record);
         });
 
         it('does not send view event when multi selecting', function() {

--- a/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
@@ -23,11 +23,11 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
 
     describe ('encoding and decoding', function() {
         it('encodes correctly', function() {
-            expect(facetedSearchDataView.superEncodeUuid(0,"1231-456-789")).toBe("-0-1231-456-789");
-            expect(facetedSearchDataView.getUniqueId(0,"1231-456-789")).toBe(facetedSearchDataView.MAP_ID_PREFIX + "-0-1231-456-789");
+            expect(facetedSearchDataView.elementIdFromUuid('prefix', "1231-456-789")).toBe("prefix-1231-456-789");
+            expect(facetedSearchDataView.mapElementId("1231-456-789")).toBe(facetedSearchDataView.MAP_ID_PREFIX + "-1231-456-789");
         });
         it('decodes correctly', function() {
-            expect(facetedSearchDataView.uuidFromElementId("-0-1231-456-789")).toBe("1231-456-789");
+            expect(facetedSearchDataView.uuidFromElementId(facetedSearchDataView.MAP_ID_PREFIX + "-1231-456-789")).toBe("1231-456-789");
         });
     });
 

--- a/src/test/javascript/portal/search/FacetedSearchResultsMiniMapSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsMiniMapSpec.js
@@ -9,7 +9,7 @@ describe("Portal.search.FacetedSearchResultsMiniMap", function() {
     var bbox;
     var uuid = 1234;
     var storeRowIndex = 0;
-    var mapContainerId = "aUniqueIdCreatedBy-FacetedSearchResultsDataView-getUniqueId";
+    var mapContainerId = "aUniqueIdCreatedBy-FacetedSearchResultsDataView-mapElementId";
 
     beforeEach(function() {
         bbox = new Portal.search.MetadataExtent();

--- a/src/test/javascript/portal/search/FacetedSearchResultsPanelSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsPanelSpec.js
@@ -38,13 +38,13 @@ describe("Portal.search.FacetedSearchResultsPanel", function() {
     describe('active geo network record store events', function() {
         it('refreshes view on record added', function() {
             spyOn(resultsPanel, '_refreshView');
-            Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED);
+            Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_ADDED);
             expect(resultsPanel._refreshView).toHaveBeenCalled();
         });
 
         it('refreshes view on record removed', function() {
             spyOn(resultsPanel, '_refreshView');
-            Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED);
+            Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_REMOVED);
             expect(resultsPanel._refreshView).toHaveBeenCalled();
         });
     });

--- a/src/test/javascript/portal/ui/DownloadCartWidgetSpec.js
+++ b/src/test/javascript/portal/ui/DownloadCartWidgetSpec.js
@@ -17,20 +17,20 @@ describe("Portal.ui.DownloadCartWidget", function() {
         expect(downloadCartWidget.downloadCartSize).not.toBeNull();
     });
 
-    it('listens for ACTIVE_GEONETWORK_RECORD_ADDED event', function() {
+    it('listens for DATA_COLLECTION_ADDED event', function() {
         spyOn(downloadCartWidget, 'updateDownloadCartSize');
-        Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED);
+        Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_ADDED);
         expect(downloadCartWidget.updateDownloadCartSize).toHaveBeenCalled();
 
     });
 
     it('one record is added', function() {
-        Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED);
+        Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_ADDED);
         expect(downloadCartWidget.getCollectionCounterAsString()).toEqual("1");
     });
 
     it('it clears', function() {
-        Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED);
+        Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_ADDED);
         Ext.MsgBus.publish(PORTAL_EVENTS.RESET);
         expect(downloadCartWidget.getCollectionCounterAsString()).toEqual("0");
     });

--- a/src/test/javascript/portal/ui/MainPanelSpec.js
+++ b/src/test/javascript/portal/ui/MainPanelSpec.js
@@ -25,7 +25,7 @@ describe("Portal.ui.MainPanel", function() {
     });
 
     afterEach(function() {
-        Ext.MsgBus.unsubscribe(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, mainPanel._onViewGeoNetworkRecord, mainPanel);
+        Ext.MsgBus.unsubscribe(PORTAL_EVENTS.VIEW_DATA_COLLECTION, mainPanel._onViewGeoNetworkRecord, mainPanel);
     });
 
     describe('initialisation', function() {
@@ -58,7 +58,7 @@ describe("Portal.ui.MainPanel", function() {
 
         it('should set visualise to active item when geonetwork record is viewed', function() {
             spyOn(mainPanel.layout, 'setActiveItem');
-            Ext.MsgBus.publish(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD);
+            Ext.MsgBus.publish(PORTAL_EVENTS.VIEW_DATA_COLLECTION);
             expect(mainPanel.layout.setActiveItem).toHaveBeenCalledWith(TAB_INDEX_VISUALISE);
         });
 

--- a/src/test/javascript/portal/ui/MapPanelSpec.js
+++ b/src/test/javascript/portal/ui/MapPanelSpec.js
@@ -131,7 +131,7 @@ describe("Portal.ui.MapPanel", function() {
     describe('geonetwork record added event', function() {
         it('maximises map actions control on active geonetork record added event', function() {
             spyOn(mapPanel, '_maximiseMapActionsControl');
-            Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED);
+            Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_ADDED);
             expect(mapPanel._maximiseMapActionsControl).toHaveBeenCalled();
         });
     });

--- a/src/test/javascript/portal/ui/VisualisePanelSpec.js
+++ b/src/test/javascript/portal/ui/VisualisePanelSpec.js
@@ -64,7 +64,7 @@ describe('Portal.ui.VisualisePanel', function() {
     describe('record added', function() {
         it('expands details panel', function() {
             spyOn(visualisePanel.detailsPanel, 'expand');
-            Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED);
+            Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_ADDED);
             expect(visualisePanel.detailsPanel.expand).toHaveBeenCalled();
         });
     });

--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -618,8 +618,8 @@ table.featureInfo caption {
     filter: alpha(opacity=0); /* IE6/IE7 */
 }
 
-div.olMap.miniMap{
-    border: 1px solid #ccc;
+div.olMap.miniMap {
+    border: 1px solid #ccc !important;
 }
 
 div.olMap.miniMap:hover:not(.x-item-disabled) {

--- a/web-app/js/portal/PortalEvents.js
+++ b/web-app/js/portal/PortalEvents.js
@@ -1,15 +1,15 @@
 var PORTAL_EVENTS = {
-    BEFORE_SELECTED_LAYER_CHANGED:      "beforeSelectedLayerChanged",
-    SELECTED_LAYER_CHANGED:             "selectedLayerChanged",
-    BASE_LAYER_CHANGED:                 "baseLayerChanged",
-    LAYER_REMOVED:                      "layerRemoved",
-    LAYER_LOADING_START:                "layerLoadingStart",
-    LAYER_LOADING_END:                  "layerLoadingEnd",
-    BASE_LAYER_LOADED_FROM_SERVER:      "baseLayersLoadedFromServer",
-    DATA_COLLECTION_ADDED:              "dataCollectionAdded",
-    DATA_COLLECTION_MODIFIED:           "dataCollectionModified",
-    DATA_COLLECTION_REMOVED:            "dataCollectionRemoved",
-    VIEW_DATA_COLLECTION:               "viewDataCollection",
-    RESET:                              "reset",
-    LOAD_SNAPSHOT:                      "loadSnapshot"
+    BEFORE_SELECTED_LAYER_CHANGED: "beforeSelectedLayerChanged",
+    SELECTED_LAYER_CHANGED:        "selectedLayerChanged",
+    BASE_LAYER_CHANGED:            "baseLayerChanged",
+    LAYER_REMOVED:                 "layerRemoved",
+    LAYER_LOADING_START:           "layerLoadingStart",
+    LAYER_LOADING_END:             "layerLoadingEnd",
+    BASE_LAYER_LOADED_FROM_SERVER: "baseLayersLoadedFromServer",
+    DATA_COLLECTION_ADDED:         "dataCollectionAdded",
+    DATA_COLLECTION_MODIFIED:      "dataCollectionModified",
+    DATA_COLLECTION_REMOVED:       "dataCollectionRemoved",
+    VIEW_DATA_COLLECTION:          "viewDataCollection",
+    RESET:                         "reset",
+    LOAD_SNAPSHOT:                 "loadSnapshot"
 };

--- a/web-app/js/portal/PortalEvents.js
+++ b/web-app/js/portal/PortalEvents.js
@@ -1,4 +1,4 @@
-PORTAL_EVENTS = {
+var PORTAL_EVENTS = {
     BEFORE_SELECTED_LAYER_CHANGED:      "beforeSelectedLayerChanged",
     SELECTED_LAYER_CHANGED:             "selectedLayerChanged",
     BASE_LAYER_CHANGED:                 "baseLayerChanged",
@@ -6,10 +6,10 @@ PORTAL_EVENTS = {
     LAYER_LOADING_START:                "layerLoadingStart",
     LAYER_LOADING_END:                  "layerLoadingEnd",
     BASE_LAYER_LOADED_FROM_SERVER:      "baseLayersLoadedFromServer",
-    ACTIVE_GEONETWORK_RECORD_ADDED:     "activeGeonetworkRecordAdded",
-    ACTIVE_GEONETWORK_RECORD_MODIFIED:  "activeGeonetworkRecordModified",
-    ACTIVE_GEONETWORK_RECORD_REMOVED:   "activeGeonetworkRecordRemoved",
-    VIEW_GEONETWORK_RECORD:             "viewGeonetworkRecord",
+    DATA_COLLECTION_ADDED:              "dataCollectionAdded",
+    DATA_COLLECTION_MODIFIED:           "dataCollectionModified",
+    DATA_COLLECTION_REMOVED:            "dataCollectionRemoved",
+    VIEW_DATA_COLLECTION:               "viewDataCollection",
     RESET:                              "reset",
     LOAD_SNAPSHOT:                      "loadSnapshot"
 };

--- a/web-app/js/portal/cart/DownloadPanel.js
+++ b/web-app/js/portal/cart/DownloadPanel.js
@@ -63,9 +63,9 @@ Portal.cart.DownloadPanel = Ext.extend(Ext.Panel, {
 
     _registerEvents: function() {
         this.on('beforeshow', function() { this.generateContent() }, this);
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, function() { this.generateContent() }, this);
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_MODIFIED, function() { this.generateContent() }, this);
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED, function() { this.generateContent() }, this);
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.DATA_COLLECTION_ADDED, function() { this.generateContent() }, this);
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.DATA_COLLECTION_MODIFIED, function() { this.generateContent() }, this);
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.DATA_COLLECTION_REMOVED, function() { this.generateContent() }, this);
     },
 
     onDownloadRequested: function(downloadUrl, collection) {

--- a/web-app/js/portal/data/ActiveGeoNetworkRecordStore.js
+++ b/web-app/js/portal/data/ActiveGeoNetworkRecordStore.js
@@ -58,13 +58,13 @@ Portal.data.ActiveGeoNetworkRecordStore = Ext.extend(Portal.data.GeoNetworkRecor
 
     _recordLoaded: function(geoNetworkRecord) {
         geoNetworkRecord.loaded = true;
-        Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, geoNetworkRecord);
+        Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_ADDED, geoNetworkRecord);
     },
 
     _onRemove: function(store, record) {
         this._removeRecordAttributes(record);
         this._removeFromLayerStore(record);
-        Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED, record);
+        Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_REMOVED, record);
     },
 
     _removeFromLayerStore: function(record) {
@@ -105,7 +105,7 @@ Portal.data.ActiveGeoNetworkRecordStore = Ext.extend(Portal.data.GeoNetworkRecor
 
     removeAll: function(store) {
         Portal.data.ActiveGeoNetworkRecordStore.superclass.removeAll.call(this);
-        Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED);
+        Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_REMOVED);
         Ext.MsgBus.publish(PORTAL_EVENTS.RESET);
     },
 

--- a/web-app/js/portal/data/GeoNetworkRecordFetcher.js
+++ b/web-app/js/portal/data/GeoNetworkRecordFetcher.js
@@ -37,7 +37,7 @@ Portal.data.GeoNetworkRecordFetcher = Ext.extend(Ext.util.Observable, {
             var record = store.getAt(0);
 
             Portal.data.ActiveGeoNetworkRecordStore.instance().add(record);
-            Ext.MsgBus.publish(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, record);
+            Ext.MsgBus.publish(PORTAL_EVENTS.VIEW_DATA_COLLECTION, record);
         });
     },
 

--- a/web-app/js/portal/details/NcWmsPanel.js
+++ b/web-app/js/portal/details/NcWmsPanel.js
@@ -352,7 +352,7 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Container, {
         if (this.geoNetworkRecord) {
             this._addDateTimeFilterToLayer();
             this.geoNetworkRecord.updateNcwmsParams(dateRangeStart, dateRangeEnd, geometry);
-            Ext.MsgBus.publish(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_MODIFIED);
+            Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_MODIFIED);
         }
     },
 

--- a/web-app/js/portal/details/SpatialSubsetControlsPanel.js
+++ b/web-app/js/portal/details/SpatialSubsetControlsPanel.js
@@ -9,6 +9,13 @@ Ext.namespace('Portal.details');
 
 Portal.details.SpatialSubsetControlsPanel = Ext.extend(Ext.Panel, {
 
+    constructor: function(cfg) {
+
+        this.map = cfg.map;
+
+        Portal.details.SpatialSubsetControlsPanel.superclass.constructor.call(this, cfg);
+    },
+
     initComponent: function() {
         Portal.details.SpatialSubsetControlsPanel.superclass.initComponent.call(this);
         this._addLabel(OpenLayers.i18n('spatialExtentHeading'));

--- a/web-app/js/portal/details/SubsetPanel.js
+++ b/web-app/js/portal/details/SubsetPanel.js
@@ -24,6 +24,7 @@ Portal.details.SubsetPanel = Ext.extend(Ext.Container, {
         }
         else {
             var filterGroupPanel = new Portal.filter.ui.FilterGroupPanel({
+                map: cfg.map,
                 layer: cfg.layer
             });
 

--- a/web-app/js/portal/details/SubsetPanel.js
+++ b/web-app/js/portal/details/SubsetPanel.js
@@ -10,31 +10,16 @@ Portal.details.SubsetPanel = Ext.extend(Ext.Container, {
 
     constructor: function(cfg) {
 
-        this.layer = cfg.layer;
-
-        var items = [];
-
-        if (this.layer.isNcwms()) {
-            var ncwmsPanel = new Portal.details.NcWmsPanel({
-                map: cfg.map,
-                layer: cfg.layer
-            });
-
-            items.push(ncwmsPanel);
-        }
-        else {
-            var filterGroupPanel = new Portal.filter.ui.FilterGroupPanel({
-                map: cfg.map,
-                layer: cfg.layer
-            });
-
-            items.push(filterGroupPanel);
-        }
+        var panelType = cfg.layer.isNcwms() ? Portal.details.NcWmsPanel : Portal.filter.ui.FilterGroupPanel;
+        var newPanel = new panelType({
+            map: cfg.map,
+            layer: cfg.layer
+        });
 
         var config = Ext.apply({
             title: OpenLayers.i18n('subsetPanelTitle'),
             hideMode: 'offsets', // fixes #1278
-            items: items
+            items: [newPanel]
         }, cfg);
 
         Portal.details.SubsetPanel.superclass.constructor.call(this, config);

--- a/web-app/js/portal/filter/ui/FilterGroupPanel.js
+++ b/web-app/js/portal/filter/ui/FilterGroupPanel.js
@@ -11,6 +11,7 @@ Portal.filter.ui.FilterGroupPanel = Ext.extend(Ext.Container, {
     constructor: function(cfg) {
 
         this.layer = cfg.layer;
+        this.map = cfg.map;
         this.loadingMessage = this._createLoadingMessageContainer();
         var config = Ext.apply({
             autoDestroy: true,
@@ -200,7 +201,8 @@ Portal.filter.ui.FilterGroupPanel = Ext.extend(Ext.Container, {
         var uiElementClass = filterClass.prototype.getUiComponentClass();
         var newFilterPanel = new uiElementClass({
             filter: filter,
-            layer: this.layer
+            layer: this.layer,
+            map: this.map
         });
 
         this.relayEvents(newFilterPanel, ['addFilter']);

--- a/web-app/js/portal/filter/ui/GeometryFilterPanel.js
+++ b/web-app/js/portal/filter/ui/GeometryFilterPanel.js
@@ -17,7 +17,7 @@ Portal.filter.ui.GeometryFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPan
 
         Portal.filter.ui.GeometryFilterPanel.superclass.constructor.call(this, config);
 
-        this.map = cfg.layer.map;
+        this.map = cfg.map;
         this.map.events.on({
             scope: this,
             'spatialconstraintadded': function(geometry) {
@@ -32,15 +32,15 @@ Portal.filter.ui.GeometryFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPan
     setLayerAndFilter: function(layer, filter) {
         Portal.filter.ui.GeometryFilterPanel.superclass.setLayerAndFilter.apply(this, arguments);
 
-        if (layer.map.spatialConstraintControl) {
-            this._updateWithGeometry(layer.map.spatialConstraintControl.getConstraint());
-            filter.map = layer.map;
+        if (this.map.spatialConstraintControl) {
+            this._updateWithGeometry(this.map.spatialConstraintControl.getConstraint());
+            filter.map = this.map;
         }
     },
 
     _createControls: function() {
         this.spatialSubsetControlsPanel = new Portal.details.SpatialSubsetControlsPanel({
-            map: this.layer.map,
+            map: this.map,
             hideLabel: true
         });
         this.add(this.spatialSubsetControlsPanel);

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -20,9 +20,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
 
         this.rowId = 0;
 
-        this.setTplSizeVariables();
-
-        var tpl = new Ext.XTemplate(
+        this.tpl = new Ext.XTemplate(
             '<tpl for=".">',
             '<div class="resultsHeaderBackground">',
             '    <div class="x-panel-header">',
@@ -65,18 +63,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
             }
         );
 
-        var config = {
-            store: this.store,
-            tpl: tpl
-        };
-
-        Ext.apply(this, config);
         Portal.search.FacetedSearchResultsDataView.superclass.initComponent.apply(this, arguments);
-    },
-
-    setTplSizeVariables: function() {
-        this.resultBodyHeight = this.MINIMAP_HEIGHT + (2 * this.MINIMAP_PADDING) + 2;
-        this.textBodyLeftMargin = this.MINIMAP_WIDTH + (2 * this.MINIMAP_PADDING);
     },
 
     addMinimapLink: function(storeRowIndex, uuid) {

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -83,10 +83,14 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
 
         var that = this;
         var selector = '#' + this.getUniqueId(storeRowIndex, uuid);
-        jQuery(selector).live("click", that, function() {
+        jQuery(selector).live("click", that, function(clickEvent) {
+
+            var multiSelect = clickEvent.ctrlKey;
             var superUuid = jQuery(this).attr('id').replace(this.MAP_ID_PREFIX, '');
-            that.addRecordFromSuperUuid(superUuid);
+            that.addRecordFromSuperUuid(superUuid, multiSelect);
+
             jQuery(this).addClass("x-item-disabled");
+
             return false;
         });
     },
@@ -316,14 +320,16 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         return chunks.join("-");
     },
 
-    _viewButtonOnClick: function(btn) {
+    _viewButtonOnClick: function(btn, clickEvent) {
+
+        var multiSelect = clickEvent.ctrlKey;
+        var superUuid = btn.container.id.replace("fsSearchAddBtn", '');
+        this.addRecordFromSuperUuid(superUuid, multiSelect);
 
         btn.addClass("x-btn-selected");
-        var superUuid = btn.container.id.replace("fsSearchAddBtn", '');
-        this.addRecordFromSuperUuid(superUuid);
     },
 
-    addRecordFromSuperUuid: function(superUuid) {
+    addRecordFromSuperUuid: function(superUuid, multiSelect) {
         var uuid = this.decodeSuperUuid(superUuid);
         var record = this._getRecordFromUuid(uuid);
 
@@ -333,7 +339,10 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
 
             Portal.data.ActiveGeoNetworkRecordStore.instance().add(record);
         }
-        Ext.MsgBus.publish(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, record);
+
+        if (!multiSelect) {
+            Ext.MsgBus.publish(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, record);
+        }
     }
 });
 

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -19,8 +19,6 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
 
     initComponent: function() {
 
-        this.rowId = 0;
-
         this.tpl = new Ext.XTemplate(
             '<tpl for=".">',
             '<div class="resultsHeaderBackground">',
@@ -49,7 +47,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
             this,
             {
                 getButton: function(values) {
-                    this.createButton.defer(1, this, [values.uuid, values.storeRowIndex]);
+                    this.createButton.defer(1, this, [values.uuid]);
                     return "";
                 },
                 getStatusClasses: function(values) {
@@ -64,7 +62,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         Portal.search.FacetedSearchResultsDataView.superclass.initComponent.apply(this, arguments);
     },
 
-    addMinimapLink: function(storeRowIndex, uuid) {
+    addMinimapLink: function(uuid) {
 
         var that = this;
         var selector = '#' + this.mapElementId(uuid);
@@ -78,23 +76,6 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
 
             return false;
         });
-    },
-
-    collectData: function(records, startIndex) {
-        var r = [];
-
-        for (var i = 0; i < records.length; i++) {
-            var newRecord = this.prepareData(records[i].data, startIndex + i, records[i]);
-            newRecord = this._addStoreRowCount(newRecord);
-            r[r.length] = newRecord;
-        }
-        return r;
-    },
-
-    _addStoreRowCount: function(record) {
-        record['storeRowIndex'] = this.rowId;
-        this.rowId++;
-        return record;
     },
 
     getParametersAsHtml: function(values) {
@@ -209,7 +190,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         return moment(dateString, this.DATE_FACET_INPUT_FORMAT);
     },
 
-    createButton: function(uuid, storeRowIndex) {
+    createButton: function(uuid) {
         var cls = "";
         var tooltip = OpenLayers.i18n('collectionExistsMsg');
 
@@ -268,7 +249,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         var miniMap = new Portal.search.FacetedSearchResultsMiniMap(values);
         miniMap.addLayersAndRender();
 
-        this.addMinimapLink(values.storeRowIndex, values.uuid);
+        this.addMinimapLink(values.uuid);
 
         // Must return something, otherwise 'undefined' is rendered in the mini map div in some browsers,
         // e.g. firefox (but not chrome).

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -14,6 +14,8 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
     MINIMAP_PADDING: 4,
     MAP_ID_PREFIX: "facetedSearchMap",
     ADD_BUTTON_PREFIX: "fsSearchAddBtn",
+    CSS_CLASS_ITEM_DISABLED: 'x-item-disabled',
+    CSS_CLASS_BUTTON_SELECTED: 'x-btn-selected',
 
     DATE_FACET_INPUT_FORMAT: 'YYYY-MM-DDtHH:mm:ss:SSSz',
 
@@ -51,7 +53,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
                     return "";
                 },
                 getStatusClasses: function(values) {
-                    return (this.isRecActive(values.uuid)) ? "x-item-disabled" : "";
+                    return (this.isRecActive(values.uuid)) ? this.CSS_CLASS_ITEM_DISABLED : "";
                 },
                 getMiniMapLinkTitle: function(values) {
                     return (this.isRecActive(values.uuid)) ? OpenLayers.i18n('collectionExistsMsg') : OpenLayers.i18n("addDataCollectionMsg");
@@ -72,7 +74,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
             var uuid = this.uuidFromElementId(jQuery(this).attr('id'));
             that.addRecordWithUuid(uuid, multiSelect);
 
-            jQuery(this).addClass("x-item-disabled");
+            jQuery(this).addClass(this.CSS_CLASS_ITEM_DISABLED);
 
             return false;
         });
@@ -195,7 +197,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         var tooltip = OpenLayers.i18n('collectionExistsMsg');
 
         if (this.isRecActive(uuid)) {
-            cls = "x-btn-selected";
+            cls = this.CSS_CLASS_BUTTON_SELECTED;
         }
         else {
             tooltip = OpenLayers.i18n('addDataCollectionMsg');
@@ -295,7 +297,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         var uuid = this.uuidFromElementId(btn.container.id);
         this.addRecordWithUuid(uuid, multiSelect);
 
-        btn.addClass("x-btn-selected");
+        btn.addClass(this.CSS_CLASS_BUTTON_SELECTED);
     },
 
     addRecordWithUuid: function(uuid, multiSelect) {

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -69,7 +69,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         jQuery(selector).live("click", that, function(clickEvent) {
 
             var multiSelect = clickEvent.ctrlKey;
-            var superUuid = jQuery(this).attr('id').replace(this.MAP_ID_PREFIX, '');
+            var superUuid = this.uuidFromElementId(jQuery(this).attr('id'));
             that.addRecordFromSuperUuid(superUuid, multiSelect);
 
             jQuery(this).addClass("x-item-disabled");
@@ -292,14 +292,13 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
     _viewButtonOnClick: function(btn, clickEvent) {
 
         var multiSelect = clickEvent.ctrlKey;
-        var superUuid = btn.container.id.replace(this.ADD_BUTTON_PREFIX, '');
+        var superUuid = this.uuidFromElementId(btn.container.id);
         this.addRecordFromSuperUuid(superUuid, multiSelect);
 
         btn.addClass("x-btn-selected");
     },
 
-    addRecordFromSuperUuid: function(superUuid, multiSelect) {
-        var uuid = this.uuidFromElementId(superUuid);
+    addRecordFromSuperUuid: function(uuid, multiSelect) {
         var record = this._getRecordFromUuid(uuid);
 
         trackUsage(OpenLayers.i18n('layerSelectionTrackingCategory'), OpenLayers.i18n('layerSelectionTrackingAction'), record.data.title);

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -28,14 +28,14 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
             '        <div class="resultsRowHeaderTitle">',
             '            <h3>{[values.title]}</h3>',
             '        </div>',
-            '        <div class="facetedSearchBtn" id="{[this.ADD_BUTTON_PREFIX]}{[this.encode(values)]}">',
+            '        <div class="facetedSearchBtn" id="{[this.buttonElementId(values.uuid)]}">',
             '            {[this.getButton(values)]}',
             '        </div>',
             '    </div>',
             '    <div class="x-panel-body facetedSearchResultBody">',
             '         <div class="x-panel miniMap {[this.getStatusClasses(values)]}" title="{[this.getMiniMapLinkTitle(values)]}"',
             '            style="height:{[this.MINIMAP_HEIGHT]}px;width:{[this.MINIMAP_WIDTH]}px;margin:{[this.MINIMAP_PADDING]}px! important"',
-            '            id="{[this.MAP_ID_PREFIX]}{[this.encode(values)]}">',
+            '            id="{[this.mapElementId(values.uuid)]}">',
             '            {[this.getMiniMap(values)]}',
             '        </div>' +
             '        <div class="x-panel resultsTextBody {[this.getStatusClasses(values)]}">',
@@ -52,9 +52,6 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
                     this.createButton.defer(1, this, [values.uuid, values.storeRowIndex]);
                     return "";
                 },
-                encode: function(values) {
-                    return this.elementIdFromUuid('', values.uuid);
-                },
                 getStatusClasses: function(values) {
                     return (this.isRecActive(values.uuid)) ? "x-item-disabled" : "";
                 },
@@ -70,7 +67,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
     addMinimapLink: function(storeRowIndex, uuid) {
 
         var that = this;
-        var selector = '#' + this.getUniqueId(storeRowIndex, uuid);
+        var selector = '#' + this.mapElementId(uuid);
         jQuery(selector).live("click", that, function(clickEvent) {
 
             var multiSelect = clickEvent.ctrlKey;
@@ -223,7 +220,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
             tooltip = OpenLayers.i18n('addDataCollectionMsg');
         }
 
-        var buttonElementId = this.elementIdFromUuid(this.ADD_BUTTON_PREFIX, uuid);
+        var buttonElementId = this.buttonElementId(uuid);
 
         if (Ext.get(buttonElementId)) {
             new Ext.Button({
@@ -266,7 +263,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
 
     getMiniMap: function(values) {
 
-        values.mapContainerId = this.getUniqueId(values.storeRowIndex, values.uuid);
+        values.mapContainerId = this.mapElementId(values.uuid);
 
         var miniMap = new Portal.search.FacetedSearchResultsMiniMap(values);
         miniMap.addLayersAndRender();
@@ -293,8 +290,12 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         return record;
     },
 
-    getUniqueId: function(storeRowIndex, uuid) {
+    mapElementId: function(uuid) {
         return this.elementIdFromUuid(this.MAP_ID_PREFIX, uuid);
+    },
+
+    buttonElementId: function(uuid) {
+        return this.elementIdFromUuid(this.ADD_BUTTON_PREFIX, uuid);
     },
 
     elementIdFromUuid: function(prefix, uuid) {

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -13,6 +13,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
     MINIMAP_WIDTH: 160, // 16:9 ratio http://size43.com/jqueryVideoTool.html
     MINIMAP_PADDING: 4,
     MAP_ID_PREFIX: "facetedSearchMap",
+    ADD_BUTTON_PREFIX: "fsSearchAddBtn",
 
     DATE_FACET_INPUT_FORMAT: 'YYYY-MM-DDtHH:mm:ss:SSSz',
 
@@ -27,7 +28,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
             '        <div class="resultsRowHeaderTitle">',
             '            <h3>{[values.title]}</h3>',
             '        </div>',
-            '        <div class="facetedSearchBtn" id="fsSearchAddBtn{[this.encode(values)]}">',
+            '        <div class="facetedSearchBtn" id="{[this.ADD_BUTTON_PREFIX]}{[this.encode(values)]}">',
             '            {[this.getButton(values)]}',
             '        </div>',
             '    </div>',
@@ -222,7 +223,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
             tooltip = OpenLayers.i18n('addDataCollectionMsg');
         }
 
-        var buttonElementId = "fsSearchAddBtn" + this.superEncodeUuid(storeRowIndex, uuid);
+        var buttonElementId = this.ADD_BUTTON_PREFIX + this.superEncodeUuid(storeRowIndex, uuid);
 
         if (Ext.get(buttonElementId)) {
             new Ext.Button({
@@ -310,7 +311,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
     _viewButtonOnClick: function(btn, clickEvent) {
 
         var multiSelect = clickEvent.ctrlKey;
-        var superUuid = btn.container.id.replace("fsSearchAddBtn", '');
+        var superUuid = btn.container.id.replace(this.ADD_BUTTON_PREFIX, '');
         this.addRecordFromSuperUuid(superUuid, multiSelect);
 
         btn.addClass("x-btn-selected");

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -301,8 +301,8 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         return "-" + uuid;
     },
 
-    decodeSuperUuid: function(encodedUuid) {
-        var chunks = encodedUuid.split("-");
+    uuidFromElementId: function(elementId) {
+        var chunks = elementId.split("-");
         chunks.splice(0, 1);
         return chunks.join("-");
     },
@@ -317,7 +317,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
     },
 
     addRecordFromSuperUuid: function(superUuid, multiSelect) {
-        var uuid = this.decodeSuperUuid(superUuid);
+        var uuid = this.uuidFromElementId(superUuid);
         var record = this._getRecordFromUuid(uuid);
 
         trackUsage(OpenLayers.i18n('layerSelectionTrackingCategory'), OpenLayers.i18n('layerSelectionTrackingAction'), record.data.title);

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -69,8 +69,8 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         jQuery(selector).live("click", that, function(clickEvent) {
 
             var multiSelect = clickEvent.ctrlKey;
-            var superUuid = this.uuidFromElementId(jQuery(this).attr('id'));
-            that.addRecordFromSuperUuid(superUuid, multiSelect);
+            var uuid = this.uuidFromElementId(jQuery(this).attr('id'));
+            that.addRecordWithUuid(uuid, multiSelect);
 
             jQuery(this).addClass("x-item-disabled");
 
@@ -292,13 +292,13 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
     _viewButtonOnClick: function(btn, clickEvent) {
 
         var multiSelect = clickEvent.ctrlKey;
-        var superUuid = this.uuidFromElementId(btn.container.id);
-        this.addRecordFromSuperUuid(superUuid, multiSelect);
+        var uuid = this.uuidFromElementId(btn.container.id);
+        this.addRecordWithUuid(uuid, multiSelect);
 
         btn.addClass("x-btn-selected");
     },
 
-    addRecordFromSuperUuid: function(uuid, multiSelect) {
+    addRecordWithUuid: function(uuid, multiSelect) {
         var record = this._getRecordFromUuid(uuid);
 
         trackUsage(OpenLayers.i18n('layerSelectionTrackingCategory'), OpenLayers.i18n('layerSelectionTrackingAction'), record.data.title);

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -328,7 +328,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         }
 
         if (!multiSelect) {
-            Ext.MsgBus.publish(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, record);
+            Ext.MsgBus.publish(PORTAL_EVENTS.VIEW_DATA_COLLECTION, record);
         }
     }
 });

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -53,7 +53,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
                     return "";
                 },
                 encode: function(values) {
-                    return this.superEncodeUuid(values.uuid);
+                    return this.elementIdFromUuid('', values.uuid);
                 },
                 getStatusClasses: function(values) {
                     return (this.isRecActive(values.uuid)) ? "x-item-disabled" : "";
@@ -223,7 +223,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
             tooltip = OpenLayers.i18n('addDataCollectionMsg');
         }
 
-        var buttonElementId = this.ADD_BUTTON_PREFIX + this.superEncodeUuid(uuid);
+        var buttonElementId = this.elementIdFromUuid(this.ADD_BUTTON_PREFIX, uuid);
 
         if (Ext.get(buttonElementId)) {
             new Ext.Button({
@@ -294,11 +294,11 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
     },
 
     getUniqueId: function(storeRowIndex, uuid) {
-        return this.MAP_ID_PREFIX + this.superEncodeUuid(uuid);
+        return this.elementIdFromUuid(this.MAP_ID_PREFIX, uuid);
     },
 
-    superEncodeUuid: function(uuid) {
-        return "-" + uuid;
+    elementIdFromUuid: function(prefix, uuid) {
+        return String.format('{0}-{1}', prefix, uuid);
     },
 
     uuidFromElementId: function(elementId) {

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -53,7 +53,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
                     return "";
                 },
                 encode: function(values) {
-                    return this.superEncodeUuid(values.storeRowIndex, values.uuid);
+                    return this.superEncodeUuid(values.uuid);
                 },
                 getStatusClasses: function(values) {
                     return (this.isRecActive(values.uuid)) ? "x-item-disabled" : "";
@@ -223,7 +223,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
             tooltip = OpenLayers.i18n('addDataCollectionMsg');
         }
 
-        var buttonElementId = this.ADD_BUTTON_PREFIX + this.superEncodeUuid(storeRowIndex, uuid);
+        var buttonElementId = this.ADD_BUTTON_PREFIX + this.superEncodeUuid(uuid);
 
         if (Ext.get(buttonElementId)) {
             new Ext.Button({
@@ -294,17 +294,16 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
     },
 
     getUniqueId: function(storeRowIndex, uuid) {
-        return  this.MAP_ID_PREFIX + this.superEncodeUuid(storeRowIndex, uuid);
+        return this.MAP_ID_PREFIX + this.superEncodeUuid(uuid);
     },
 
-    // uuid alone is unique unless search results have duplicates
-    superEncodeUuid: function(storeRowIndex, uuid) {
-        return "-" + storeRowIndex + "-" + uuid;
+    superEncodeUuid: function(uuid) {
+        return "-" + uuid;
     },
 
     decodeSuperUuid: function(encodedUuid) {
         var chunks = encodedUuid.split("-");
-        chunks.splice(0, 2);
+        chunks.splice(0, 1);
         return chunks.join("-");
     },
 

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -37,7 +37,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
             '            style="height:{[this.MINIMAP_HEIGHT]}px;width:{[this.MINIMAP_WIDTH]}px;margin:{[this.MINIMAP_PADDING]}px! important"',
             '            id="{[this.mapElementId(values.uuid)]}">',
             '            {[this.getMiniMap(values)]}',
-            '        </div>' +
+            '        </div>',
             '        <div class="x-panel resultsTextBody {[this.getStatusClasses(values)]}">',
             '            <h5 class="floatRight"><i>{[this.getGeoNetworkRecordPointOfTruthLinkAsHtml(values)]}',
             '            </i></h5>',
@@ -125,12 +125,12 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         var broader = [];
         Ext.each(values.parameter, function(param) {
             var broaderTerms = this.classificationStore.getBroaderTerms(param, 2, 'Measured parameter');
-            if(broaderTerms.length > 0) {
+            if (broaderTerms.length > 0) {
                 broader = broader.concat(broaderTerms);
             }
         }, this);
         broader = broader.sort();
-        return broader.filter( function(item, pos) {
+        return broader.filter(function(item, pos) {
             return !pos || item != broader[pos - 1];
         });
     },
@@ -151,14 +151,14 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
         var label = this._buildLabel("fa-tags", OpenLayers.i18n('searchPlatformText'));
 
         var broader = this.classificationStore.getBroaderTerms(platform, 1, 'Platform');
-        if(broader.length > 0) {
+        if (broader.length > 0) {
             broader = broader.sort();
             broader = broader.filter( function(item, pos) {
                 return !pos || item != broader[pos - 1];
             });
             return template.apply({
                 "label": label,
-                "value": broader.join( ', ')
+                "value": broader.join(', ')
             });
         }
         return "";
@@ -260,7 +260,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
 
     isRecActive: function(uuid) {
         var record = this._getRecordFromUuid(uuid);
-        return (Portal.data.ActiveGeoNetworkRecordStore.instance().isRecordActive(record))
+        return Portal.data.ActiveGeoNetworkRecordStore.instance().isRecordActive(record);
     },
 
     _getRecordFromUuid: function(uuid) {

--- a/web-app/js/portal/search/FacetedSearchResultsPanel.js
+++ b/web-app/js/portal/search/FacetedSearchResultsPanel.js
@@ -34,7 +34,6 @@ Portal.search.FacetedSearchResultsPanel = Ext.extend(Ext.Panel, {
             ]
         };
 
-
         Ext.apply(this, config);
 
         Portal.search.FacetedSearchResultsPanel.superclass.initComponent.apply(this, arguments);
@@ -45,20 +44,6 @@ Portal.search.FacetedSearchResultsPanel = Ext.extend(Ext.Panel, {
 
         this._subscribeToActiveGeoNetworkRecordStoreEvents();
     },
-
-
-    _viewButtonOnClick: function(btn) {
-
-        btn.addClass("x-btn-selected");
-        var uuid = btn.container.id.replace("fsSearchAddBtn",'');
-        var record = this._getRecordFromUuid(uuid);
-
-        if (!Portal.data.ActiveGeoNetworkRecordStore.instance().isRecordActive(record)) {
-            Portal.data.ActiveGeoNetworkRecordStore.instance().add(record);
-        }
-        Ext.MsgBus.publish(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, record);
-    },
-
 
     _subscribeToActiveGeoNetworkRecordStoreEvents: function() {
         Ext.each([PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED], function(eventName) {
@@ -71,8 +56,6 @@ Portal.search.FacetedSearchResultsPanel = Ext.extend(Ext.Panel, {
 
     _refreshView: function() {
         this.dataView.refresh();
-        // todo set the scroll back to top
-        //this.dataView.setPosition({ x: 0, y: 0 });
     },
 
     _onStoreLoad: function() {

--- a/web-app/js/portal/search/FacetedSearchResultsPanel.js
+++ b/web-app/js/portal/search/FacetedSearchResultsPanel.js
@@ -46,7 +46,7 @@ Portal.search.FacetedSearchResultsPanel = Ext.extend(Ext.Panel, {
     },
 
     _subscribeToActiveGeoNetworkRecordStoreEvents: function() {
-        Ext.each([PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED], function(eventName) {
+        Ext.each([PORTAL_EVENTS.DATA_COLLECTION_ADDED, PORTAL_EVENTS.DATA_COLLECTION_REMOVED], function(eventName) {
 
             Ext.MsgBus.subscribe(eventName, function() {
                 this._refreshView();

--- a/web-app/js/portal/ui/DownloadCartWidget.js
+++ b/web-app/js/portal/ui/DownloadCartWidget.js
@@ -35,12 +35,12 @@ Portal.ui.DownloadCartWidget = Ext.extend(Ext.Panel, {
 
         Portal.ui.DownloadCartWidget.superclass.constructor.call(this, config);
 
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, function() {
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.DATA_COLLECTION_ADDED, function() {
             this.collectionCounter ++;
             this.updateDownloadCartSize();
         }, this);
 
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_REMOVED, function() {
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.DATA_COLLECTION_REMOVED, function() {
             this.collectionCounter --;
             this.updateDownloadCartSize();
         }, this);

--- a/web-app/js/portal/ui/MainPanel.js
+++ b/web-app/js/portal/ui/MainPanel.js
@@ -43,8 +43,8 @@ Portal.ui.MainPanel = Ext.extend(Ext.Panel, {
 
         Portal.ui.MainPanel.superclass.constructor.call(this, config);
 
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, this._onViewGeoNetworkRecord, this);
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, this._onGeoNetworkRecordAdded, this);
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.VIEW_DATA_COLLECTION, this._onViewGeoNetworkRecord, this);
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.DATA_COLLECTION_ADDED, this._onGeoNetworkRecordAdded, this);
     },
 
     _onViewGeoNetworkRecord: function() {

--- a/web-app/js/portal/ui/MainPanel.js
+++ b/web-app/js/portal/ui/MainPanel.js
@@ -52,7 +52,7 @@ Portal.ui.MainPanel = Ext.extend(Ext.Panel, {
 
     afterRender: function() {
         Portal.ui.MainPanel.superclass.afterRender.call(this);
-        this._highlightActiveTab();
+        this._highlightActiveTab(true);
     },
 
     getActiveTab: function() {
@@ -67,17 +67,19 @@ Portal.ui.MainPanel = Ext.extend(Ext.Panel, {
         this.layout.setActiveTab(TAB_INDEX_DOWNLOAD);
     },
 
-    _highlightActiveTab: function() {
+    _highlightActiveTab: function(initialLoad) {
 
         // Ensure tab selectors reflect actual tab selected
         var tabIndex = this.items.indexOf(this.getActiveTab());
 
         // clean slate
         jQuery('[id^=viewPortTab]').removeClass('viewPortTabActive').removeClass('viewPortTabActiveLast');
+
         // a collection was added
-        if (tabIndex > 0) {
+        if (!initialLoad) {
             jQuery('[id^=viewPortTab]').removeClass('viewPortTabDisabled');
         }
+
         // all tabs up until the selected tab highlighted
         for (var i = 0; i <= tabIndex; i++) {
             var newClasses = (i == tabIndex) ? 'viewPortTabActive viewPortTabActiveLast' : 'viewPortTabActive';

--- a/web-app/js/portal/ui/MainPanel.js
+++ b/web-app/js/portal/ui/MainPanel.js
@@ -44,10 +44,15 @@ Portal.ui.MainPanel = Ext.extend(Ext.Panel, {
         Portal.ui.MainPanel.superclass.constructor.call(this, config);
 
         Ext.MsgBus.subscribe(PORTAL_EVENTS.VIEW_GEONETWORK_RECORD, this._onViewGeoNetworkRecord, this);
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, this._onGeoNetworkRecordAdded, this);
     },
 
     _onViewGeoNetworkRecord: function() {
         this.setActiveTab(TAB_INDEX_VISUALISE);
+    },
+
+    _onGeoNetworkRecordAdded: function() {
+        this._highlightActiveTab();
     },
 
     afterRender: function() {

--- a/web-app/js/portal/ui/MapPanel.js
+++ b/web-app/js/portal/ui/MapPanel.js
@@ -50,7 +50,7 @@ Portal.ui.MapPanel = Ext.extend(Portal.common.MapPanel, {
             this.onBaseLayerChanged(message);
         }, this);
 
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, function() {
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.DATA_COLLECTION_ADDED, function() {
             this._maximiseMapActionsControl();
         }, this);
 

--- a/web-app/js/portal/ui/VisualisePanel.js
+++ b/web-app/js/portal/ui/VisualisePanel.js
@@ -39,7 +39,7 @@ Portal.ui.VisualisePanel = Ext.extend(Ext.Panel, {
 
         this.on('beforehide', function() { this.onBeforeHide() }, this);
 
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.ACTIVE_GEONETWORK_RECORD_ADDED, function() {
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.DATA_COLLECTION_ADDED, function() {
             this.detailsPanel.expand();
         }, this);
     },


### PR DESCRIPTION
This is a little something that I think will be handy. It lets you ctrl+click on step 1 and add multiple collections without being taken to step 2 for each one.

Current bugs:
* There is a problem with map binding to a few UI controls (to reproduce just ctrl+click before you've added any other data collections)

Nice to have:
* There are a few page elements that move about when you ctrl+click add a data collection (mainly the mini-map, I think). It would be nice if they didn't move when you added collections (and just greyed-out).