### PR TITLE
Revert 44895d2eb; make help links configurable

### DIFF
--- a/grails-app/views/header/_mainPortalHeader.gsp
+++ b/grails-app/views/header/_mainPortalHeader.gsp
@@ -29,6 +29,8 @@
     </g:if>
 
     <div id="toplinks">
-        <a class="external mainlinks" target="_blank" href="${grailsApplication.config.help.url}" title="Portal Help">Help</a>
+        <g:each in="${grailsApplication.config.portal.header.externalLinks}" var="link">
+            <a class="external mainlinks" target="_blank" href="${link.href}" title="${link.tooltipText}">${link.linkText}</a>
+        </g:each>
     </div>
 </div>


### PR DESCRIPTION
Had to do this manually, rather than git-revert.  See
aodn/aodn-portal#1847.

Will need a corresponding change to the chef recipe if generating the
config file that way.