### PR TITLE
avoid failing network requests while running tests

### DIFF
--- a/src/test/javascript/portal/ui/MapPanelSpec.js
+++ b/src/test/javascript/portal/ui/MapPanelSpec.js
@@ -19,6 +19,7 @@ describe("Portal.ui.MapPanel", function() {
     var mapPanel;
 
     beforeEach(function() {
+        OpenLayers.Util.getImageLocation = returns(null);
         mapPanel = new Portal.ui.MapPanel({
             appConfig : appConfig
         });


### PR DESCRIPTION
mock OpenLayers.Util.getImageLocation

fixes #1851 