### PR TITLE
Simplify filter clearing logic

### DIFF
--- a/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
@@ -183,27 +183,22 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
 
     describe('_clearFilters method', function() {
         var removeFilterSpy;
+        var mockFilterPanel;
 
         beforeEach(function() {
             removeFilterSpy = jasmine.createSpy('handleRemoveFilter');
-        });
 
-        var _mockFilterPanel = function(filterType, removeSpy) {
-
-            return {
-                handleRemoveFilter: removeSpy ? removeSpy : noOp,
-                filter: {
-                    type: filterType
-                }
+            mockFilterPanel = {
+                handleRemoveFilter: removeFilterSpy
             };
-        };
+        });
 
         it('clears all non-global filters', function() {
 
             filterGroupPanel.filterPanels = [
-                _mockFilterPanel('datetime', removeFilterSpy),
-                _mockFilterPanel('boolean', removeFilterSpy),
-                _mockFilterPanel('string', removeFilterSpy)
+                mockFilterPanel,
+                mockFilterPanel,
+                mockFilterPanel
             ];
 
             spyOn(filterGroupPanel, '_updateLayerFilters');
@@ -211,26 +206,6 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
             filterGroupPanel._clearFilters();
 
             expect(removeFilterSpy.callCount).toBe(3);
-            expect(filterGroupPanel._updateLayerFilters).toHaveBeenCalled();
-        });
-
-
-        it('does not clear the global spatial extent', function() {
-            filterGroupPanel.filterPanels = [
-                _mockFilterPanel('geometrypropertytype'),
-                _mockFilterPanel('datetime'),
-                _mockFilterPanel('boolean'),
-                _mockFilterPanel('string')
-            ];
-
-            var geomFilter = filterGroupPanel.filterPanels[0];
-
-            spyOn(filterGroupPanel, '_updateLayerFilters');
-            spyOn(geomFilter, 'handleRemoveFilter');
-
-            filterGroupPanel._clearFilters();
-
-            expect(geomFilter.handleRemoveFilter).not.toHaveBeenCalled();
             expect(filterGroupPanel._updateLayerFilters).toHaveBeenCalled();
         });
     });

--- a/web-app/js/portal/filter/ui/FilterGroupPanel.js
+++ b/web-app/js/portal/filter/ui/FilterGroupPanel.js
@@ -251,16 +251,10 @@ Portal.filter.ui.FilterGroupPanel = Ext.extend(Ext.Container, {
     },
 
     _clearFilters: function() {
-        var that = this;
         Ext.each(this.filterPanels, function(panel) {
-            if (!that._isGlobalFilterPanel(panel)) {
-                panel.handleRemoveFilter();
-            }
+            panel.handleRemoveFilter();
         });
-        this._updateLayerFilters();
-    },
 
-    _isGlobalFilterPanel: function(panel) {
-        return panel.filter.type == "geometrypropertytype";
+        this._updateLayerFilters();
     }
 });

--- a/web-app/js/portal/filter/ui/GeometryFilterService.js
+++ b/web-app/js/portal/filter/ui/GeometryFilterService.js
@@ -35,10 +35,12 @@ Portal.filter.ui.GeometryFilterService = Ext.extend(Portal.filter.ui.BaseFilterP
     },
 
     _createControls: function() {
-        // Not a physical panel, Using a global Geometry filter
+        // No controls to create (handled by the global spatial filter)
     },
 
-    handleRemoveFilter: function() {},
+    handleRemoveFilter: function() {
+        // Nothing to do on clear (handled by the global spatial filter)
+    },
 
     needsFilterRange: function() {
         return false;


### PR DESCRIPTION
Simplify _clearFilters() in FilterGroupPanel. handleRemoveFilter() should always be safe to call so there is no need to prevent it from being called on a Geometry filter.