### PR TITLE
Determine character encoding of metadata xml stream before escaping

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/LayerController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/LayerController.groovy
@@ -9,8 +9,6 @@ package au.org.emii.portal
 
 import au.org.emii.portal.wms.NcwmsServer
 import au.org.emii.portal.wms.GeoserverServer
-import org.springframework.web.util.HtmlUtils
-import org.xml.sax.SAXException
 
 import grails.converters.JSON
 
@@ -34,24 +32,24 @@ class LayerController {
 
             try {
                 def con = new URL(_getMetadataUrl(params.uuid)).openConnection()
+                def reader = new InputStreamReader(con.content)
                 def metadataText = con.content.text
 
                 if (_isXmlContent(con.contentType)) {
 
                     def xml = new XmlSlurper().parseText(metadataText)
                     //TODO: Validate schema before proceeding
-
-                    def abstractText = HtmlUtils.htmlEscape(xml.identificationInfo.MD_DataIdentification.abstract.CharacterString.text())
+                    def abstractText = HtmlUtils.htmlEscape(xml.identificationInfo.MD_DataIdentification.abstract.CharacterString.text(), reader.getEncoding())
 
                     response = abstractText
                     status = HTTP_200_OK
                 }
             }
-            catch (SAXException e) {
-                status = HTTP_500_INTERNAL_SERVER_ERROR
-            }
             catch (FileNotFoundException e) {
                 status = HTTP_404_NOT_FOUND
+            }
+            catch (Exception e) {
+                status = HTTP_500_INTERNAL_SERVER_ERROR
             }
         }
 

--- a/grails-app/utils/au/org/emii/portal/HtmlCharacterEntityReferences.groovy
+++ b/grails-app/utils/au/org/emii/portal/HtmlCharacterEntityReferences.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+
+package au.org.emii.portal
+
+final class HtmlCharacterEntityReferences {
+
+    /**
+     * Taken from Spring source code
+     * https://github.com/spring-projects/spring-framework/blob/master/spring-web/src/main/java/org/springframework/web/util/HtmlCharacterEntityReferences.java#L132
+     */
+
+    /**
+     * Return the reference mapped to the given character or {@code null}.
+     * @since 4.1.2
+     */
+    public String convertToReference(char character, String encoding) {
+        if (encoding.startsWith("UTF")){
+            switch (character){
+                case '<':
+                    return "&lt;";
+                case '>':
+                    return "&gt;";
+                case '"':
+                    return "&quot;";
+                case '&':
+                    return "&amp;";
+                case '\'':
+                    return "&#39;";
+            }
+        }
+        else if (character < 1000 || (character >= 8000 && character < 10000)) {
+            int index = (character < 1000 ? character : character - 7000);
+            String entityReference = this.characterToEntityReferenceMap[index];
+            if (entityReference != null) {
+                return entityReference;
+            }
+        }
+        return null;
+    }
+}

--- a/grails-app/utils/au/org/emii/portal/HtmlUtils.groovy
+++ b/grails-app/utils/au/org/emii/portal/HtmlUtils.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+
+package au.org.emii.portal
+
+import org.spockframework.util.Assert
+
+final class HtmlUtils {
+
+    /**
+     * Taken from Spring source code
+     * https://github.com/spring-projects/spring-framework/blob/bccd59e6c8845c6521d3b325bea89bcbcbe4d833/spring-web/src/main/java/org/springframework/web/util/HtmlUtils.java#L82
+     */
+
+    /**
+     * Turn special characters into HTML character references.
+     * Handles complete character set defined in HTML 4.01 recommendation.
+     * <p>Escapes all special characters to their corresponding
+     * entity reference (e.g. {@code &lt;}) at least as required by the
+     * specified encoding. In other words, if a special character does
+     * not have to be escaped for the given encoding, it may not be.
+     * <p>Reference:
+     * <a href="http://www.w3.org/TR/html4/sgml/entities.html">
+     * http://www.w3.org/TR/html4/sgml/entities.html
+     * </a>
+     * @param input the (unescaped) input string
+     * @param encoding The name of a supported {@link java.nio.charset.Charset charset}
+     * @return the escaped string
+     * @since 4.1.2
+     */
+    public static String htmlEscape(String input, String encoding) {
+        def characterEntityReferences = new HtmlCharacterEntityReferences();
+        Assert.notNull(encoding, "Encoding is required");
+        if (input == null) {
+            return null;
+        }
+        StringBuilder escaped = new StringBuilder(input.length() * 2);
+        for (int i = 0; i < input.length(); i++) {
+            char character = input.charAt(i);
+            String reference = characterEntityReferences.convertToReference(character, encoding);
+            if (reference != null) {
+                escaped.append(reference);
+            } else {
+                escaped.append(character);
+            }
+        }
+        return escaped.toString();
+    }
+}


### PR DESCRIPTION
Fixes issue #1748 in conjunction with chef upgrade