### PR TITLE
Data Collection Layers refactor

### DIFF
--- a/src/test/javascript/portal/cart/InsertionServiceSpec.js
+++ b/src/test/javascript/portal/cart/InsertionServiceSpec.js
@@ -9,8 +9,6 @@ describe('Portal.cart.InsertionService', function() {
 
     var mockInsertionService;
     var dataCollection;
-    var geoserverLayer = { isNcwms: returns(false) };
-    var ncwmsLayer = { isNcwms: returns(true) };
 
     beforeEach(function() {
         mockInsertionService = new Portal.cart.InsertionService();
@@ -18,7 +16,6 @@ describe('Portal.cart.InsertionService', function() {
         dataCollection = {
             title: 'the title',
             uuid: '42',
-            getSelectedLayer: returns(geoserverLayer),
             getDataDownloadHandlers: returns([{}])
         };
     });
@@ -40,7 +37,7 @@ describe('Portal.cart.InsertionService', function() {
 
         it('creates an ncwms injector for ncwms layers', function() {
             mockInsertionService.insertionValues(getNcwmsRecord());
-            expectGetInjectorToHaveBeenCalled(Portal.cart.NcwmsInjector)
+            expectGetInjectorToHaveBeenCalled(Portal.cart.NcwmsInjector);
         });
 
         it('creates a wms injector for wms layers', function() {
@@ -95,13 +92,13 @@ describe('Portal.cart.InsertionService', function() {
     }
 
     function getWmsRecord() {
-        dataCollection.getSelectedLayer = returns(geoserverLayer);
+        dataCollection.isNcwms = returns(false);
 
         return dataCollection;
     }
 
     function getNcwmsRecord() {
-        dataCollection.getSelectedLayer = returns(ncwmsLayer);
+        dataCollection.isNcwms = returns(true);
 
         return dataCollection;
     }

--- a/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
@@ -80,13 +80,11 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
             urlFn = handler._getUrlGeneratorFunction();
 
             testCollection = {
-                getLayerState: function() {
-                    return {
-                        getSelectedLayer: returns({
-                            _buildGetFeatureRequestUrl: buildUrlSpy
-                        })
-                    };
-                },
+                getLayerState: returns({
+                    getSelectedLayer: returns({
+                        _buildGetFeatureRequestUrl: buildUrlSpy
+                    })
+                }),
                 getFilters: returns([])
             };
 
@@ -115,13 +113,11 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
         beforeEach(function() {
 
             testCollection = {
-                getLayerState: function() {
-                    return {
-                        getSelectedLayer: returns({
-                            _buildGetFeatureRequestUrl: returns('the_url')
-                        })
-                    };
-                },
+                getLayerState: returns({
+                    getSelectedLayer: returns({
+                        _buildGetFeatureRequestUrl: returns('the_url')
+                    })
+                }),
                 getFilters: returns([])
             };
         });

--- a/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
@@ -80,9 +80,13 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
             urlFn = handler._getUrlGeneratorFunction();
 
             testCollection = {
-                getSelectedLayer: returns({
-                    _buildGetFeatureRequestUrl: buildUrlSpy
-                }),
+                getLayerState: function() {
+                    return {
+                        getSelectedLayer: returns({
+                            _buildGetFeatureRequestUrl: buildUrlSpy
+                        })
+                    };
+                },
                 getFilters: returns([])
             };
 
@@ -111,9 +115,13 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
         beforeEach(function() {
 
             testCollection = {
-                getSelectedLayer: returns({
-                    _buildGetFeatureRequestUrl: returns('the_url')
-                }),
+                getLayerState: function() {
+                    return {
+                        getSelectedLayer: returns({
+                            _buildGetFeatureRequestUrl: returns('the_url')
+                        })
+                    };
+                },
                 getFilters: returns([])
             };
         });

--- a/src/test/javascript/portal/data/DataCollectionLayersSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionLayersSpec.js
@@ -142,4 +142,20 @@ describe("Portal.data.DataCollectionLayersSpec", function() {
             });
         });
     });
+
+    describe('isNcwms', function() {
+        it('returns appropriate WMS type', function() {
+            var isNcwms = true;
+
+            spyOn(dataCollectionLayers, 'getDefaultLayer').andReturn({
+                isNcwms: function() {
+                    return isNcwms;
+                }
+            });
+
+            expect(dataCollectionLayers.isNcwms()).toBe(true);
+            isNcwms = false;
+            expect(dataCollectionLayers.isNcwms()).toBe(false);
+        });
+    });
 });

--- a/src/test/javascript/portal/data/DataCollectionSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionSpec.js
@@ -11,6 +11,7 @@ describe("Portal.data.DataCollection", function() {
 
     beforeEach(function() {
         dataCollection = new Portal.data.DataCollection();
+        spyOn(dataCollection, 'getWmsLayerLinks').andReturn([]);
     });
 
     describe('updateNcwmsParams', function() {
@@ -59,13 +60,16 @@ describe("Portal.data.DataCollection", function() {
 
     describe('layerstate', function() {
         it('lazily initialises layer state', function() {
-            spyOn(dataCollection, 'getWmsLayerLinks').andReturn([]);
-
             var layerState = dataCollection.getLayerState();
             expect(layerState).toBeInstanceOf(Portal.data.DataCollectionLayers);
 
             // Make sure we're reusing the same object.
             expect(dataCollection.getLayerState()).toBe(layerState);
         });
+    });
+
+    it('returns correct WMS type', function() {
+        spyOn(dataCollection.getLayerState(), 'isNcwms').andReturn(true);
+        expect(dataCollection.isNcwms()).toBe(true);
     });
 });

--- a/src/test/javascript/portal/data/DataCollectionSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionSpec.js
@@ -7,7 +7,11 @@
 
 describe("Portal.data.DataCollection", function() {
 
-    var dataCollection = new Portal.data.DataCollection();
+    var dataCollection;
+
+    beforeEach(function() {
+        dataCollection = new Portal.data.DataCollection();
+    });
 
     describe('updateNcwmsParams', function() {
 
@@ -50,6 +54,18 @@ describe("Portal.data.DataCollection", function() {
                 latitudeRangeStart: 4,
                 latitudeRangeEnd: 1
             });
+        });
+    });
+
+    describe('layerstate', function() {
+        it('lazily initialises layer state', function() {
+            spyOn(dataCollection, 'getWmsLayerLinks').andReturn([]);
+
+            var layerState = dataCollection.getLayerState();
+            expect(layerState).toBeInstanceOf(Portal.data.DataCollectionLayers);
+
+            // Make sure we're reusing the same object.
+            expect(dataCollection.getLayerState()).toBe(layerState);
         });
     });
 });

--- a/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
@@ -43,7 +43,11 @@ describe('Portal.cart.WfsDownloadHandler', function () {
                 };
                 var dummyFilters = ['filters'];
                 var dummyCollection = {
-                    getSelectedLayer: returns(dummyLayer),
+                    getLayerState: function() {
+                        return {
+                            getSelectedLayer: returns(dummyLayer)
+                        };
+                    },
                     getFilters: returns(dummyFilters)
                 };
 

--- a/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
@@ -43,11 +43,9 @@ describe('Portal.cart.WfsDownloadHandler', function () {
                 };
                 var dummyFilters = ['filters'];
                 var dummyCollection = {
-                    getLayerState: function() {
-                        return {
-                            getSelectedLayer: returns(dummyLayer)
-                        };
-                    },
+                    getLayerState: returns({
+                        getSelectedLayer: returns(dummyLayer)
+                    }),
                     getFilters: returns(dummyFilters)
                 };
 

--- a/src/test/javascript/portal/details/NcWmsPanelSpec.js
+++ b/src/test/javascript/portal/details/NcWmsPanelSpec.js
@@ -28,11 +28,11 @@ describe('Portal.details.NcWmsPanel', function() {
         layer.map = map;
 
         layerState = new Ext.util.Observable();
+        layerState.getSelectedLayer = returns(layer);
 
         dataCollection = {
             getUuid: returns(45678),
             updateNcwmsParams: jasmine.createSpy('updateNcwmsParams'),
-            getSelectedLayer: returns(layer),
             getLayerState: returns(layerState)
         };
 

--- a/src/test/javascript/portal/details/StylePanelSpec.js
+++ b/src/test/javascript/portal/details/StylePanelSpec.js
@@ -102,11 +102,9 @@ describe("Portal.details.StylePanel", function() {
 
         it("Returns empty array if layer.styles is undefined", function() {
 
-            dataCollection.getLayerState = function() {
-                return {
-                    getSelectedLayer: returns({styles: undefined})
-                };
-            };
+            dataCollection.getLayerState = returns({
+                getSelectedLayer: returns({styles: undefined})
+            });
 
             var retVal = stylePanel._processStyleData();
 
@@ -119,28 +117,18 @@ describe("Portal.details.StylePanel", function() {
                 return String.format('{0} {1} {2} {3}', a, b, c, d);
             };
 
-            dataCollection.getLayerState = function() {
-                return {
-                    getSelectedLayer: returns({
-                        isNcwms: returns(true),
-                        styles: [
-                            {name: 'style1', palette: 'palette1'},
-                            {name: 'style1', palette: 'palette2'},
-                            {name: 'style2', palette: 'palette1'},
-                            {name: 'style2', palette: 'palette2'}
-                        ]
-                    })
-                };
-            };
-            dataCollection.getSelectedLayer = returns({
-                isNcwms: returns(true),
-                styles: [
-                    {name: 'style1', palette: 'palette1'},
-                    {name: 'style1', palette: 'palette2'},
-                    {name: 'style2', palette: 'palette1'},
-                    {name: 'style2', palette: 'palette2'}
-                ]
+            dataCollection.getLayerState = returns({
+                getSelectedLayer: returns({
+                    isNcwms: returns(true),
+                    styles: [
+                        {name: 'style1', palette: 'palette1'},
+                        {name: 'style1', palette: 'palette2'},
+                        {name: 'style2', palette: 'palette1'},
+                        {name: 'style2', palette: 'palette2'}
+                    ]
+                })
             });
+
             var retVal = stylePanel._processStyleData();
             var expected = '[' +
                 '["style1/palette1","[object Object] style1/palette1 palette1 true"],' +

--- a/src/test/javascript/portal/details/StylePanelSpec.js
+++ b/src/test/javascript/portal/details/StylePanelSpec.js
@@ -102,7 +102,12 @@ describe("Portal.details.StylePanel", function() {
 
         it("Returns empty array if layer.styles is undefined", function() {
 
-            dataCollection.getSelectedLayer = returns({styles: undefined});
+            dataCollection.getLayerState = function() {
+                return {
+                    getSelectedLayer: returns({styles: undefined})
+                };
+            };
+
             var retVal = stylePanel._processStyleData();
 
             expect(JSON.stringify(retVal)).toBe(JSON.stringify([]));
@@ -114,6 +119,19 @@ describe("Portal.details.StylePanel", function() {
                 return String.format('{0} {1} {2} {3}', a, b, c, d);
             };
 
+            dataCollection.getLayerState = function() {
+                return {
+                    getSelectedLayer: returns({
+                        isNcwms: returns(true),
+                        styles: [
+                            {name: 'style1', palette: 'palette1'},
+                            {name: 'style1', palette: 'palette2'},
+                            {name: 'style2', palette: 'palette1'},
+                            {name: 'style2', palette: 'palette2'}
+                        ]
+                    })
+                };
+            };
             dataCollection.getSelectedLayer = returns({
                 isNcwms: returns(true),
                 styles: [

--- a/src/test/javascript/portal/details/SubsetItemsWrapperPanelSpec.js
+++ b/src/test/javascript/portal/details/SubsetItemsWrapperPanelSpec.js
@@ -16,9 +16,9 @@ describe("Portal.details.SubsetItemsWrapperPanel", function() {
 
         layer = new OpenLayers.Layer.WMS();
         layerState = new Ext.util.Observable();
+        layerState.getSelectedLayer = returns(layer);
 
         dataCollection = {
-            getSelectedLayer: returns(layer),
             getTitle: returns('amazetion'),
             getLayerState: returns(layerState)
         };

--- a/src/test/javascript/portal/details/SubsetPanelSpec.js
+++ b/src/test/javascript/portal/details/SubsetPanelSpec.js
@@ -21,12 +21,15 @@ describe("Portal.details.SubsetPanel", function() {
         );
         layer.map = map;
 
+        var layerState = new Ext.util.Observable();
+        layerState.getSelectedLayer = returns(layer);
+
         subsetPanel = new Portal.details.SubsetPanel({
             map: map,
             dataCollection: {
-                getSelectedLayer: returns(layer),
                 updateNcwmsParams: noOp,
-                getLayerState: returns(new Ext.util.Observable())
+                getLayerState: returns(layerState),
+                isNcwms: returns(true)
             }
         });
     });

--- a/src/test/javascript/portal/filter/FilterServiceSpec.js
+++ b/src/test/javascript/portal/filter/FilterServiceSpec.js
@@ -19,7 +19,9 @@ describe("Portal.filter.FilterService", function() {
         failureCallback = jasmine.createSpy('failureCallback');
         callbackScope = {};
         testDataCollection = {
-            getSelectedLayer: returns({server: {}}),
+            getLayerState: returns({
+                getSelectedLayer: returns({server: {}})
+            }),
             setFilters: noOp
         };
     });

--- a/src/test/javascript/portal/filter/ui/BooleanFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/BooleanFilterPanelSpec.js
@@ -27,8 +27,11 @@ describe("Portal.filter.ui.BooleanFilterPanel", function() {
             },
             dataCollection: {
                 getTitle: returns('Collection title'),
-                getSelectedLayer: returns({
-                    getDownloadCql: returns("")
+                getLayerState: returns({
+                    getSelectedLayer: returns({
+                        name: 'test layer',
+                        getDownloadCql: returns("")
+                    })
                 })
             }
         });

--- a/src/test/javascript/portal/filter/ui/ComboFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/ComboFilterPanelSpec.js
@@ -26,8 +26,11 @@ describe("Portal.filter.ui.ComboFilterPanel", function() {
             },
             dataCollection: {
                 getTitle: returns('Collection title'),
-                getSelectedLayer: returns({
-                    getDownloadCql: returns("")
+                getLayerState: returns({
+                    getSelectedLayer: returns({
+                        name: 'test layer',
+                        getDownloadCql: returns("")
+                    })
                 })
             }
         });

--- a/src/test/javascript/portal/filter/ui/DateFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/DateFilterPanelSpec.js
@@ -25,8 +25,11 @@ describe("Portal.filter.ui.DateFilterPanel", function() {
             },
             dataCollection: {
                 getTitle: returns('Collection title'),
-                getSelectedLayer: returns({
-                    getDownloadCql: returns('')
+                getLayerState: returns({
+                    getSelectedLayer: returns({
+                        name: 'layerName',
+                        getDownloadCql: returns("")
+                    })
                 })
             }
         });
@@ -63,7 +66,7 @@ describe("Portal.filter.ui.DateFilterPanel", function() {
         beforeEach(function() {
             spyOn(filterPanel, '_fireAddEvent');
             spyOn(window, 'trackUsage');
-            component = {'_dateField':{"name":"atestname"}}
+            component = {'_dateField':{"name":"atestname"}};
         });
 
         it('fires events when required fields are set', function() {

--- a/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
@@ -21,7 +21,9 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
 
         filterGroupPanel = new Portal.filter.ui.FilterGroupPanel({
             dataCollection: {
-                getSelectedLayer: returns(layer)
+                getLayerState: returns({
+                    getSelectedLayer: returns(layer)
+                })
             }
         });
     });
@@ -44,7 +46,9 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
 
             filterGroupPanel = new Portal.filter.ui.FilterGroupPanel({
                 dataCollection: {
-                    getSelectedLayer: returns(layer)
+                    getLayerState: returns({
+                        getSelectedLayer: returns(layer)
+                    })
                 }
             });
 
@@ -139,7 +143,9 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
 
             filterGroupPanel = new Portal.filter.ui.FilterGroupPanel({
                 dataCollection: {
-                    getSelectedLayer: returns(layer)
+                    getLayerState: returns({
+                        getSelectedLayer: returns(layer)
+                    })
                 }
             });
 
@@ -176,7 +182,9 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
 
             filterGroupPanel = new Portal.filter.ui.FilterGroupPanel({
                 dataCollection: {
-                    getSelectedLayer: returns(layer)
+                    getLayerState: returns({
+                        getSelectedLayer: returns(layer)
+                    })
                 }
             });
 

--- a/src/test/javascript/portal/filter/ui/NumberFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/NumberFilterPanelSpec.js
@@ -32,7 +32,12 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
                 setValue: noOp
             },
             dataCollection: {
-                getTitle: returns('Collection title')
+                getTitle: returns('Collection title'),
+                getLayerState: returns({
+                    getSelectedLayer: returns({
+                        name: 'test layer'
+                    })
+                })
             }
         });
     });

--- a/web-app/js/portal/cart/BodaacDownloadHandler.js
+++ b/web-app/js/portal/cart/BodaacDownloadHandler.js
@@ -77,7 +77,7 @@ Portal.cart.BodaacDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
                 filters: collection.getFilters()
             });
 
-            var wmsLayer = collection.getSelectedLayer();
+            var wmsLayer = collection.getLayerState().getSelectedLayer();
             return wmsLayer._buildGetFeatureRequestUrl(
                 _this._resourceHref(),
                 _this._layerName(),

--- a/web-app/js/portal/cart/InsertionService.js
+++ b/web-app/js/portal/cart/InsertionService.js
@@ -21,11 +21,10 @@ Portal.cart.InsertionService = Ext.extend(Object, {
             downloadConfirmationScope: this
         };
 
-        var wmsLayer = collection.getSelectedLayer();
         var htmlInjection;
 
         if (this._isCollectionDownloadable(collection)) {
-            if (wmsLayer.isNcwms()) {
+            if (collection.isNcwms()) {
                 htmlInjection = new Portal.cart.NcwmsInjector(config);
             }
             else {

--- a/web-app/js/portal/cart/PythonDownloadHandler.js
+++ b/web-app/js/portal/cart/PythonDownloadHandler.js
@@ -37,7 +37,7 @@ Portal.cart.PythonDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
         var _this = this;
 
         return function(collection) {
-            return collection.getSelectedLayer().getFeatureRequestUrl(
+            return collection.getLayerState().getSelectedLayer().getFeatureRequestUrl(
                 collection.getFilters(),
                 _this._resourceHref(),
                 _this._resourceName(),

--- a/web-app/js/portal/cart/WfsDownloadHandler.js
+++ b/web-app/js/portal/cart/WfsDownloadHandler.js
@@ -37,11 +37,11 @@ Portal.cart.WfsDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
         var _this = this;
 
         return function(collection) {
-            return collection.getSelectedLayer().getFeatureRequestUrl(
+            return collection.getLayerState().getSelectedLayer().getFeatureRequestUrl(
                 collection.getFilters(),
                 _this._resourceHref(),
                 _this._resourceName(),
-                collection.getSelectedLayer().getCsvDownloadFormat()
+                collection.getLayerState().getSelectedLayer().getCsvDownloadFormat()
             );
         };
     }

--- a/web-app/js/portal/data/DataCollection.js
+++ b/web-app/js/portal/data/DataCollection.js
@@ -131,6 +131,16 @@ Portal.data.DataCollection = function() {
         return linkStore.getRange(); // Get all records
     };
 
+    constructor.prototype.getLayerState = function() {
+        if (!this.layerState) {
+            this.layerState = new Portal.data.DataCollectionLayers({
+                dataCollection: this
+            });
+        }
+
+        return this.layerState;
+    };
+
     // TODO: remove this.
     constructor.prototype.getSelectedLayer = function() {
         return this.getLayerState().getSelectedLayer();

--- a/web-app/js/portal/data/DataCollection.js
+++ b/web-app/js/portal/data/DataCollection.js
@@ -75,7 +75,7 @@ Portal.data.DataCollection = function() {
     constructor.prototype.updateFilters = function() {
 
         // Update layer with new values
-        var layer = this.getSelectedLayer();
+        var layer = this.getLayerState().getSelectedLayer();
 
         if (layer.updateCqlFilter) {
             layer.updateCqlFilter(this.getFilters());
@@ -141,9 +141,8 @@ Portal.data.DataCollection = function() {
         return this.layerState;
     };
 
-    // TODO: remove this.
-    constructor.prototype.getSelectedLayer = function() {
-        return this.getLayerState().getSelectedLayer();
+    constructor.prototype.isNcwms = function() {
+        return this.getLayerState().isNcwms();
     };
 
     return constructor;

--- a/web-app/js/portal/data/DataCollectionLayers.js
+++ b/web-app/js/portal/data/DataCollectionLayers.js
@@ -18,6 +18,10 @@ Portal.data.DataCollectionLayers = Ext.extend(Ext.util.Observable, {
         Portal.data.DataCollectionLayers.superclass.constructor.call(this, config);
     },
 
+    isNcwms: function() {
+        return this.getDefaultLayer().isNcwms();
+    },
+
     getLayers: function() {
         return this.layerCache;
     },

--- a/web-app/js/portal/data/DataCollectionStore.js
+++ b/web-app/js/portal/data/DataCollectionStore.js
@@ -61,23 +61,16 @@ Portal.data.DataCollectionStore = Ext.extend(Ext.data.Store, {
         var _this = this;
 
         Ext.each(dataCollections, function(dataCollection) {
-            // TODO: revisit - what is the life cycle of DataCollectionLayers?
-            var dataCollectionLayers = new Portal.data.DataCollectionLayers({
-                dataCollection: dataCollection
-            });
-
-            dataCollection.getLayerState = function() {
-                return dataCollectionLayers;
-            };
+            var layerState = dataCollection.getLayerState();
 
             this.layerStore.addUsingOpenLayer(
-                dataCollectionLayers.getSelectedLayer(),
+                layerState.getSelectedLayer(),
                 function(layerRecord) {
                     _this._recordLoaded(dataCollection);
                 }
             );
 
-            dataCollectionLayers.on('selectedlayerchanged', function(newLayer, oldLayer) {
+            layerState.on('selectedlayerchanged', function(newLayer, oldLayer) {
                 if (oldLayer) {
                     this.layerStore.removeUsingOpenLayer(oldLayer);
                 }

--- a/web-app/js/portal/data/DataCollectionStore.js
+++ b/web-app/js/portal/data/DataCollectionStore.js
@@ -99,6 +99,6 @@ Portal.data.DataCollectionStore = Ext.extend(Ext.data.Store, {
     },
 
     _removeFromLayerStore: function(dataCollection) {
-        this.layerStore.removeUsingOpenLayer(dataCollection.getSelectedLayer());
+        this.layerStore.removeUsingOpenLayer(dataCollection.getLayerState().getSelectedLayer());
     }
 });

--- a/web-app/js/portal/details/LayerDetailsPanel.js
+++ b/web-app/js/portal/details/LayerDetailsPanel.js
@@ -10,7 +10,6 @@ Ext.namespace('Portal.details');
 Portal.details.LayerDetailsPanel = Ext.extend(Ext.Container, {
 
     constructor: function(cfg) {
-
         var config = Ext.apply({
             title: OpenLayers.i18n('layerDetailsPanelTitle')
         }, cfg);

--- a/web-app/js/portal/details/NcWmsPanel.js
+++ b/web-app/js/portal/details/NcWmsPanel.js
@@ -18,7 +18,7 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Container, {
 
         Ext.apply(this, cfg);
 
-        this.layer = this.dataCollection.getSelectedLayer();
+        this.layer = this.dataCollection.getLayerState().getSelectedLayer();
 
         this.dataCollection.getLayerState().on('selectedlayerchanged', function(newLayer) {
             this._onSelectedLayerChanged(newLayer);

--- a/web-app/js/portal/details/StylePanel.js
+++ b/web-app/js/portal/details/StylePanel.js
@@ -78,7 +78,7 @@ Portal.details.StylePanel = Ext.extend(Ext.Container, {
 
     _initWithLayer: function() {
 
-        var layer = this.dataCollection.getSelectedLayer();
+        var layer = this.dataCollection.getLayerState().getSelectedLayer();
 
         if (layer.isNcwms()) {
             this.ncwmsScaleRangeControls.loadScaleFromLayer();
@@ -118,7 +118,7 @@ Portal.details.StylePanel = Ext.extend(Ext.Container, {
 
     _processStyleData: function() {
         var data = [];
-        var layer = this.dataCollection.getSelectedLayer();
+        var layer = this.dataCollection.getLayerState().getSelectedLayer();
 
         Ext.each(layer.styles, function(style) {
 
@@ -146,7 +146,7 @@ Portal.details.StylePanel = Ext.extend(Ext.Container, {
         var styleName = this.dataCollection.getLayerState().getStyle() || '';
         var palette = this._getPalette(styleName);
 
-        var layer = this.dataCollection.getSelectedLayer();
+        var layer = this.dataCollection.getLayerState().getSelectedLayer();
         var url = this.buildGetLegend(layer, styleName, palette, false);
 
         this.legendImage.setUrl(url);

--- a/web-app/js/portal/details/SubsetItemsTabPanel.js
+++ b/web-app/js/portal/details/SubsetItemsTabPanel.js
@@ -10,7 +10,6 @@ Ext.namespace('Portal.details');
 Portal.details.SubsetItemsTabPanel = Ext.extend(Ext.TabPanel, {
 
     constructor: function (cfg) {
-
         this.subsetPanel = new Portal.details.SubsetPanel(cfg);
         this.infoPanel = new Portal.details.InfoPanel(cfg);
         this.layerDetailsPanel = new Portal.details.LayerDetailsPanel(cfg);

--- a/web-app/js/portal/details/SubsetItemsWrapperPanel.js
+++ b/web-app/js/portal/details/SubsetItemsWrapperPanel.js
@@ -13,7 +13,7 @@ Portal.details.SubsetItemsWrapperPanel = Ext.extend(Ext.Panel, {
 
         var tabPanelForLayer = this._initSubsetItemsTabPanel(cfg);
 
-        this.createTools(cfg.dataCollection.getSelectedLayer());
+        this.createTools(cfg.dataCollection.getLayerState().getSelectedLayer());
 
         cfg.dataCollection.getLayerState().on('loadstart', function() {
             this._onLayerLoadStart();

--- a/web-app/js/portal/details/SubsetPanel.js
+++ b/web-app/js/portal/details/SubsetPanel.js
@@ -10,7 +10,7 @@ Portal.details.SubsetPanel = Ext.extend(Ext.Container, {
 
     constructor: function(cfg) {
 
-        var panelType = cfg.dataCollection.getSelectedLayer().isNcwms() ?
+        var panelType = cfg.dataCollection.isNcwms() ?
                 Portal.details.NcWmsPanel : Portal.filter.ui.FilterGroupPanel;
         var newPanel = new panelType(cfg);
 

--- a/web-app/js/portal/filter/FilterService.js
+++ b/web-app/js/portal/filter/FilterService.js
@@ -17,7 +17,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
 
     loadFilters: function(dataCollection, successCallback, failureCallback, callbackScope) {
 
-        var layer = dataCollection.getSelectedLayer(); // Todo - DN: What do we do here without getSelectedLayer() ?
+        var layer = dataCollection.getLayerState().getSelectedLayer(); // Todo - DN: What do we do here without getSelectedLayer() ?
 
         var params = {
             server: layer.server.uri,
@@ -79,7 +79,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
 
     loadFilterRange: function(filterId, dataCollection, successCallback, failureCallback, callbackScope) {
 
-        var layer = dataCollection.getSelectedLayer();
+        var layer = dataCollection.getLayerState().getSelectedLayer();
 
         var params = {
             filter: filterId,


### PR DESCRIPTION
* remove `DataCollection.getSelectedLayer()` - this must now be accessed via the `DataCollectionLayers` object.

I am now looking to:
1. remove unnecessary access to the `DataCollectionLayers` object
1. rename the class to something better (`LayerList` is the leading candidate currently)

1) above will hopefully allow me to delete much of the mocking present in this PR.