### PR TITLE
Selected layer always on top on map

### DIFF
--- a/src/test/javascript/portal/data/LayerStoreSpec.js
+++ b/src/test/javascript/portal/data/LayerStoreSpec.js
@@ -343,4 +343,45 @@ describe("Portal.data.LayerStore", function() {
             expect(layer.loading).toEqual(false);
         });
     });
+
+    describe('_selectedLayerChanged', function() {
+
+        beforeEach(function() {
+            layerStore._addLayer(layerWithId(1));
+            layerStore._addLayer(layerWithId(2));
+            layerStore._addLayer(layerWithId(3));
+        });
+
+        it('moves selected layer to the top', function() {
+
+            layerStore._selectedLayerChanged('', layerWithId(2));
+
+            expect(layerStore.data.length).toBe(3);
+            expect(layerIds(layerStore)).toEqual([1, 3, 2]); // The end of the array represents the top of the layer stack
+        });
+
+        it('handles layers that are not found', function() {
+
+            layerStore._selectedLayerChanged('', layerWithId(4));
+
+            expect(layerStore.data.length).toBe(3);
+            expect(layerIds(layerStore)).toEqual([1, 2, 3]);
+        });
+
+        function layerWithId(id) {
+            var layer = createOpenLayer('' + id);
+            layer.id = id;
+            return layer;
+        }
+
+        function layerIds(layerStore) {
+            var ids = [];
+
+            Ext.each(layerStore.data.items, function(record) {
+                ids.push(record.data.layer.id);
+            });
+
+            return ids;
+        }
+    });
 });

--- a/src/test/javascript/portal/ui/MapPanelSpec.js
+++ b/src/test/javascript/portal/ui/MapPanelSpec.js
@@ -128,14 +128,6 @@ describe("Portal.ui.MapPanel", function() {
         });
     });
 
-    describe('geonetwork record added event', function() {
-        it('maximises map actions control on active geonetork record added event', function() {
-            spyOn(mapPanel, '_maximiseMapActionsControl');
-            Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_ADDED);
-            expect(mapPanel._maximiseMapActionsControl).toHaveBeenCalled();
-        });
-    });
-
     describe('removeAllLayers event', function() {
 
         it('should call _closeFeatureInfoPopup()', function() {

--- a/web-app/js/portal/data/ActiveGeoNetworkRecordStore.js
+++ b/web-app/js/portal/data/ActiveGeoNetworkRecordStore.js
@@ -139,29 +139,6 @@ Portal.data.ActiveGeoNetworkRecordStore = Ext.extend(Portal.data.GeoNetworkRecor
             if (record.loaded) { loadedRecords.push(record); }
         });
         return loadedRecords;
-    },
-
-    changeItemOrder: function(record, direction) {
-        var mapping = this.buildMapping(record, direction);
-        if (mapping) {
-            this.data.reorder(mapping);
-
-            var message = {
-                "layer": record.layerRecord.data.layer,
-                "direction": direction
-            };
-            Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_MODIFIED, message);
-        }
-    },
-
-    buildMapping: function(record, direction) {
-        var currentIndex = this.indexOf(record);
-        var obj = new Object();
-
-        if (this.data.items[currentIndex + direction]) {
-            obj[currentIndex]  = currentIndex + direction;
-            return obj;
-        }
     }
 });
 

--- a/web-app/js/portal/data/LayerStore.js
+++ b/web-app/js/portal/data/LayerStore.js
@@ -243,7 +243,6 @@ Portal.data.LayerStore = Ext.extend(GeoExt.data.LayerStore, {
                         Ext.apply(layerDescriptor, configOverrides);
                         this.addUsingDescriptor(layerDescriptor);
                     },
-
                     this
                 );
 

--- a/web-app/js/portal/data/LayerStore.js
+++ b/web-app/js/portal/data/LayerStore.js
@@ -216,6 +216,33 @@ Portal.data.LayerStore = Ext.extend(GeoExt.data.LayerStore, {
         Ext.MsgBus.subscribe(PORTAL_EVENTS.RESET, function(subject, openLayer) {
             this.removeAll();
         }, this);
+
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.SELECTED_LAYER_CHANGED, this._selectedLayerChanged, this);
+    },
+
+    _selectedLayerChanged: function(eventName, openLayer) {
+
+        if (openLayer) {
+            var recordIndex = this.findBy(this._layerMatcher(openLayer));
+
+            if (recordIndex >= 0) {
+                this._moveLayerToTop(recordIndex);
+            }
+        }
+    },
+
+    _layerMatcher: function(openLayer) {
+
+        return function(record) {
+            return record.data.layer.id == openLayer.id;
+        };
+    },
+
+    _moveLayerToTop: function(recordIndex) {
+
+        var record = this.getAt(recordIndex);
+        this.remove(record);
+        this.add(record);
     },
 
     _initBaseLayers: function() {

--- a/web-app/js/portal/details/SubsetItemsWrapperPanel.js
+++ b/web-app/js/portal/details/SubsetItemsWrapperPanel.js
@@ -58,7 +58,6 @@ Portal.details.SubsetItemsWrapperPanel = Ext.extend(Ext.Panel, {
 
     showError: function() {
         this.tools.errorToolItem.show();
-
     },
 
     createTools: function() {
@@ -81,12 +80,6 @@ Portal.details.SubsetItemsWrapperPanel = Ext.extend(Ext.Panel, {
             title: OpenLayers.i18n('removeDataCollection'),
             scope: this
         };
-    },
-
-    _changeLayerOrder: function(direction) {
-        var collectionId = this.layer.parentGeoNetworkRecord.data.uuid;
-        var record = Portal.data.ActiveGeoNetworkRecordStore.instance().getRecordFromUuid(collectionId);
-        Portal.data.ActiveGeoNetworkRecordStore.instance().changeItemOrder(record, direction);
     },
 
     _layerDelete: function(event, toolEl, panel) {

--- a/web-app/js/portal/details/SubsetPanelAccordion.js
+++ b/web-app/js/portal/details/SubsetPanelAccordion.js
@@ -17,18 +17,9 @@ Portal.details.SubsetPanelAccordion = Ext.extend(Ext.Panel, {
             autoScroll: true,
             layoutConfig: {
                 hideCollapseTool: true
-            },
-            listeners: {
-                beforeAdd: this.collapseAll
             }
         }, cfg);
 
         Portal.details.SubsetPanelAccordion.superclass.constructor.call(this, config);
-    },
-
-    collapseAll: function() {
-        this.items.each(function(f) {
-            f.collapse();
-        });
     }
 });

--- a/web-app/js/portal/details/SubsettingPanel.js
+++ b/web-app/js/portal/details/SubsettingPanel.js
@@ -11,9 +11,6 @@ Portal.details.SubsettingPanel = Ext.extend(Ext.Panel, {
 
     constructor : function(cfg) {
 
-        this.map = cfg.map;
-        this.mapPanel = cfg.mapPanel;
-
         this.spatialSubsetControlsPanel = new Portal.details.SpatialSubsetControlsPanel({
             map: cfg.map,
             hideLabel: false
@@ -56,7 +53,6 @@ Portal.details.SubsettingPanel = Ext.extend(Ext.Panel, {
         }, this);
     },
 
-
     updateSubsetPanelAccordionItem: function(layer) {
         if (layer) {
             if (!this._itemExistsForLayer(layer)) {
@@ -67,7 +63,7 @@ Portal.details.SubsettingPanel = Ext.extend(Ext.Panel, {
     },
 
     _itemExistsForLayer: function(layer) {
-        return (this.subsetPanelAccordion.items.item(this._getItemIdForLayer(layer)) != undefined) ;
+        return (this.subsetPanelAccordion.items.item(this._getItemIdForLayer(layer)) != undefined);
     },
 
     _addItemForLayer: function(layer) {

--- a/web-app/js/portal/details/SubsettingPanel.js
+++ b/web-app/js/portal/details/SubsettingPanel.js
@@ -67,12 +67,22 @@ Portal.details.SubsettingPanel = Ext.extend(Ext.Panel, {
         var layerContainer = new Portal.details.SubsetItemsWrapperPanel({
             map: this.map,
             layer: layer,
-            layerItemId: this._getItemIdForLayer(layer)
+            layerItemId: this._getItemIdForLayer(layer),
+            listeners: {
+                expand: this._fireSelectedLayerChangedEvent(layer),
+                scope: this
+            }
         });
 
         this.subsetPanelAccordion.add(layerContainer);
         this.subsetPanelAccordion.doLayout();
         this.emptyTextPanel.hide();
+    },
+
+    _fireSelectedLayerChangedEvent: function(layer) {
+        return function() {
+            Ext.MsgBus.publish(PORTAL_EVENTS.SELECTED_LAYER_CHANGED, layer);
+        }
     },
 
     _activateItemForLayer: function(layer) {

--- a/web-app/js/portal/details/SubsettingPanel.js
+++ b/web-app/js/portal/details/SubsettingPanel.js
@@ -47,10 +47,6 @@ Portal.details.SubsettingPanel = Ext.extend(Ext.Panel, {
         Ext.MsgBus.subscribe(PORTAL_EVENTS.LAYER_REMOVED, function(eventName, openlayer) {
             this._removeFolderForLayer(openlayer);
         }, this);
-
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.DATA_COLLECTION_MODIFIED, function(eventName, message) {
-            this._updateItemOrder(message);
-        }, this);
     },
 
     updateSubsetPanelAccordionItem: function(layer) {
@@ -85,32 +81,6 @@ Portal.details.SubsettingPanel = Ext.extend(Ext.Panel, {
             this.subsetPanelAccordion.layout.setActiveItem(this._getItemIdForLayer(layer));
             this.subsetPanelAccordion.items.item(this._getItemIdForLayer(layer)).expand();
         }
-    },
-
-    _updateItemOrder: function(message) {
-
-        var movingItemIndex = this.subsetPanelAccordion.items.keys.indexOf(this._getItemIdForLayer(message.layer));
-        var newIndex = message.direction + movingItemIndex;
-
-        var itemToMove = this.subsetPanelAccordion.getComponent(movingItemIndex);
-        this.subsetPanelAccordion.remove(itemToMove, false);
-        this.subsetPanelAccordion.insert(newIndex, itemToMove);
-        this.subsetPanelAccordion.layout.setActiveItem(this._getItemIdForLayer(message.layer));
-
-        // Do the actual DOM maniplulation with jQuery. Extjs3.4 wont/cant
-        var siblings = jQuery('#' + itemToMove.id).parent().children();
-        var targetSibling = siblings.eq(newIndex);
-        var movingSibling = siblings.eq(movingItemIndex);
-
-        movingSibling.fadeOut(300, function() {
-            if (message.direction > 0) {
-                targetSibling.after(movingSibling);
-            }
-            else {
-                targetSibling.before(movingSibling);
-            }
-            movingSibling.fadeIn(50);
-        });
     },
 
     _removeFolderForLayer: function(layer) {

--- a/web-app/js/portal/ui/MapPanel.js
+++ b/web-app/js/portal/ui/MapPanel.js
@@ -50,20 +50,10 @@ Portal.ui.MapPanel = Ext.extend(Portal.common.MapPanel, {
             this.onBaseLayerChanged(message);
         }, this);
 
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.DATA_COLLECTION_ADDED, function() {
-            this._maximiseMapActionsControl();
-        }, this);
-
         Ext.MsgBus.subscribe(PORTAL_EVENTS.RESET, function () {
             this.reset();
             this._closeFeatureInfoPopup();
         }, this);
-    },
-
-    _maximiseMapActionsControl: function() {
-        if (this.mapOptions.mapActionsControl) {
-            this.mapOptions.mapActionsControl.maximizeControl();
-        }
     },
 
     onSelectedLayerChanged: function (openLayer) {
@@ -80,11 +70,6 @@ Portal.ui.MapPanel = Ext.extend(Portal.common.MapPanel, {
     afterRender: function () {
         Portal.ui.MapPanel.superclass.afterRender.call(this);
         this.mapOptions.afterRender(this);
-    },
-
-    autoZoomCheckboxHandler: function (box, checked) {
-        Portal.app.appConfig.portal.autoZoom = checked;
-        this.autoZoom = checked;
     },
 
     reset: function () {
@@ -134,10 +119,6 @@ Portal.ui.MapPanel = Ext.extend(Portal.common.MapPanel, {
         this.mapOptions = new Portal.ui.openlayers.MapOptions(this.appConfig, this);
         this.map = this.mapOptions.newMap();
         this.map.setDefaultSpatialConstraintType(this.defaultSpatialConstraintType);
-    },
-
-    getServer: function (item) {
-        return item.server;
     },
 
     _autoZoomToLayer: function(openLayer) {


### PR DESCRIPTION
This change removes data collection reordering from the Portal. It also changes the behaviour such that the currently-selected layer is always on the top of the map view. This means that the layer you're subsetting is never obscured by another layer.