### PR TITLE
Change client side log config

### DIFF
--- a/web-app/js/portal/ui/MainPanel.js
+++ b/web-app/js/portal/ui/MainPanel.js
@@ -15,6 +15,12 @@ Portal.ui.MainPanel = Ext.extend(Ext.Panel, {
 
     constructor: function(cfg) {
 
+        this.logger = log4javascript.getLogger('Portal.ui.MainPanel');
+        this.logger.setLevel(log4javascript.Level.INFO);
+
+        log.debug('root Hello world!');  // This will be logged...
+        this.logger.debug('MainPanel Hello world!');  // ... but this will not.
+
         Ext.apply(this, cfg);
 
         this.addEvents('tabchange');

--- a/web-app/js/portal/utils/Logging.js
+++ b/web-app/js/portal/utils/Logging.js
@@ -5,7 +5,9 @@
  *
  */
 
-var log = log4javascript.getLogger();
+var log = log4javascript.getLogger('Portal');
 
 var ajaxAppender = new log4javascript.AjaxAppender('system/clientLog');
 log.addAppender(ajaxAppender);
+
+log.addAppender(new log4javascript.BrowserConsoleAppender);


### PR DESCRIPTION
**DO NOT MERGE**

This demonstrates how hierarchical loggers can be configured (as with log4j), as well as setting different levels for different loggers.

I wanted to put this up as a topic for discussion.

Currently, we don't log very much on the client side, despite the code there making up the majority of the code base for the portal.

I think we all find logging during development pretty useful (whether it be using the `log4javascript` framework, or simply `console.log()`.  Not sure how useful logging in production is or has been - I don't look there very often personally.

As @pmbohm rightly pointed out in a previous PR of mine, it's probably not that useful to flood the browser console with log messages, just like when logging in any other app.  So, I think to do this we need finer grained control over loggers and their levels, as this PR demonstrates.

Or maybe it's all just overkill and we shouldn't bother with (permanent) logging at all - just add/remove logs when developing at will.
