### PR TITLE
track gogoduck downloads with GA

### DIFF
--- a/src/test/javascript/portal/cart/DownloadPanelSpec.js
+++ b/src/test/javascript/portal/cart/DownloadPanelSpec.js
@@ -239,7 +239,7 @@ describe("Portal.cart.DownloadPanel", function() {
 
             downloadPanel.confirmDownload(testCollection, callbackScope, callback, testParams, testKey);
             testParams.onAccept(testParams);
-            expect(window.trackUsage).toHaveBeenCalledWith(OpenLayers.i18n('downloadTrackingCategory'), OpenLayers.i18n('downloadTrackingActionPrefix') + OpenLayers.i18n(testKey), testCollection.title);
+            expect(window.trackUsage).toHaveBeenCalledWith(OpenLayers.i18n('downloadTrackingCategory'), OpenLayers.i18n('downloadTrackingActionPrefix') + OpenLayers.i18n(testKey), testCollection.title, undefined);
         });
     });
 

--- a/web-app/js/portal/cart/DownloadPanel.js
+++ b/web-app/js/portal/cart/DownloadPanel.js
@@ -181,10 +181,10 @@ Portal.cart.DownloadPanel = Ext.extend(Ext.Panel, {
 
         params.onAccept = function(callbackParams) {
             self.downloader.download(collection, generateUrlCallbackScope, generateUrlCallback, callbackParams);
-            trackUsage(
-                OpenLayers.i18n('downloadTrackingCategory'),
+            trackDownloadUsage(
                 OpenLayers.i18n('downloadTrackingActionPrefix') + OpenLayers.i18n(textKey),
-                collection.title
+                collection.title,
+                undefined
             );
         };
 

--- a/web-app/js/portal/cart/GogoduckDownloadHandler.js
+++ b/web-app/js/portal/cart/GogoduckDownloadHandler.js
@@ -76,8 +76,24 @@ Portal.cart.GogoduckDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
             }
         };
 
+        this._trackUsage(layerName, args.subsetDescriptor);
+
         var paramsAsJson = Ext.util.JSON.encode(args);
 
         return String.format(this.ASYNC_DOWNLOAD_URL + 'jobParameters={0}', encodeURIComponent(paramsAsJson));
+    },
+
+    _trackUsage: function(layerName, subsetDescriptor) {
+        trackDownloadUsage(
+            OpenLayers.i18n('gogoduckTrackingLabel'),
+            layerName,
+            String.format("TIME:{0},{1} LAT:{2},{3} LON:{4},{5}",
+                subsetDescriptor.temporalExtent.start,
+                subsetDescriptor.temporalExtent.end,
+                subsetDescriptor.spatialExtent.south,
+                subsetDescriptor.spatialExtent.north,
+                subsetDescriptor.spatialExtent.west,
+                subsetDescriptor.spatialExtent.east)
+        );
     }
 });

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -286,6 +286,7 @@ OpenLayers.Util.extend(OpenLayers.Lang.en, {
     trackingTypedBboxLabel: 'typedBbox',
     facetTrackingCategory: "Facets",
     goButtonTrackingLabel: "Go",
+    gogoduckTrackingLabel: "GoGoDuck",
 
     shareButton: "New portal with only this collection"
 });

--- a/web-app/js/portal/utils/trackUsage.js
+++ b/web-app/js/portal/utils/trackUsage.js
@@ -34,3 +34,11 @@ function trackFiltersUsage(actionKey, label, collection) {
     );
 }
 
+function trackDownloadUsage(action, collection, downloadParams) {
+    trackUsage(
+        OpenLayers.i18n('downloadTrackingCategory'),
+        action,
+        collection,
+        downloadParams
+    );
+}


### PR DESCRIPTION
Request by @pblain.

The main difference is that we will have the aggregation parameters - and we can actually understand what people are doing with GGD.