### PR TITLE
fixes #1821 - without creating new bugs!

### DIFF
--- a/web-app/js/portal/details/SubsettingPanel.js
+++ b/web-app/js/portal/details/SubsettingPanel.js
@@ -69,27 +69,20 @@ Portal.details.SubsettingPanel = Ext.extend(Ext.Panel, {
             layer: layer,
             layerItemId: this._getItemIdForLayer(layer),
             listeners: {
-                expand: this._fireSelectedLayerChangedEvent(layer),
-                scope: this
+                expand: function (panel) {
+                    Ext.MsgBus.publish(PORTAL_EVENTS.SELECTED_LAYER_CHANGED, panel.layer);
+                }
             }
         });
 
         this.subsetPanelAccordion.add(layerContainer);
-        this.subsetPanelAccordion.doLayout();
         this.emptyTextPanel.hide();
-    },
-
-    _fireSelectedLayerChangedEvent: function(layer) {
-        return function() {
-            Ext.MsgBus.publish(PORTAL_EVENTS.SELECTED_LAYER_CHANGED, layer);
-        }
+        this.subsetPanelAccordion.doLayout();
     },
 
     _activateItemForLayer: function(layer) {
-
         if (this._itemExistsForLayer(layer)) {
             this.subsetPanelAccordion.layout.setActiveItem(this._getItemIdForLayer(layer));
-            this.subsetPanelAccordion.items.item(this._getItemIdForLayer(layer)).expand();
         }
     },
 

--- a/web-app/js/portal/prototypes/NonCollapsingAccordionLayout.js
+++ b/web-app/js/portal/prototypes/NonCollapsingAccordionLayout.js
@@ -24,18 +24,33 @@ Ext.ux.NonCollapsingAccordionLayout = Ext.extend( Ext.layout.Accordion, {
         // Setup event listeners for beforeexpand and beforecollapse to run the functionality
         c.on( 'beforeexpand', this.beforeExpandPanel, this );
         c.on( 'beforecollapse', this.beforeCollapsePanel, this );
+        c.on( 'destroy', this.onDestroy, this );
     },
 
-    beforeExpandPanel : function( panel ) {
+    beforeExpandPanel : function(panel) {
         var panelToCollapse = this.currentlyExpandedPanel;  // A holder for the previously selected panel
         this.currentlyExpandedPanel = panel;                // Set the new panel as the currently expanded one
         panelToCollapse.collapse();                         // Collapse the previously selected panel
         return true;
     },
 
-    beforeCollapsePanel : function( panel ) {
+    beforeCollapsePanel : function(panel) {
         // Cancel the collapse if the panel to collapse is the currently expanded panel
         if( panel == this.currentlyExpandedPanel ) return false;
+    },
+
+    onDestroy: function(panel) {
+        if( panel == this.currentlyExpandedPanel ) {
+            var lastItem = this.container.items.length - 1;
+            if (lastItem > -1) {
+                this.currentlyExpandedPanel = this.container.items.items[lastItem];
+                this.currentlyExpandedPanel.expand();
+            }
+            else {
+                this.currentlyExpandedPanel = null;
+            }
+        }
     }
+
 });
 Ext.Container.LAYOUTS[ 'noncollapsingaccordion' ] = Ext.ux.NonCollapsingAccordionLayout;


### PR DESCRIPTION
Now publishes 'PORTAL_EVENTS.SELECTED_LAYER_CHANGED' when an accordion item is expanded, therefore the map is notified