### PR TITLE
fix #1834, scroll to top search results

### DIFF
--- a/src/test/javascript/portal/search/FacetedSearchResultsPanelSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsPanelSpec.js
@@ -48,23 +48,4 @@ describe("Portal.search.FacetedSearchResultsPanel", function() {
             expect(resultsPanel._refreshView).toHaveBeenCalled();
         });
     });
-
-    describe('scroll position', function() {
-        it('calls resetScrollPositionToTop on store load', function() {
-            spyOn(resultsPanel, '_resetScrollPositionToTop');
-            store.fireEvent('load');
-            expect(resultsPanel._resetScrollPositionToTop).toHaveBeenCalled();
-        });
-
-        it('sets scroll position to 0', function() {
-            resultsPanel.body = {
-                dom: {
-                    scrollTop: 123
-                }
-            };
-
-            store.fireEvent('load');
-            expect(resultsPanel.body.dom.scrollTop).toBe(0);
-        });
-    });
 });

--- a/src/test/javascript/portal/search/SearchBodyPanelSpec.js
+++ b/src/test/javascript/portal/search/SearchBodyPanelSpec.js
@@ -13,8 +13,6 @@ describe("Portal.search.SearchBodyPanel", function() {
             resultsStore: new Portal.data.GeoNetworkRecordStore(),
             searcher: new Portal.service.CatalogSearcher()
         });
-
-        spyOn(searchBodyPanel.searchResultsPanel, '_resetScrollPositionToTop');
     });
 
     describe('initialisation', function() {
@@ -35,10 +33,24 @@ describe("Portal.search.SearchBodyPanel", function() {
 
         describe('onResultsStoreLoad', function() {
             it('displays alert when store is empty', function() {
+                spyOn(searchBodyPanel, '_resetScrollPositionToTop');
                 spyOn(searchBodyPanel, '_displayNoResultsAlert');
                 searchBodyPanel.resultsStore.getTotalCount = returns(0);
                 searchBodyPanel._onResultsStoreLoad();
                 expect(searchBodyPanel._displayNoResultsAlert).toHaveBeenCalled();
+            });
+
+            it('sets scroll position to 0', function() {
+                spyOn(searchBodyPanel, '_resetScrollPositionToTop').andCallThrough();
+                searchBodyPanel.body = {
+                    dom: {
+                        scrollTop: 123
+                    }
+                };
+
+                searchBodyPanel.resultsStore.fireEvent('load');
+                expect(searchBodyPanel._resetScrollPositionToTop).toHaveBeenCalled();
+                expect(searchBodyPanel.body.dom.scrollTop).toBe(0);
             });
         });
     });

--- a/web-app/js/portal/search/FacetedSearchResultsPanel.js
+++ b/web-app/js/portal/search/FacetedSearchResultsPanel.js
@@ -58,11 +58,6 @@ Portal.search.FacetedSearchResultsPanel = Ext.extend(Ext.Panel, {
     },
 
     _onStoreLoad: function() {
-        // We want to reset scroll position to top on load, in case we were
-        // previously not at the top.
-        // Ref: https://github.com/aodn/aodn-portal/issues/464
-        this._resetScrollPositionToTop();
-
         this.pagingBar.onLoad(
             this.store,
             null,
@@ -73,10 +68,6 @@ Portal.search.FacetedSearchResultsPanel = Ext.extend(Ext.Panel, {
                 }
             }
         );
-    },
-
-    _resetScrollPositionToTop: function() {
-        this.body.dom.scrollTop = 0;
     }
 });
 

--- a/web-app/js/portal/search/SearchBodyPanel.js
+++ b/web-app/js/portal/search/SearchBodyPanel.js
@@ -17,6 +17,7 @@ Portal.search.SearchBodyPanel = Ext.extend(Ext.Panel, {
         this.searcher = cfg.searcher;
 
         this.searchResultsPanel = new Portal.search.FacetedSearchResultsPanel({
+            searchResultsPanel: this,
             searcher: this.searcher,
             store: this.resultsStore,
             classificationStore: cfg.classificationStore
@@ -42,6 +43,16 @@ Portal.search.SearchBodyPanel = Ext.extend(Ext.Panel, {
         if (this.resultsStore.getTotalCount() == 0) {
             this._displayNoResultsAlert();
         }
+
+        // We want to reset scroll position to top on load, in case we were
+        // previously not at the top.
+        // Ref: https://github.com/aodn/aodn-portal/issues/464
+        // Ref: https://github.com/aodn/aodn-portal/issues/1834
+        this._resetScrollPositionToTop();
+    },
+
+    _resetScrollPositionToTop: function() {
+        this.body.dom.scrollTop = 0;
     },
 
     _displayNoResultsAlert: function() {


### PR DESCRIPTION
the bug stems from scrolling the wrong element on store reloads,
this commit fixes it by scrolling searchResultsPanel, which is the
element with the scroll bar, rather than scrolling
FacetedSearchResultsPanel, which is just the encapsulated element

fixes #1834 