### PR TITLE
do not post unnecessary parameters for GGD jobs

### DIFF
--- a/src/test/javascript/portal/cart/DownloaderSpec.js
+++ b/src/test/javascript/portal/cart/DownloaderSpec.js
@@ -64,7 +64,6 @@ describe("Portal.cart.Downloader", function() {
             expect(Ext.Ajax.request).toHaveBeenCalledWith({
                 url: wfsDownloadUrl,
                 scope: downloader,
-                params: params,
                 success: downloader._onAsyncDownloadRequestSuccess,
                 failure: downloader._onAsyncDownloadRequestFailure
             });
@@ -73,15 +72,14 @@ describe("Portal.cart.Downloader", function() {
         describe('_onAsyncDownloadRequestSuccess', function() {
             it('calls serviceResponseHandler', function() {
                 var response = { responseText: "responseText" };
-                var options = {
-                    params: {
-                        emailAddress: "emailAddress",
-                        serviceResponseHandler: jasmine.createSpy()
-                    }
+                params = {
+                    emailAddress: "emailAddress",
+                    serviceResponseHandler: jasmine.createSpy()
                 };
-                downloader._onAsyncDownloadRequestSuccess(response, options);
+                downloader.params = params;
+                downloader._onAsyncDownloadRequestSuccess(response);
 
-                expect(options.params.serviceResponseHandler).toHaveBeenCalledWith(response.responseText);
+                expect(downloader.params.serviceResponseHandler).toHaveBeenCalledWith(response.responseText);
             });
 
             it('return empty string if serviceResponseHandler is undefined', function() {

--- a/web-app/js/portal/cart/Downloader.js
+++ b/web-app/js/portal/cart/Downloader.js
@@ -103,21 +103,21 @@ Portal.cart.Downloader = Ext.extend(Ext.util.Observable, {
     _downloadAsynchronously: function(collection, downloadUrl, params) {
         log.debug('downloading asynchronously', downloadUrl);
 
+        this.params = params;
         Ext.Ajax.request({
             url: downloadUrl,
             scope: this,
-            params: params,
             success: this._onAsyncDownloadRequestSuccess,
             failure: this._onAsyncDownloadRequestFailure
         });
     },
 
-    _onAsyncDownloadRequestSuccess: function(response, options) {
+    _onAsyncDownloadRequestSuccess: function(response) {
         Ext.Msg.alert(
             OpenLayers.i18n('asyncDownloadPanelTitle'),
             OpenLayers.i18n('asyncDownloadSuccessMsg', {
-                email: options.params.emailAddress,
-                serviceMessage: this._getServiceMessage(options.params.serviceResponseHandler, response.responseText)
+                email: this.params.emailAddress,
+                serviceMessage: this._getServiceMessage(this.params.serviceResponseHandler, response.responseText)
             })
         );
     },


### PR DESCRIPTION
do not post unnecessary parameters for GGD jobs

It can probably be refactored to look a bit nicer, such as binding the success function with the correct parameters, however I'm not too fussed about it.