### PR TITLE
motd used from brandingBase

### DIFF
--- a/grails-app/taglib/au/org/emii/portal/MessageOfTheDayTagLib.groovy
+++ b/grails-app/taglib/au/org/emii/portal/MessageOfTheDayTagLib.groovy
@@ -57,9 +57,11 @@ class MessageOfTheDayTagLib {
     def getMotd() {
         def motd = null
 
-        if (grailsApplication.config.portal.motdUrl) {
+        def motdUrl = portalBranding.getMotdUrl()
+
+        if (motdUrl) {
             try {
-                motd = new URL(grailsApplication.config.portal.motdUrl).text
+                motd = new URL(motdUrl).text
             }
             catch (Exception e) {
                 log.debug "Failed getting motd ", e

--- a/src/groovy/au/org/emii/portal/PortalBranding.groovy
+++ b/src/groovy/au/org/emii/portal/PortalBranding.groovy
@@ -77,4 +77,13 @@ class PortalBranding {
             true
         )
     }
+
+    def getMotdUrl() {
+        if (grailsApplication.config.portal.brandingBase) {
+            return "${grailsApplication.config.portal.brandingBase}/motd"
+        }
+        else {
+            return grailsApplication.config.portal.motdUrl
+        }
+    }
 }

--- a/test/unit/au/org/emii/portal/PortalBrandingTests.groovy
+++ b/test/unit/au/org/emii/portal/PortalBrandingTests.groovy
@@ -71,4 +71,14 @@ class PortalBrandingTests extends GrailsUnitTestCase {
             portalBranding.returnBrandedUrlIfValid("invalidBrandedUrl", "nonBrandedValue", false)
         )
     }
+
+    void testGetMotdUrlNotBranded() {
+        portalBranding.grailsApplication.config.portal.motdUrl = "motdUrl"
+        assertEquals("motdUrl", portalBranding.getMotdUrl())
+    }
+
+    void testGetMotdUrlBranded() {
+        portalBranding.grailsApplication.config.portal.brandingBase = "isBranded"
+        assertEquals("isBranded/motd", portalBranding.getMotdUrl())
+    }
 }


### PR DESCRIPTION
if brandingBase is defined, motd is being taken from
brandingBase/motd. makes it easier to reuse the motd functionality
after rebranding the portal

requested originally by @markhepburn