### PR TITLE
NonCollapsingAccordionLayout component name

### DIFF
--- a/web-app/js/portal/details/SubsetPanelAccordion.js
+++ b/web-app/js/portal/details/SubsetPanelAccordion.js
@@ -13,7 +13,7 @@ Portal.details.SubsetPanelAccordion = Ext.extend(Ext.Panel, {
 
         var config = Ext.apply({
             cls: 'subsetPanelAccordion',
-            layout: 'nonCollapsingAccordion',
+            layout: 'noncollapsingaccordion',
             autoScroll: true,
             layoutConfig: {
                 animate: true,

--- a/web-app/js/portal/prototypes/NonCollapsingAccordionLayout.js
+++ b/web-app/js/portal/prototypes/NonCollapsingAccordionLayout.js
@@ -38,4 +38,4 @@ Ext.ux.NonCollapsingAccordionLayout = Ext.extend( Ext.layout.Accordion, {
         if( panel == this.currentlyExpandedPanel ) return false;
     }
 });
-Ext.Container.LAYOUTS[ 'nonCollapsingAccordion' ] = Ext.ux.NonCollapsingAccordionLayout;
+Ext.Container.LAYOUTS[ 'noncollapsingaccordion' ] = Ext.ux.NonCollapsingAccordionLayout;


### PR DESCRIPTION
This fixes a bug that @pmbohm spotted where Ext has trouble with names that aren't all lowercase.