### PR TITLE
Number filter hasValue should return true if comparison value is 0

### DIFF
--- a/src/test/javascript/portal/filter/NumberFilterSpec.js
+++ b/src/test/javascript/portal/filter/NumberFilterSpec.js
@@ -63,6 +63,24 @@ describe("Portal.filter.NumberFilter", function() {
         });
     });
 
+    describe('first field is 0', function() {
+
+        beforeEach(function() {
+
+            filter.setValue({
+                firstField: 0
+            });
+        });
+
+        describe('hasValue', function() {
+
+            it('returns true', function() {
+
+                expect(filter.hasValue()).toBeTruthy();
+            });
+        });
+    });
+
     describe('two values entered', function() {
 
         beforeEach(function() {

--- a/web-app/js/portal/filter/NumberFilter.js
+++ b/web-app/js/portal/filter/NumberFilter.js
@@ -36,7 +36,7 @@ Portal.filter.NumberFilter = Ext.extend(Portal.filter.Filter, {
 
     hasValue: function() {
 
-        return this.getValue() && (this._getFirstField() || this._getSecondField());
+        return this.getValue() && (this._getFirstField() || this._getFirstField() === 0);
     },
 
     getHumanReadableForm: function() {


### PR DESCRIPTION
Fixes #1787

Also, we no longer check whether the second field has a value as there isn't a case where it should have a value without the first field also having a value.