### PR TITLE
New helper function for testing

### DIFF
--- a/src/test/javascript/SpecHelperSpec.js
+++ b/src/test/javascript/SpecHelperSpec.js
@@ -67,4 +67,21 @@ describe('Custom matchers', function () {
             expect([]).not.toBeNonEmptyString();
         });
     });
+
+    describe('returns()', function() {
+
+        it('returns the value it was created with', function() {
+
+            var testObj = {};
+            var returnNumber = returns(64);
+            var returnBool = returns(false);
+            var returnObject = returns(testObj);
+            var returnsUndefined = returns(undefined);
+
+            expect(returnNumber()).toBe(64);
+            expect(returnBool()).toBe(false);
+            expect(returnObject()).toBe(testObj);
+            expect(returnsUndefined()).toBe(undefined);
+        });
+    });
 });

--- a/src/test/javascript/portal/cart/BaseInjectorSpec.js
+++ b/src/test/javascript/portal/cart/BaseInjectorSpec.js
@@ -62,7 +62,7 @@ describe('Portal.cart.BaseInjector', function() {
 
     describe('getDataMarkup', function() {
         beforeEach(function() {
-            injector._shouldEstimateSize = function() { return true; }
+            injector._shouldEstimateSize = returns(true)
         });
 
         it('returns the failed message if it can not calculate an estimate', function() {
@@ -77,8 +77,8 @@ describe('Portal.cart.BaseInjector', function() {
             var sizeEstimateParams = {};
 
             geoNetworkRecord.dataDownloadHandlers.push({
-                canEstimateDownloadSize: function() { return true },
-                getDownloadEstimateParams: function() { return sizeEstimateParams }
+                canEstimateDownloadSize: returns(true),
+                getDownloadEstimateParams: returns(sizeEstimateParams)
             });
 
             var markup = injector._getDataMarkup(geoNetworkRecord);

--- a/src/test/javascript/portal/cart/DownloadConfirmationWindowSpec.js
+++ b/src/test/javascript/portal/cart/DownloadConfirmationWindowSpec.js
@@ -74,19 +74,19 @@ describe("Portal.cart.DownloadConfirmationWindow", function() {
                 });
 
                 it('disables download button when email address is invalid', function() {
-                    confirmationWindow.downloadEmailPanel.isVisible = function() { return true };
+                    confirmationWindow.downloadEmailPanel.isVisible = returns(true);
                     confirmationWindow.downloadEmailPanel.fireEvent('invalid');
                     expect(downloadButton.disable).toHaveBeenCalled();
                 });
 
                 it('enables download button when email address is valid', function() {
-                    confirmationWindow.downloadEmailPanel.isVisible = function() { return true };
+                    confirmationWindow.downloadEmailPanel.isVisible = returns(true);
                     confirmationWindow.downloadEmailPanel.fireEvent('valid');
                     expect(downloadButton.enable).toHaveBeenCalled();
                 });
 
                 it('does nothing if email address panel is hidden', function() {
-                    confirmationWindow.downloadEmailPanel.isVisible = function() { return false };
+                    confirmationWindow.downloadEmailPanel.isVisible = returns(false);
 
                     Ext.each(['valid', 'invalid'], function(event) {
                         confirmationWindow.downloadEmailPanel.fireEvent(event);

--- a/src/test/javascript/portal/cart/DownloaderSpec.js
+++ b/src/test/javascript/portal/cart/DownloaderSpec.js
@@ -20,7 +20,7 @@ describe("Portal.cart.Downloader", function() {
         wfsDownloadUrl = 'http://download';
         generateUrlCallback = jasmine.createSpy('generateUrl').andReturn(wfsDownloadUrl);
         downloadToken = 1234;
-        downloader._newDownloadToken = function() { return downloadToken; }
+        downloader._newDownloadToken = returns(downloadToken);
 
         collection = {};
         params = {};

--- a/src/test/javascript/portal/cart/InsertionServiceSpec.js
+++ b/src/test/javascript/portal/cart/InsertionServiceSpec.js
@@ -17,7 +17,7 @@ describe('Portal.cart.InsertionService', function() {
             title: 'the title',
             uuid: '42',
             wmsLayer: {
-                isNcwms: function() {return false}
+                isNcwms: returns(false)
             },
             aggregator: { childAggregators: [] }
         };
@@ -100,7 +100,7 @@ describe('Portal.cart.InsertionService', function() {
     }
 
     function getNcwmsRecord() {
-        geoNetworkRecord.wmsLayer.isNcwms = function() {return true};
+        geoNetworkRecord.wmsLayer.isNcwms = returns(true);
 
         geoNetworkRecord.dataDownloadHandlers = [{}];
 

--- a/src/test/javascript/portal/cart/WmsInjectorSpec.js
+++ b/src/test/javascript/portal/cart/WmsInjectorSpec.js
@@ -46,8 +46,8 @@ describe('Portal.cart.WmsInjector', function() {
     function fakeFilter(s) {
 
         return {
-            getHumanReadableForm: function() { return s },
-            hasValue: function() { return true }
+            getHumanReadableForm: returns(s),
+            hasValue: returns(true)
         };
     }
 });

--- a/src/test/javascript/portal/common/LayerDescriptorSpec.js
+++ b/src/test/javascript/portal/common/LayerDescriptorSpec.js
@@ -158,9 +158,7 @@ describe("Portal.common.LayerDescriptor", function() {
                 data: {
                     bbox: {
                         geometries: [],
-                        getBounds: function() {
-                            return new OpenLayers.Bounds(1,2,3,4);
-                        }
+                        getBounds: returns(new OpenLayers.Bounds(1,2,3,4))
                     }
                 }
             };

--- a/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
@@ -86,7 +86,7 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
             };
 
             spyOn(Portal.filter.combiner, 'BodaacCqlBuilder').andReturn({
-                buildCql: function() { return 'the_cql' }
+                buildCql: returns('the_cql')
             });
 
             urlFn(testCollection);
@@ -111,7 +111,7 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
 
             testCollection = {
                 wmsLayer: {
-                    _buildGetFeatureRequestUrl: function() { return 'the_url' }
+                    _buildGetFeatureRequestUrl: returns('the_url')
                 }
             };
         });

--- a/src/test/javascript/portal/data/GeoNetworkRecordFetcherSpec.js
+++ b/src/test/javascript/portal/data/GeoNetworkRecordFetcherSpec.js
@@ -76,7 +76,7 @@ describe("Portal.data.GeoNetworkRecordFetcher", function() {
             Ext.each(testCases, function(testValues) {
                 var testUrl = testValues[0];
                 var expectedOutput = testValues[1];
-                fetcher._getUrl = function() { return testUrl };
+                fetcher._getUrl = returns(testUrl);
 
                 var actualOutput = fetcher.getUuidsFromUrl();
 

--- a/src/test/javascript/portal/data/LayerStoreSpec.js
+++ b/src/test/javascript/portal/data/LayerStoreSpec.js
@@ -74,7 +74,7 @@ describe("Portal.data.LayerStore", function() {
         });
 
         it('GeoServer', function() {
-            spyOn(Portal.data.Server, 'getInfo').andReturn({ getLayerType: function() { return 'type'; } });
+            spyOn(Portal.data.Server, 'getInfo').andReturn({ getLayerType: returns('type') });
             spyOn(layerStore, 'addUsingDescriptor');
 
             layerStore.addUsingLayerLink("layerName", layerLink, {}, layerRecordCallback);

--- a/src/test/javascript/portal/details/NcWmsPanelSpec.js
+++ b/src/test/javascript/portal/details/NcWmsPanelSpec.js
@@ -23,8 +23,8 @@ describe('Portal.details.NcWmsPanel', function() {
         spyOn(Portal.ui.TimeRangeLabel.prototype, 'update');
 
         layer = _mockLayer();
-        layer.getMissingDays =  function() { return [] };
-        layer.isNcwms = function() { return true };
+        layer.getMissingDays = returns([]);
+        layer.isNcwms = returns(true);
         layer.events = { on: noOp };
         layer.processTemporalExtent = noOp;
         layer.map = map;
@@ -96,8 +96,8 @@ describe('Portal.details.NcWmsPanel', function() {
 
     describe('reset button', function() {
         it('resets the temporal extent', function() {
-            layer.getTemporalExtentMin = function() { return "ExtentMin"; };
-            layer.getTemporalExtentMax = function() { return "ExtentMax"; };
+            layer.getTemporalExtentMin = returns("ExtentMin");
+            layer.getTemporalExtentMax = returns("ExtentMax");
 
             spyOn(ncwmsPanel, '_resetExtent');
             ncwmsPanel.resetConstraints();
@@ -194,8 +194,8 @@ describe('Portal.details.NcWmsPanel', function() {
                 return this.temporalExtent;
             },
             setSubsetExtentView: function() {},
-            getSubsetExtentMin: function() { return extent.min(); },
-            getSubsetExtentMax: function() { return extent.max(); }
+            getSubsetExtentMin: returns(extent.min()),
+            getSubsetExtentMax: returns(extent.max())
         };
     }
 });

--- a/src/test/javascript/portal/details/NcWmsPanelSpec.js
+++ b/src/test/javascript/portal/details/NcWmsPanelSpec.js
@@ -34,7 +34,7 @@ describe('Portal.details.NcWmsPanel', function() {
             layer: layer
         });
 
-        ncwmsPanel._setBounds =  noOp;
+        ncwmsPanel._setBounds = noOp;
         ncwmsPanel._removeLoadingInfo = noOp;
         ncwmsPanel.selectedLayer = layer;
 

--- a/src/test/javascript/portal/details/PolygonDisplayPanelSpec.js
+++ b/src/test/javascript/portal/details/PolygonDisplayPanelSpec.js
@@ -29,9 +29,7 @@ describe('Portal.details.PolygonDisplayPanel', function() {
         it('calls load data', function() {
             var vertices = ['1 1', '2 2'];
             var geometry = {
-                getVertices: function() {
-                    return vertices;
-                }
+                getVertices: returns(vertices)
             };
 
             spyOn(polyDisplayPanel.verticesStore, 'loadData');

--- a/src/test/javascript/portal/details/SpatialConstraintDisplayPanelSpec.js
+++ b/src/test/javascript/portal/details/SpatialConstraintDisplayPanelSpec.js
@@ -68,7 +68,7 @@ describe("Portal.details.SpatialConstraintDisplayPanel", function() {
 
             it('shows box display panel when constraint is box', function() {
                 var geometry = {
-                    isBox: function() { return true; }
+                    isBox: returns(true)
                 };
 
                 spyOn(displayPanel, '_showCard');
@@ -80,7 +80,7 @@ describe("Portal.details.SpatialConstraintDisplayPanel", function() {
 
             it('shows polygon display panel when constraint is polygon', function() {
                 var geometry = {
-                    isBox: function() { return false; }
+                    isBox: returns(false)
                 };
 
                 spyOn(displayPanel, '_showCard');

--- a/src/test/javascript/portal/details/StylePanelSpec.js
+++ b/src/test/javascript/portal/details/StylePanelSpec.js
@@ -112,7 +112,7 @@ describe("Portal.details.StylePanel", function() {
             };
 
             var layer = {
-                isNcwms: function() {return true},
+                isNcwms: returns(true),
                 styles: [
                     {name: 'style1', palette: 'palette1'},
                     {name: 'style1', palette: 'palette2'},
@@ -155,7 +155,7 @@ describe("Portal.details.StylePanel", function() {
 
         it('does not load combo box data if 1 style or fewer', function() {
 
-            stylePanel._processStyleData = function() { return ['style1'] };
+            stylePanel._processStyleData = returns(['style1']);
 
             stylePanel._stylesLoaded();
 
@@ -168,7 +168,7 @@ describe("Portal.details.StylePanel", function() {
         it('loads combo box data if more than 1 style to choose from', function() {
 
             var styles = ['style1', 'style2'];
-            stylePanel._processStyleData = function() { return styles };
+            stylePanel._processStyleData = returns(styles);
 
             stylePanel._stylesLoaded();
 
@@ -181,8 +181,8 @@ describe("Portal.details.StylePanel", function() {
 
     describe("_getPalette(layer)", function() {
 
-        var ncWmsLayer = {isNcwms: function() {return true}};
-        var otherLayer = {isNcwms: function() {return false}};
+        var ncWmsLayer = {isNcwms: returns(true)};
+        var otherLayer = {isNcwms: returns(false)};
 
         it("Returns palette when the style is in the form style/palette", function() {
 

--- a/src/test/javascript/portal/filter/FilterServiceSpec.js
+++ b/src/test/javascript/portal/filter/FilterServiceSpec.js
@@ -104,7 +104,7 @@ describe("Portal.filter.FilterService", function() {
 
         it('should use download layer if present', function() {
 
-            layer.getDownloadLayer = function() { return 'wfsName'; };
+            layer.getDownloadLayer = returns('wfsName');
 
             expect(service._filterLayerName(layer)).toBe('wfsName');
         });

--- a/src/test/javascript/portal/filter/GeometryFilterSpec.js
+++ b/src/test/javascript/portal/filter/GeometryFilterSpec.js
@@ -16,12 +16,12 @@ describe("Portal.filter.GeometryFilter", function() {
             filter = new Portal.filter.GeometryFilter({
                 name: 'column_name',
                 value: {
-                    toWkt: function() { return 'WKT' },
-                    getBounds: function() { return 'bounds' }
+                    toWkt: returns('WKT'),
+                    getBounds: returns('bounds')
                 }
             });
             filter.map = {
-                getSpatialConstraintType: function() { return 'polygon' }
+                getSpatialConstraintType: returns('polygon')
             };
         });
 
@@ -53,12 +53,12 @@ describe("Portal.filter.GeometryFilter", function() {
             filter = new Portal.filter.GeometryFilter({
                 name: 'column_name',
                 value: {
-                    toWkt: function() { return 'WKT' },
-                    getBounds: function() { return 'bounds' }
+                    toWkt: returns('WKT'),
+                    getBounds: returns('bounds')
                 }
             });
             filter.map = {
-                getSpatialConstraintType: function() { return 'box' }
+                getSpatialConstraintType: returns('box')
             };
         });
 

--- a/src/test/javascript/portal/filter/NumberFilterSpec.js
+++ b/src/test/javascript/portal/filter/NumberFilterSpec.js
@@ -15,7 +15,7 @@ describe("Portal.filter.NumberFilter", function() {
             name: 'column_name',
             label: 'Important number'
         });
-        filter._generateOperatorHtml = function() { return 'html' };
+        filter._generateOperatorHtml = returns('html');
     });
 
     describe('empty value entered', function() {

--- a/src/test/javascript/portal/filter/combiner/BodaacCqlBuilderSpec.js
+++ b/src/test/javascript/portal/filter/combiner/BodaacCqlBuilderSpec.js
@@ -16,24 +16,24 @@ describe("Portal.filter.combiner.BodaacCqlBuilder", function() {
             filters: [
                 {
                     constructor: Portal.filter.GeometryFilter, // Is Geometry filter
-                    isVisualised: function() { return true },
-                    hasValue: function() { return true },
-                    getCql: function() { return 'cql1' }
+                    isVisualised: returns(true),
+                    hasValue: returns(true),
+                    getCql: returns('cql1')
                 },
                 {
-                    isVisualised: function() { return false }, // Not visualised
-                    hasValue: function() { return true },
-                    getCql: function() { return 'cql2' }
+                    isVisualised: returns(false), // Not visualised
+                    hasValue: returns(true),
+                    getCql: returns('cql2')
                 },
                 {
-                    isVisualised: function() { return true },
-                    hasValue: function() { return false }, // No value
-                    getCql: function() { return 'cql3' }
+                    isVisualised: returns(true),
+                    hasValue: returns(false), // No value
+                    getCql: returns('cql3')
                 },
                 {
-                    isVisualised: function() { return true },
-                    hasValue: function() { return true },
-                    getCql: function() { return 'cql4' }
+                    isVisualised: returns(true),
+                    hasValue: returns(true),
+                    getCql: returns('cql4')
                 }
             ]
         };

--- a/src/test/javascript/portal/filter/combiner/DataDownloadCqlBuilderSpec.js
+++ b/src/test/javascript/portal/filter/combiner/DataDownloadCqlBuilderSpec.js
@@ -16,24 +16,24 @@ describe("Portal.filter.combiner.DataDownloadCqlBuilder", function() {
             filters: [
                 {
                     constructor: Portal.filter.GeometryFilter, // Is Geometry filter
-                    isVisualised: function() { return true },
-                    hasValue: function() { return true },
-                    getCql: function() { return 'cql1' }
+                    isVisualised: returns(true),
+                    hasValue: returns(true),
+                    getCql: returns('cql1')
                 },
                 {
-                    isVisualised: function() { return false }, // Not visualised
-                    hasValue: function() { return true },
-                    getCql: function() { return 'cql2' }
+                    isVisualised: returns(false), // Not visualised
+                    hasValue: returns(true),
+                    getCql: returns('cql2')
                 },
                 {
-                    isVisualised: function() { return true },
-                    hasValue: function() { return false }, // No value
-                    getCql: function() { return 'cql3' }
+                    isVisualised: returns(true),
+                    hasValue: returns(false), // No value
+                    getCql: returns('cql3')
                 },
                 {
-                    isVisualised: function() { return true },
-                    hasValue: function() { return true },
-                    getCql: function() { return 'cql4' }
+                    isVisualised: returns(true),
+                    hasValue: returns(true),
+                    getCql: returns('cql4')
                 }
             ]
         };

--- a/src/test/javascript/portal/filter/combiner/HumanReadableFilterDescriberSpec.js
+++ b/src/test/javascript/portal/filter/combiner/HumanReadableFilterDescriberSpec.js
@@ -16,24 +16,24 @@ describe("Portal.filter.combiner.HumanReadableFilterDescriber", function() {
             filters: [
                 {
                     constructor: Portal.filter.GeometryFilter, // Is Geometry filter
-                    isVisualised: function() { return true },
-                    hasValue: function() { return true },
-                    getHumanReadableForm: function() { return 'one' }
+                    isVisualised: returns(true),
+                    hasValue: returns(true),
+                    getHumanReadableForm: returns('one')
                 },
                 {
-                    isVisualised: function() { return false }, // Not visualised
-                    hasValue: function() { return true },
-                    getHumanReadableForm: function() { return 'two' }
+                    isVisualised: returns(false), // Not visualised
+                    hasValue: returns(true),
+                    getHumanReadableForm: returns('two')
                 },
                 {
-                    isVisualised: function() { return true },
-                    hasValue: function() { return false }, // No value
-                    getHumanReadableForm: function() { return 'three' }
+                    isVisualised: returns(true),
+                    hasValue: returns(false), // No value
+                    getHumanReadableForm: returns('three')
                 },
                 {
-                    isVisualised: function() { return true },
-                    hasValue: function() { return true },
-                    getHumanReadableForm: function() { return 'four' }
+                    isVisualised: returns(true),
+                    hasValue: returns(true),
+                    getHumanReadableForm: returns('four')
                 }
             ]
         };

--- a/src/test/javascript/portal/filter/combiner/MapCqlBuilderSpec.js
+++ b/src/test/javascript/portal/filter/combiner/MapCqlBuilderSpec.js
@@ -16,29 +16,29 @@ describe("Portal.filter.combiner.MapCqlBuilder", function() {
             filters: [
                 {
                     constructor: Portal.filter.GeometryFilter, // Is Geometry filter
-                    isVisualised: function() { return true },
-                    hasValue: function() { return true },
-                    getCql: function() { return 'cql1' }
+                    isVisualised: returns(true),
+                    hasValue: returns(true),
+                    getCql: returns('cql1')
                 },
                 {
-                    isVisualised: function() { return false }, // Not visualised
-                    hasValue: function() { return true },
-                    getCql: function() { return 'cql2' }
+                    isVisualised: returns(false), // Not visualised
+                    hasValue: returns(true),
+                    getCql: returns('cql2')
                 },
                 {
-                    isVisualised: function() { return true },
-                    hasValue: function() { return false }, // No value
-                    getCql: function() { return 'cql3' }
+                    isVisualised: returns(true),
+                    hasValue: returns(false), // No value
+                    getCql: returns('cql3')
                 },
                 {
-                    isVisualised: function() { return true },
-                    hasValue: function() { return true },
-                    getCql: function() { return 'cql4' }
+                    isVisualised: returns(true),
+                    hasValue: returns(true),
+                    getCql: returns('cql4')
                 },
                 {
-                    isVisualised: function() { return true },
-                    hasValue: function() { return true },
-                    getCql: function() { return 'cql5' }
+                    isVisualised: returns(true),
+                    hasValue: returns(true),
+                    getCql: returns('cql5')
                 }
             ]
         };

--- a/src/test/javascript/portal/filter/ui/BooleanFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/BooleanFilterPanelSpec.js
@@ -11,7 +11,7 @@ describe("Portal.filter.ui.BooleanFilterPanel", function() {
 
     beforeEach(function() {
         var MockButton = function() {
-            this.getValue = function() { return false; };
+            this.getValue = returns(false);
             this.setValue = jasmine.createSpy();
         };
 
@@ -21,13 +21,13 @@ describe("Portal.filter.ui.BooleanFilterPanel", function() {
 
         booleanFilter = new Portal.filter.ui.BooleanFilterPanel({
             filter: {
-                getName: function() { return 'test' },
-                getLabel: function() { return 'testLabel' },
+                getName: returns('test'),
+                getLabel: returns('testLabel'),
                 setValue: noOp
             },
             layer: {
                 name: 'test layer',
-                getDownloadCql: function() { return ""; }
+                getDownloadCql: returns("")
             }
         });
 

--- a/src/test/javascript/portal/filter/ui/ComboFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/ComboFilterPanelSpec.js
@@ -20,13 +20,13 @@ describe("Portal.filter.ui.ComboFilterPanel", function() {
 
         filterPanel = new Portal.filter.ui.ComboFilterPanel({
             filter: {
-                getName: function() { return 'test' },
-                getLabel: function() { return 'testLabel' },
+                getName: returns('test'),
+                getLabel: returns('testLabel'),
                 setValue: noOp
             },
             layer: {
                 name: 'test layer',
-                getDownloadCql: function() { return ""; }
+                getDownloadCql: returns("")
             }
         });
     });
@@ -35,20 +35,20 @@ describe("Portal.filter.ui.ComboFilterPanel", function() {
 
         beforeEach(function() {
             filterPanel.combo = {};
-            filterPanel.getRawValue = function() { return "L'Astrolabe"; };
+            filterPanel.getRawValue = returns("L'Astrolabe");
             filterPanel.markInvalid = noOp;
         });
 
         it('should return true when in the store', function() {
 
-            filterPanel.findRecord = function() { return true; };
+            filterPanel.findRecord = returns(true);
             expect(filterPanel.validateValue()).toEqual(true);
         });
 
         it('should mark combo invalid when not in the store', function() {
 
             spyOn(filterPanel, 'markInvalid');
-            filterPanel.findRecord = function() { return undefined; };
+            filterPanel.findRecord = returns(undefined);
             filterPanel.validateValue("anything");
             expect(filterPanel.markInvalid).toHaveBeenCalled();
             expect(filterPanel.validateValue()).toEqual(false);
@@ -61,7 +61,7 @@ describe("Portal.filter.ui.ComboFilterPanel", function() {
             spyOn(window, 'trackUsage');
             filterPanel.filter.setValue = jasmine.createSpy('setValue');
             filterPanel.combo = {
-                getValue: function() { return "value" },
+                getValue: returns("value"),
                 disabled: false
             };
         });

--- a/src/test/javascript/portal/filter/ui/DateFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/DateFilterPanelSpec.js
@@ -25,9 +25,7 @@ describe("Portal.filter.ui.DateFilterPanel", function() {
             },
             layer: {
                 name: 'layerName',
-                getDownloadCql: function() {
-                    return '';
-                }
+                getDownloadCql: returns('')
             },
             setLayerAndFilter: noOp
         });
@@ -68,7 +66,7 @@ describe("Portal.filter.ui.DateFilterPanel", function() {
         });
 
         it('fires events when required fields are set', function() {
-            component._dateField.getValue = function() { return '12-02-1990' };
+            component._dateField.getValue = returns('12-02-1990');
             filterPanel._applyDateFilter(component);
             expect(window.trackUsage).toHaveBeenCalledWith("Filters", "Date", "atestname user set 12-02-1990", "layerName");
             expect(filterPanel._fireAddEvent).toHaveBeenCalled();

--- a/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
@@ -16,8 +16,8 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
     beforeEach(function() {
         layer = new OpenLayers.Layer.WMS();
         layer.server = { uri: "uri" };
-        layer.getDownloadLayer = function() { return "downloadLayer"; };
-        layer.isKnownToThePortal = function() { return true; };
+        layer.getDownloadLayer = returns("downloadLayer");
+        layer.isKnownToThePortal = returns(true);
         layer.map = getMockMap();
 
         filterGroupPanel = new Portal.filter.ui.FilterGroupPanel({
@@ -42,9 +42,7 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
             };
 
             filterPanel = {
-                needsFilterRange: function() {
-                    return false;
-                }
+                needsFilterRange: returns(false)
             };
 
             filterGroupPanel = new Portal.filter.ui.FilterGroupPanel(cfg);
@@ -81,38 +79,38 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
                 filters: [
                     {
                         constructor: Portal.filter.BooleanFilter,
-                        isVisualised: function() { return true },
-                        hasValue: function() { return true },
-                        getLabel: function() { return "kappa" },
-                        getHumanReadableForm: function() { return 'four' }
+                        isVisualised: returns(true),
+                        hasValue: returns(true),
+                        getLabel: returns("kappa"),
+                        getHumanReadableForm: returns('four')
                     },
                     {
                         constructor: Portal.filter.BooleanFilter,
-                        isVisualised: function() { return false },
-                        hasValue: function() { return true },
-                        getLabel: function() { return "gamma" },
-                        getHumanReadableForm: function() { return 'two' }
+                        isVisualised: returns(false),
+                        hasValue: returns(true),
+                        getLabel: returns("gamma"),
+                        getHumanReadableForm: returns('two')
                     },
                     {
                         constructor: Portal.filter.StringFilter,
-                        isVisualised: function() { return true },
-                        hasValue: function() { return false },
-                        getLabel: function() { return "beta" },
-                        getHumanReadableForm: function() { return 'three' }
+                        isVisualised: returns(true),
+                        hasValue: returns(false),
+                        getLabel: returns("beta"),
+                        getHumanReadableForm: returns('three')
                     },
                     {
                         constructor: Portal.filter.StringFilter,
-                        isVisualised: function() { return true },
-                        hasValue: function() { return true },
-                        getLabel: function() { return "omega" },
-                        getHumanReadableForm: function() { return 'five' }
+                        isVisualised: returns(true),
+                        hasValue: returns(true),
+                        getLabel: returns("omega"),
+                        getHumanReadableForm: returns('five')
                     },
                     {
                         constructor: Portal.filter.GeometryFilter,
-                        isVisualised: function() { return true },
-                        hasValue: function() { return true },
-                        getLabel: function() { return "alpha" },
-                        getHumanReadableForm: function() { return 'one' }
+                        isVisualised: returns(true),
+                        hasValue: returns(true),
+                        getLabel: returns("alpha"),
+                        getHumanReadableForm: returns('one')
                     }
                 ]
             };
@@ -138,8 +136,8 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
             layer = {
                 server: { uri: "uri" }
             };
-            layer.isKnownToThePortal = function() { return true };
-            filterGroupPanel._isLayerActive = function() {return true};
+            layer.isKnownToThePortal = returns(true);
+            filterGroupPanel._isLayerActive = returns(true);
 
             filterGroupPanel = new Portal.filter.ui.FilterGroupPanel({
                 layer: layer
@@ -148,9 +146,7 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
             filters = ["Boolean"];
 
             filterPanel = {
-                needsFilterRange: function() {
-                    return false;
-                }
+                needsFilterRange: returns(false)
             };
 
             spyOn(filterGroupPanel, '_clearFilters');
@@ -178,16 +174,14 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
             layer = {
                 server: { uri: "uri" }
             };
-            filterGroupPanel._isLayerActive = function() {return true};
+            filterGroupPanel._isLayerActive = returns(true);
 
             filterGroupPanel = new Portal.filter.ui.FilterGroupPanel({
                 layer: layer
             });
 
             filterPanel = {
-                needsFilterRange: function() {
-                    return false;
-                }
+                needsFilterRange: returns(false)
             };
 
             spyOn(filterGroupPanel, '_updateLayerFilters');

--- a/src/test/javascript/portal/filter/ui/GeometryFilterServiceSpec.js
+++ b/src/test/javascript/portal/filter/ui/GeometryFilterServiceSpec.js
@@ -13,14 +13,14 @@ describe("Portal.filter.GeometryFilterService", function() {
     beforeEach(function() {
         map = new OpenLayers.SpatialConstraintMap();
         map.navigationControl = {};
-        map.navigationControl.deactivate = function() { return null };
+        map.navigationControl.deactivate = returns(null);
 
         spyOn(Portal.filter.ui.GeometryFilterService.prototype, 'setLayerAndFilter');
         spyOn(Portal.filter.ui.GeometryFilterService.prototype, '_updateWithGeometry');
         filterPanel = new Portal.filter.ui.GeometryFilterService({
             map: map,
             filter: {
-                getName: function() { return 'geom_filter' },
+                getName: returns('geom_filter'),
                 setValue: noOp,
                 clearValue: noOp
             }

--- a/src/test/javascript/portal/filter/ui/NumberFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/NumberFilterPanelSpec.js
@@ -143,19 +143,17 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
             expect(numberFilter.filter.setValue).toHaveBeenCalled();
         });
 
-
         it('updates when operator is set to none / cleared ', function() {
             spyOn(numberFilter, '_fireAddEvent');
 
-            numberFilter.operators.clearValue = function() { noOp };
-            numberFilter.firstField.reset = function() { noOp };
-            numberFilter.secondField.reset = function() { noOp };
-            numberFilter.secondField.setVisible = function() { noOp };
-            numberFilter.filter.clearValue = function() { noOp };
+            numberFilter.operators.clearValue = noOp;
+            numberFilter.firstField.reset = noOp;
+            numberFilter.secondField.reset = noOp;
+            numberFilter.secondField.setVisible = noOp;
+            numberFilter.filter.clearValue = noOp;
 
             numberFilter.handleRemoveFilter();
             expect(numberFilter._fireAddEvent).toHaveBeenCalled();
         });
-
     });
 });

--- a/src/test/javascript/portal/filter/ui/NumberFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/NumberFilterPanelSpec.js
@@ -13,23 +13,15 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
 
         Portal.filter.ui.NumberFilterPanel.prototype._createControls = function() {
             this.firstField = {
-                getValue: function() {
-                    return false;
-                },
-                validate: function() {
-                    return true;
-                }
+                getValue: returns(false),
+                validate: returns(true)
             };
             this.operators = {
                 getValue: noOp
             };
             this.secondField = {
-                getValue: function() {
-                    return false;
-                },
-                validate: function() {
-                    return true;
-                }
+                getValue: returns(false),
+                validate: returns(true)
             };
         };
 
@@ -48,11 +40,11 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
     describe('_updateFilter', function() {
         beforeEach(function() {
             numberFilter._createControls();
-            numberFilter.firstField.getValue = function() { return 5 };
+            numberFilter.firstField.getValue = returns(5);
             numberFilter.firstField.clearInvalid = function() {};
             numberFilter.secondField.clearInvalid = function() {};
-            numberFilter.firstField.validateValue = function() {return true};
-            numberFilter.secondField.validateValue = function() {return true};
+            numberFilter.firstField.validateValue = returns(true);
+            numberFilter.secondField.validateValue = returns(true);
             numberFilter.operators = {
                 lastSelectionText: 'less than',
                 getValue: noOp,
@@ -65,7 +57,7 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
         it('sends correct tracking data  when operator is not between', function() {
             spyOn(window, 'trackUsage');
 
-            numberFilter._operatorIsBetween = function() { return false };
+            numberFilter._operatorIsBetween = returns(false);
             numberFilter._updateFilter();
 
             expect(window.trackUsage).toHaveBeenCalledWith("Filters", "Number", "testLabel less than 5", "test layer");
@@ -74,9 +66,9 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
         it('sends correct tracking data when operator is between', function() {
             spyOn(window, 'trackUsage');
 
-            numberFilter._operatorIsBetween = function() { return true };
+            numberFilter._operatorIsBetween = returns(true);
             numberFilter.operators.lastSelectionText = 'between';
-            numberFilter.secondField.getValue = function() { return 6 };
+            numberFilter.secondField.getValue = returns(6);
             numberFilter._updateFilter();
 
             expect(window.trackUsage).toHaveBeenCalledWith("Filters", "Number", "testLabel between 5 and 6", "test layer");
@@ -85,14 +77,14 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
         it('no update when operator is not set', function() {
             spyOn(numberFilter.filter, 'setValue');
 
-            numberFilter._operatorIsNotSet = function() { return true };
+            numberFilter._operatorIsNotSet = returns(true);
             numberFilter.operators.lastSelectionText = '';
 
             numberFilter._updateFilter();
             expect(numberFilter.filter.setValue).not.toHaveBeenCalled();
 
-            numberFilter.firstField.getValue = function() { return 4 };
-            numberFilter.secondField.getValue = function() { return 6 };
+            numberFilter.firstField.getValue = returns(4);
+            numberFilter.secondField.getValue = returns(6);
             numberFilter._updateFilter();
             expect(numberFilter.filter.setValue).not.toHaveBeenCalled();
         });
@@ -100,10 +92,10 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
         it('no trackusage when firstField is not set on updateFilter', function() {
             spyOn(window, 'trackUsage');
 
-            numberFilter._operatorIsNotSet = function() { return false };
-            numberFilter._shouldUpdate = function() { return true };
+            numberFilter._operatorIsNotSet = returns(false);
+            numberFilter._shouldUpdate = returns(true);
 
-            numberFilter.firstField.getValue = function() { return undefined };
+            numberFilter.firstField.getValue = returns(undefined);
             numberFilter._updateFilter();
             expect(window.trackUsage).not.toHaveBeenCalled();
         });
@@ -111,11 +103,11 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
         it('trackusage is called when firstField is set on updateFilter', function() {
             spyOn(window, 'trackUsage');
 
-            numberFilter._operatorIsNotSet = function() { return false };
-            numberFilter._operatorIsBetween = function() { return false };
-            numberFilter._shouldUpdate = function() { return true };
+            numberFilter._operatorIsNotSet = returns(false);
+            numberFilter._operatorIsBetween = returns(false);
+            numberFilter._shouldUpdate = returns(true);
 
-            numberFilter.firstField.getValue = function() { return "45" };
+            numberFilter.firstField.getValue = returns("45");
             numberFilter._updateFilter();
             expect(window.trackUsage).toHaveBeenCalledWith( 'Filters', 'Number', 'testLabel less than 45', 'test layer' );
         });
@@ -123,16 +115,16 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
         it('no update when operator is between and some values are empty', function() {
             spyOn(numberFilter.filter, 'setValue');
 
-            numberFilter._operatorIsBetween = function() { return true };
+            numberFilter._operatorIsBetween = returns(true);
             numberFilter.operators.lastSelectionText = 'between';
 
-            numberFilter.firstField.validateValue = function() {return false};
+            numberFilter.firstField.validateValue = returns(false);
 
             numberFilter._updateFilter();
             expect(numberFilter.filter.setValue).not.toHaveBeenCalled();
 
-            numberFilter.firstField.getValue = function() { return false };
-            numberFilter.secondField.getValue = function() { return 6 };
+            numberFilter.firstField.getValue = returns(false);
+            numberFilter.secondField.getValue = returns(6);
             numberFilter._updateFilter();
 
             expect(numberFilter.filter.setValue).not.toHaveBeenCalled();
@@ -141,11 +133,11 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
         it('updates when operator is between and both values are valid', function() {
             spyOn(numberFilter.filter, 'setValue');
 
-            numberFilter._operatorIsBetween = function() { return true };
+            numberFilter._operatorIsBetween = returns(true);
             numberFilter.operators.lastSelectionText = 'between';
 
-            numberFilter.firstField.getValue = function() { return 30000 }; // no sanity checking yet
-            numberFilter.secondField.getValue = function() { return 6 };
+            numberFilter.firstField.getValue = returns(30000); // no sanity checking yet
+            numberFilter.secondField.getValue = returns(6);
             numberFilter._updateFilter();
 
             expect(numberFilter.filter.setValue).toHaveBeenCalled();

--- a/src/test/javascript/portal/filter/validation/SpatialConstraintValidatorSpec.js
+++ b/src/test/javascript/portal/filter/validation/SpatialConstraintValidatorSpec.js
@@ -15,7 +15,7 @@ describe("Portal.filter.validation.SpatialConstraintValidator", function() {
 
     describe('getPercentOfViewportArea', function() {
         beforeEach(function() {
-            validator._getMapArea = function() { return 113 };
+            validator._getMapArea = returns(113);
         });
 
         it('returns the correct percentage of viewport area', function() {

--- a/src/test/javascript/portal/prototypes/OpenLayersSpec.js
+++ b/src/test/javascript/portal/prototypes/OpenLayersSpec.js
@@ -45,7 +45,7 @@ describe('OpenLayers', function() {
 
         describe("_is130", function() {
             it("returns false for ncwms", function() {
-                openLayer.isNcwms = function() { return true };
+                openLayer.isNcwms = returns(true);
                 openLayer.server = {wmsVersion: '1.3.0'};
                 expect(openLayer._is130()).toBeFalsy();
             });

--- a/src/test/javascript/portal/search/FacetFilterPanelSpec.js
+++ b/src/test/javascript/portal/search/FacetFilterPanelSpec.js
@@ -99,12 +99,8 @@ describe("Portal.search.FacetFilterPanel", function() {
     describe('_addDrilldownFilters', function() {
         beforeEach(function() {
             mockDrilldownPanel = {
-                hasDrilldown: function() {
-                    return false;
-                },
-                getDrilldownPath: function() {
-                    return 'a shrubbery';
-                }
+                hasDrilldown: returns(false),
+                getDrilldownPath: returns('a shrubbery')
             };
 
             spyOn(filterPanel, '_getDrilldownPanels').andReturn(mockDrilldownPanel);
@@ -117,9 +113,7 @@ describe("Portal.search.FacetFilterPanel", function() {
         });
 
         it('adds a filter if the panel has a drilldown', function() {
-            mockDrilldownPanel.hasDrilldown = function() {
-                return true;
-            };
+            mockDrilldownPanel.hasDrilldown = returns(true);
 
             filterPanel._addDrilldownFilters();
             expect(searcher.addDrilldownFilter).toHaveBeenCalled();

--- a/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
@@ -91,13 +91,9 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
                 hasWmsLink: noOp
             };
 
-            facetedSearchDataView.uuidFromElementId = function() {
-                return "my uuid";
-            };
+            facetedSearchDataView.uuidFromElementId = returns("my uuid");
 
-            facetedSearchDataView._getRecordFromUuid = function() {
-                return record;
-            };
+            facetedSearchDataView._getRecordFromUuid = returns(record);
 
             spyOn(window, 'trackUsage');
             spyOn(Ext.MsgBus, 'publish');
@@ -131,22 +127,15 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
 
     describe('_getMeasuredParametersAsCommaSeparatedString', function() {
 
-        var params;
-
-        beforeEach(function() {
-            params = [];
-
-            facetedSearchDataView._getMeasuredParameters = function() {
-                return params;
-            };
-        });
-
         it('with some parameters', function() {
-            params = ['temp', 'salinity'];
+            facetedSearchDataView._getMeasuredParameters = returns(['temp', 'salinity']);
+
             expect(facetedSearchDataView._getMeasuredParametersText()).toEqual('temp, salinity');
         });
 
         it('with no parameters', function() {
+            facetedSearchDataView._getMeasuredParameters = returns([]);
+
             expect(facetedSearchDataView._getMeasuredParametersText()).toEqual('No parameters');
         });
     });

--- a/src/test/javascript/portal/search/SearchBodyPanelSpec.js
+++ b/src/test/javascript/portal/search/SearchBodyPanelSpec.js
@@ -36,7 +36,7 @@ describe("Portal.search.SearchBodyPanel", function() {
         describe('onResultsStoreLoad', function() {
             it('displays alert when store is empty', function() {
                 spyOn(searchBodyPanel, '_displayNoResultsAlert');
-                searchBodyPanel.resultsStore.getTotalCount = function() { return 0; };
+                searchBodyPanel.resultsStore.getTotalCount = returns(0);
                 searchBodyPanel._onResultsStoreLoad();
                 expect(searchBodyPanel._displayNoResultsAlert).toHaveBeenCalled();
             });

--- a/src/test/javascript/portal/search/SearchFiltersPanelSpec.js
+++ b/src/test/javascript/portal/search/SearchFiltersPanelSpec.js
@@ -9,34 +9,32 @@ describe("Portal.search.SearchFiltersPanel", function() {
     var searchFiltersPanel;
 
     beforeEach(function() {
-        Portal.search.SearchFiltersPanel.prototype._getEnabledFacets = function() {
-            return [
-                {
-                    name: 'parameterFilter',
-                    key: 'Measured parameter',
-                    hierarchical: true
-                },
-                {
-                    name: 'organisationFilter',
-                    key: 'Organisation',
-                    collapsedByDefault: true,
-                    hierarchical: true
-                },
-                {
-                    name: 'platformFilter',
-                    key: 'Platform',
-                    hierarchical: true
-                },
-                {
-                    classId: "Portal.search.DateSelectionPanel",
-                    name: "dateFilter"
-                },
-                {
-                    classId: "Portal.search.GeoSelectionPanel",
-                    name: "geoFilter"
-                }
-            ];
-        }
+        Portal.search.SearchFiltersPanel.prototype._getEnabledFacets = returns([
+            {
+                name: 'parameterFilter',
+                key: 'Measured parameter',
+                hierarchical: true
+            },
+            {
+                name: 'organisationFilter',
+                key: 'Organisation',
+                collapsedByDefault: true,
+                hierarchical: true
+            },
+            {
+                name: 'platformFilter',
+                key: 'Platform',
+                hierarchical: true
+            },
+            {
+                classId: "Portal.search.DateSelectionPanel",
+                name: "dateFilter"
+            },
+            {
+                classId: "Portal.search.GeoSelectionPanel",
+                name: "geoFilter"
+            }
+        ]);
 
         searchFiltersPanel = new Portal.search.SearchFiltersPanel(_mockConfig());
         spyOn(searchFiltersPanel, '_setSpinnerText');
@@ -145,7 +143,7 @@ describe("Portal.search.SearchFiltersPanel", function() {
         return {
             on: noOp,
             search: noOp,
-            hasFacetNode: function() {return false;}
+            hasFacetNode: returns(false)
         }
     }
 });

--- a/src/test/javascript/portal/ui/FeatureInfoPopupSpec.js
+++ b/src/test/javascript/portal/ui/FeatureInfoPopupSpec.js
@@ -30,7 +30,7 @@ describe("Portal.ui.FeatureInfoPopup", function()
                 server: server
             }
         );
-        layer.isNcwms = function() { return true; }
+        layer.isNcwms = returns(true);
 
         map.addLayer(layer);
         featureInfoPopup = new Portal.ui.FeatureInfoPopup({map: map, appConfig: {}});
@@ -129,7 +129,7 @@ describe("Portal.ui.FeatureInfoPopup", function()
 
     describe('_getLayerFeatureInfoRequestString', function() {
         it('sets clickPoint and BUFFER param', function() {
-            featureInfoPopup._clickPoint = function() { return {}; };
+            featureInfoPopup._clickPoint = returns({});
             spyOn(layer, 'getFeatureInfoRequestString');
 
             Ext.namespace('Portal.app.appConfig.portal');

--- a/src/test/javascript/portal/ui/MainToolbarSpec.js
+++ b/src/test/javascript/portal/ui/MainToolbarSpec.js
@@ -32,8 +32,8 @@ describe("Portal.ui.MainToolbar", function() {
 
         describe('to first tab', function() {
             beforeEach(function() {
-                mainPanel.layout.hasPrevTab = function() { return false };
-                mainPanel.layout.hasNextTab = function() { return true };
+                mainPanel.layout.hasPrevTab = returns(false);
+                mainPanel.layout.hasNextTab = returns(true);
             });
 
             it('hides prev button', function() {
@@ -55,8 +55,8 @@ describe("Portal.ui.MainToolbar", function() {
 
         describe('to middle tab', function() {
             beforeEach(function() {
-                mainPanel.layout.hasPrevTab = function() { return true };
-                mainPanel.layout.hasNextTab = function() { return true };
+                mainPanel.layout.hasPrevTab = returns(true);
+                mainPanel.layout.hasNextTab = returns(true);
             });
 
             it('shows prev button', function() {
@@ -78,8 +78,8 @@ describe("Portal.ui.MainToolbar", function() {
 
         describe('to last tab', function() {
             beforeEach(function() {
-                mainPanel.layout.hasPrevTab = function() { return true };
-                mainPanel.layout.hasNextTab = function() { return false };
+                mainPanel.layout.hasPrevTab = returns(true);
+                mainPanel.layout.hasNextTab = returns(false);
                 mainPanel.fireEvent('tabchange', mainPanel);
             });
 

--- a/src/test/javascript/portal/ui/openlayers/control/SpatialConstraintSpec.js
+++ b/src/test/javascript/portal/ui/openlayers/control/SpatialConstraintSpec.js
@@ -277,7 +277,7 @@ describe('Portal.ui.openlayers.control.SpatialConstraint', function() {
 
         beforeEach(function() {
             geometry = {
-                    crossesAntimeridian: noOp
+                crossesAntimeridian: noOp
             };
         });
 

--- a/src/test/javascript/portal/ui/openlayers/control/SpatialConstraintSpec.js
+++ b/src/test/javascript/portal/ui/openlayers/control/SpatialConstraintSpec.js
@@ -79,7 +79,7 @@ describe('Portal.ui.openlayers.control.SpatialConstraint', function() {
     describe('layer', function() {
 
         beforeEach(function() {
-            spatialConstraint._checkSketch = function() { return true };
+            spatialConstraint._checkSketch = returns(true);
         });
 
         it('intialises layer', function() {
@@ -110,7 +110,7 @@ describe('Portal.ui.openlayers.control.SpatialConstraint', function() {
         });
 
         it('does not fire spatialconstraintadded where geometry is invalid', function() {
-            spatialConstraint._checkSketch = function() { return false };
+            spatialConstraint._checkSketch = returns(false);
             spatialConstraint.map = { events: { triggerEvent: noOp } };
             var eventSpy = jasmine.createSpy('spatialconstraintadded');
             spatialConstraint.events.on({
@@ -362,7 +362,7 @@ describe('Portal.ui.openlayers.control.SpatialConstraint', function() {
             }};
 
             testGeometry = {
-                crossesAntimeridian: function() { return false }
+                crossesAntimeridian: returns(false)
             };
 
             spatialConstraint._showSpatialExtentError(testGeometry);
@@ -379,7 +379,7 @@ describe('Portal.ui.openlayers.control.SpatialConstraint', function() {
         describe('geometry crosses date line', function() {
 
             beforeEach(function() {
-                testGeometry.crossesAntimeridian = function() { return true };
+                testGeometry.crossesAntimeridian = returns(true);
 
                 spatialConstraint._showSpatialExtentError(testGeometry);
             });

--- a/src/test/javascript/portal/utils/StopWatchSpec.js
+++ b/src/test/javascript/portal/utils/StopWatchSpec.js
@@ -9,14 +9,10 @@ describe("Portal.utils.StopWatch", function() {
     it('calculates elapsed time in ms on stop', function() {
         var sw = new Portal.utils.StopWatch();
 
-        sw._now = function() {
-            return moment('2020-01-01T00:00:00.000');
-        }
+        sw._now = returns(moment('2020-01-01T00:00:00.000'));
         sw.start();
 
-        sw._now = function() {
-            return moment('2020-01-01T00:00:12.000');
-        }
+        sw._now = returns(moment('2020-01-01T00:00:12.000'));
         sw.stop();
 
         expect(sw.getElapsedMillis()).toEqual(12000);

--- a/src/test/javascript/spec_helper.js
+++ b/src/test/javascript/spec_helper.js
@@ -144,6 +144,12 @@ var mockAjaxXmlResponse = function(responseContent) {
 // An empty function to pass as a parameter
 var noOp = function() {};
 
+var returns = function(val) {
+    return function() {
+        return val;
+    }
+};
+
 var wktPolygon = 'POLYGON((1 2,3 4,1 2))';
 var constructGeometry = function() {
     return OpenLayers.Geometry.fromWKT(wktPolygon);


### PR DESCRIPTION
I get really sick of writing anonymous functions in the Jasmine tests. Would people be happy using this helper? **I don't *think* this would be controversial but maybe we get the okay from 2 devs before we merge this?**

Essentially instead of writing: (Which happens heaps in test specs)
``` javascript
var testLayer = {
    isNcwms: function() { return true }
}
```
You can just write:
``` javascript
var testLayer = {
    isNcwms: returns(true)
}
```

Note, it can't be used if the variable being returned will change after the function is created. In that case you'd need to write the anonymous function the old-fashioned way. I think there were about 3 cases of this is the current test suites.