### PR TITLE
Fixes #1793 and fixes #1792

### DIFF
--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -102,11 +102,11 @@ hr {
 }
 
 .floatLeft {
-    float: left;
+    float: left! important;
 }
 
 .floatRight {
-    float: right;
+    float: right! important;
 }
 
 .floatFullHeight::after {
@@ -882,20 +882,16 @@ div.allwhite {
     height: inherit;
 }
 
-.search-filter-panel .x-panel-header {
-    height: 12px;
-    font-size: 13px;
-    padding: 5px 2px 5px 2px;
-}
-
-.filter-selection-panel {
-    margin-bottom: 3px;
-}
-
 .filter-selection-panel .x-panel-header {
     border-radius: 4px 4px 0 4px;
     background-color: #e8e8e8;
-    padding: 10px 5px;
+}
+
+.search-filter-panel .x-panel-header,
+.filter-selection-panel .x-panel-header,
+.subsetPanelAccordion .x-panel-header {
+    margin: 5px 5px 0 0;
+    padding: 10px;
 }
 
 .filterGroupPanel h4 {
@@ -988,8 +984,7 @@ ul.x-tab-strip-top li:hover * {
 }
 
 .subsetPanelAccordion .x-panel-header {
-    margin: 5px 5px 0 0;
-    padding: 2px 5px;
+    padding: 5px 8px;
 }
 
 .subsetPanelAccordion .x-panel-collapsed * {

--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -996,8 +996,14 @@ ul.x-tab-strip-top li:hover * {
     font-weight: normal;
 }
 
-.subsetPanelAccordion .x-tool {
+.x-tool-awesome {
+    cursor: pointer;
     margin-top: 3px;
+    float: right;
+    height: 15px;
+    margin-left: 2px;
+    overflow: hidden;
+    width: 15px;
 }
 
 .downloadPanelResultsTitle {

--- a/web-app/js/portal/details/SubsetItemsWrapperPanel.js
+++ b/web-app/js/portal/details/SubsetItemsWrapperPanel.js
@@ -19,6 +19,8 @@ Portal.details.SubsetItemsWrapperPanel = Ext.extend(Ext.Panel, {
             }
         });
 
+        this.createTools();
+
         var config = Ext.apply({
             id: cfg.layerItemId,
             cls: 'subsetPanelAccordionItem',
@@ -29,33 +31,56 @@ Portal.details.SubsetItemsWrapperPanel = Ext.extend(Ext.Panel, {
                 autoHeight: true
             },
             items: [tabPanelForLayer],
+            toolTemplate: new Ext.Template('<div class="x-tool-awesome fa fa-fw {styles}" title="{title}"></div>'),
             tools: [
-                {
-                    id: 'up',
-                    qtip: 'move up',
-                    scope: this,
-                    handler: function(event, toolEl, panel) {
-                        this._changeLayerOrder(-1);
-                    }
-                },
-                {
-                    id: 'down',
-                    qtip: 'move down',
-                    scope: this,
-                    handler: function(event, toolEl, panel) {
-                        this._changeLayerOrder(1);
-                    }
-                },
-                {
-                    id: 'delete',
-                    handler: this._layerDelete,
-                    qtip: OpenLayers.i18n('removeDataCollection'),
-                    scope: this
-                }
+                this.errorToolItem,
+                this.spinnerToolItem,
+                this.deleteToolItem
             ]
         }, cfg);
 
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.LAYER_LOADING_END, function(e, openLayer) {
+            this.handleLayerLoadingEnd(openLayer);
+        }, this);
+
+
         Portal.details.SubsetItemsWrapperPanel.superclass.constructor.call(this, config);
+    },
+
+    handleLayerLoadingEnd: function(openLayer) {
+        if (openLayer == this.layer) {
+            this.tools.spinnerToolItem.hide();
+            if (openLayer.hasImgLoadErrors()) {
+                this.showError();
+            }
+        }
+    },
+
+    showError: function() {
+        this.tools.errorToolItem.show();
+
+    },
+
+    createTools: function() {
+
+        this.errorToolItem = {
+            id: 'errorToolItem',
+            styles: 'error fa-exclamation-triangle',
+            hidden: true,
+            title: OpenLayers.i18n('layerProblem')
+        };
+        this.spinnerToolItem = {
+            id: 'spinnerToolItem',
+            styles: 'fa-spin fa-spinner',
+            title: OpenLayers.i18n('loadingMessage')
+        };
+        this.deleteToolItem = {
+            id: 'deleteToolItem',
+            styles: 'fa-close',
+            handler: this._layerDelete,
+            title: OpenLayers.i18n('removeDataCollection'),
+            scope: this
+        };
     },
 
     _changeLayerOrder: function(direction) {

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -152,7 +152,7 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
     freetextFilter: 'Text Search',
     dateFilter: 'Date (UTC)',
     geoFilter: "Geographic Boundary",
-    facetedSearchNewSearchButton: 'Start new search',
+    facetedSearchNewSearchButton: 'New search',
     facetedSearchUnavailable: 'Search is currently unavailable.',
     facetedSearchResetting: 'Resetting search',
     noParametersForCollection: 'No parameters',
@@ -179,7 +179,7 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
     resetActionText: 'reset',
 
     // FacetFilterPanel
-    addAnother: 'Add another filter',
+    addAnother: 'Add another filter - where possible',
 
     // Async Downloads
     asyncDownloadPanelTitle: 'Subset',
@@ -187,7 +187,7 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
     asyncDownloadErrorMsg: 'Unable to create subsetting job. Please re-check the parameters you provided and try again.',
     gogoduckServiceMsg: "<a class='external' target='_blank' href='${url}'>Follow the progress of your job</a><br /><br />",
 
-    spatialExtentHeading: 'Global Spatial Extent',
+    spatialExtentHeading: 'Spatial Subset',
     temporalExtentHeading: 'Temporal Extent',
     generalFilterHeading: 'Filters',
     currentDateTimeLabel: 'Displaying',

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -25,7 +25,7 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
 
     // SubsettingPanel.js
     opacity: "Opacity",
-    wmsLayerProblem: "There is a problem with the availability of this collection",
+    layerProblem: "There is a problem with the availability of this collection",
     noActiveCollectionSelected: "No data collections selected",
     dataCollectionsTitle: "Subsetting data collection:",
     noCollectionSelectedHelp: "Please return and search for data collections.",

--- a/web-app/js/portal/search/DateSelectionPanel.js
+++ b/web-app/js/portal/search/DateSelectionPanel.js
@@ -51,7 +51,8 @@ Portal.search.DateSelectionPanel = Ext.extend(Ext.Panel, {
                             width: 65
                         })]
                 })
-            ]
+            ],
+            toolTemplate: new Ext.Template('')
         }, cfg, defaults);
 
         Portal.search.DateSelectionPanel.superclass.constructor.call(this, config);

--- a/web-app/js/portal/search/FacetFilterPanel.js
+++ b/web-app/js/portal/search/FacetFilterPanel.js
@@ -17,19 +17,26 @@ Portal.search.FacetFilterPanel = Ext.extend(Ext.Panel, {
         this.searcher = cfg.searcher;
 
         Ext.apply(cfg, {
-            title: '<span class="filter-selection-panel-header">' + cfg.title + '</span>', // todo create en.js entry so its reusable
+            title: cfg.title,
             containerScroll: true,
             autoScroll: true,
             collapsible: true,
             collapseFirst: false,
+            titleCollapse: true,
             collapsed: cfg.collapsedByDefault,
             cls: "search-filter-panel filter-selection-panel",
-            toolTemplate: new Ext.Template('<div class="x-tool x-tool-{id}" title="{title}">&#160;</div>'),
+            toolTemplate: new Ext.Template('<div class="x-tool-awesome fa fa-fw {styles}" title="{label}"></div>'),
             tools: [{
                 id: 'plus',
+                styles: 'fa-chain',
                 handler: this._onAdd,
                 scope: this,
-                title: OpenLayers.i18n('addAnother')
+                hidden: true,
+                label: OpenLayers.i18n('addAnother')
+            },
+            {
+                id: 'toggle',
+                hidden: true
             }]
         });
 
@@ -60,6 +67,8 @@ Portal.search.FacetFilterPanel = Ext.extend(Ext.Panel, {
 
     _registerHandlers: function() {
         this.on('afterlayout', this._setAddButtonAvailability, this);
+        this.on('expand', this._setAddButtonAvailability, this);
+        this.on('collapse', this._setAddButtonAvailability, this);
         this.mon(this.searcher, 'searchcomplete', this._setAddButtonAvailability, this);
     },
 
@@ -103,12 +112,12 @@ Portal.search.FacetFilterPanel = Ext.extend(Ext.Panel, {
             return;
         }
 
-        if (this._hasEmptyDrilldownPanel() || this._noDrilldownsAvailable()) {
+        if (this._hasEmptyDrilldownPanel() || this._noDrilldownsAvailable() || this.collapsed) {
             this.tools.plus.disabled = true;
-            this.tools.plus.addClass('tool-plus-disabled');
+            this.tools.plus.hide();
         } else {
             this.tools.plus.disabled = false;
-            this.tools.plus.removeClass('tool-plus-disabled');
+            this.tools.plus.show();
         }
     },
 

--- a/web-app/js/portal/search/GeoSelectionPanel.js
+++ b/web-app/js/portal/search/GeoSelectionPanel.js
@@ -23,9 +23,6 @@ Portal.search.GeoSelectionPanel = Ext.extend(Ext.Panel, {
             cfg.separator = "|";
 
         var defaults = {
-            collapsible: true,
-            collapsed: true,
-            titleCollapse: true
         };
 
         Ext.apply(this, cfg, defaults);
@@ -45,6 +42,10 @@ Portal.search.GeoSelectionPanel = Ext.extend(Ext.Panel, {
                     margin: '2px'
                 }
             },
+            collapsible: true,
+            collapsed: true,
+            titleCollapse: true,
+            toolTemplate: new Ext.Template(''),
             items:[
                 this.facetMap,
                 new Ext.Spacer({


### PR DESCRIPTION
Toolbar items using FontAwesome. The step 1 add extra criteria button is now only visible when available instead of being disabled. It was hard to tell when the extra criteria button were active or disabled as there are no expand/collapse icons anymore on step1, which matches Step2