### PR TITLE
fixes #1696

### DIFF
--- a/src/test/javascript/portal/filter/ui/NumberFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/NumberFilterPanelSpec.js
@@ -75,6 +75,36 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
             numberFilter._updateFilter();
 
             expect(window.trackUsage).toHaveBeenCalledWith("Filters", "Number", "testLabel between 5 and 6", "test layer");
-        })
+        });
+
+        it('no update when operator is between and some values are empty', function() {
+            spyOn(numberFilter.filter, 'setValue');
+
+            numberFilter._operatorIsBetween = function() { return true };
+            numberFilter.operators.lastSelectionText = 'between';
+
+            numberFilter._updateFilter();
+            expect(numberFilter.filter.setValue).not.toHaveBeenCalled();
+
+            numberFilter.firstField.getValue = function() { return false };
+            numberFilter.secondField.getValue = function() { return 6 };
+            numberFilter._updateFilter();
+
+            expect(numberFilter.filter.setValue).not.toHaveBeenCalled();
+        });
+
+        it('updates when operator is between and both values are valid', function() {
+            spyOn(numberFilter.filter, 'setValue');
+
+            numberFilter._operatorIsBetween = function() { return true };
+            numberFilter.operators.lastSelectionText = 'between';
+
+            numberFilter.firstField.getValue = function() { return 30000 }; // no sanity checking yet
+            numberFilter.secondField.getValue = function() { return 6 };
+            numberFilter._updateFilter();
+
+            expect(numberFilter.filter.setValue).toHaveBeenCalled();
+        });
+
     });
 });


### PR DESCRIPTION
Fixes the possibility of invalid CQL causing the portal to mark the layer invalid when using the 'between' filter and leaving either the first or second field empty.
 