### PR TITLE
Selected layer changed event

### DIFF
--- a/grails-app/views/_js_includes.gsp
+++ b/grails-app/views/_js_includes.gsp
@@ -139,6 +139,7 @@
     <script type="text/javascript" src="${resource(dir: 'js/portal/ui/openlayers', file: 'LayerParams.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/ui/openlayers', file: 'MapOptions.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/ui/openlayers', file: 'SpatialConstraintMap.js')}"></script>
+    <script type="text/javascript" src="${resource(dir: 'js/portal/ui/openlayers/layer', file: 'MiniMapBaseLayer.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/ui/openlayers/layer', file: 'NcWMS.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/ui', file: 'MapPanel.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/ui', file: 'VisualisePanel.js')}"></script>

--- a/src/test/javascript/portal/data/DataCollectionStoreSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionStoreSpec.js
@@ -14,9 +14,10 @@ describe("Portal.data.DataCollectionStoreSpec", function() {
     beforeEach(function() {
         layer = new OpenLayers.Layer();
 
-        layerStore = new Portal.data.LayerStore();
-        spyOn(layerStore, 'addUsingOpenLayer');
-        spyOn(layerStore, 'removeUsingOpenLayer');
+        layerStore = {
+            addUsingOpenLayer: jasmine.createSpy('addUsingOpenLayer'),
+            removeUsingOpenLayer: jasmine.createSpy('removeUsingOpenLayer')
+        };
 
         spyOn(Portal.data.DataCollectionLayers.prototype, '_initLayers');
         spyOn(Portal.data.DataCollectionLayers.prototype, 'getSelectedLayer').andCallFake(function() {

--- a/src/test/javascript/portal/details/NcwmsScaleRangeControlsSpec.js
+++ b/src/test/javascript/portal/details/NcwmsScaleRangeControlsSpec.js
@@ -8,12 +8,15 @@ describe('Portal.details.NcwmsScaleRangeControls', function() {
     describe('loadScaleFromLayer', function() {
 
         var controls;
-        var layerState = {};
+        var layerState;
         var dataCollection;
 
         beforeEach(function() {
 
-            spyOn(Ext.MsgBus, 'subscribe');
+            layerState = {
+                on: noOp,
+                getScaleRange: returns({})
+            };
 
             dataCollection = {
                 getLayerState: returns(layerState)

--- a/src/test/javascript/portal/details/StylePanelSpec.js
+++ b/src/test/javascript/portal/details/StylePanelSpec.js
@@ -24,10 +24,21 @@ function getParameterByNameFromUrlString(urlString, name) {
 describe("Portal.details.StylePanel", function() {
 
     var stylePanel;
-    var dataCollection = {};
+    var dataCollection;
 
     beforeEach(function() {
+        var layerState = {
+            on: noOp,
+            getScaleRange: returns({})
+        };
+
+        dataCollection = {
+            getLayerState: returns(layerState)
+        };
+
         spyOn(Ext.MsgBus, 'subscribe');
+
+        spyOn(Portal.details, 'NcwmsScaleRangeControls');
         spyOn(Portal.details.StylePanel.prototype, '_initWithLayer');
         stylePanel = new Portal.details.StylePanel({
             dataCollection: dataCollection

--- a/src/test/javascript/portal/details/SubsetItemsWrapperPanelSpec.js
+++ b/src/test/javascript/portal/details/SubsetItemsWrapperPanelSpec.js
@@ -80,4 +80,10 @@ describe("Portal.details.SubsetItemsWrapperPanel", function() {
             expect(panel._indicateLayerError).toHaveBeenCalledWith(true);
         });
     });
+
+    it('fires "DATA_COLLECTION_SELECTED" event on expand', function() {
+        spyOn(Ext.MsgBus, 'publish');
+        panel._onExpand();
+        expect(Ext.MsgBus.publish).toHaveBeenCalledWith(PORTAL_EVENTS.DATA_COLLECTION_SELECTED, dataCollection);
+    });
 });

--- a/src/test/javascript/portal/search/FacetedSearchResultsMiniMapSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsMiniMapSpec.js
@@ -50,9 +50,8 @@ describe("Portal.search.FacetedSearchResultsMiniMap", function() {
         var extentLayer;
 
         beforeEach(function() {
-            baseLayer = {};
+            baseLayer = miniMap._getBaseLayer();
             extentLayer = {};
-            spyOn(miniMap, '_getBaseLayer').andReturn(baseLayer);
             spyOn(miniMap, '_getExtentLayer').andReturn(extentLayer);
             spyOn(miniMap, 'addLayers');
         });

--- a/src/test/javascript/portal/ui/MapPanelSpec.js
+++ b/src/test/javascript/portal/ui/MapPanelSpec.js
@@ -26,21 +26,6 @@ describe("Portal.ui.MapPanel", function() {
     });
 
     describe('message bus tests', function() {
-
-        it('clears the spatial constraint when there are no layers left', function() {
-            spyOn(mapPanel.map, 'resetSpatialConstraint');
-            Ext.MsgBus.publish(PORTAL_EVENTS.SELECTED_LAYER_CHANGED, null);
-            expect(mapPanel.map.resetSpatialConstraint).toHaveBeenCalled();
-        });
-
-        it('does not clear the spatial constraint when there are layers', function() {
-            spyOn(mapPanel.map, 'updateSpatialConstraintStyle');
-            Ext.MsgBus.publish(PORTAL_EVENTS.SELECTED_LAYER_CHANGED, {
-                hasBoundingBox: noOp
-            });
-            expect(mapPanel.map.updateSpatialConstraintStyle).not.toHaveBeenCalled();
-        });
-
         it('on baseLayerChanged event', function() {
             spyOn(mapPanel, 'onBaseLayerChanged');
 

--- a/src/test/javascript/portal/ui/ViewportSpec.js
+++ b/src/test/javascript/portal/ui/ViewportSpec.js
@@ -22,6 +22,7 @@ describe("Portal.ui.Viewport", function() {
     beforeEach(function() {
         spyOn(Portal.ui, "MainPanel").andReturn(mockMainPanel);
         spyOn(Portal.ui.Viewport.superclass.constructor, "call");
+        spyOn(Portal.ui.Viewport.prototype, '_newLayerStore').andReturn({});
 
         spyOn(Portal.ui, 'MapPanel');
         spyOn(Portal.ui, 'VisualisePanel');

--- a/src/test/javascript/spec_helper.js
+++ b/src/test/javascript/spec_helper.js
@@ -107,6 +107,8 @@ var setupTestConfigAndStubs = function() {
     OpenLayers.Lang.en.loadingMessage = '';
 
     log.removeAllAppenders();
+
+    spyOn(Portal.search.FacetedSearchResultsMiniMap.prototype, '_getBaseLayer').andReturn(new OpenLayers.Layer());
 };
 
 var mockLayoutForMainPanel = function(mainPanel) {

--- a/src/test/javascript/spec_helper.js
+++ b/src/test/javascript/spec_helper.js
@@ -108,7 +108,7 @@ var setupTestConfigAndStubs = function() {
 
     log.removeAllAppenders();
 
-    spyOn(Portal.search.FacetedSearchResultsMiniMap.prototype, '_getBaseLayer').andReturn(new OpenLayers.Layer());
+    spyOn(OpenLayers.Layer, 'MiniMapBaseLayer').andReturn(new OpenLayers.Layer());
 };
 
 var mockLayoutForMainPanel = function(mainPanel) {

--- a/web-app/js/portal/PortalEvents.js
+++ b/web-app/js/portal/PortalEvents.js
@@ -1,5 +1,4 @@
 var PORTAL_EVENTS = {
-    SELECTED_LAYER_CHANGED:        "selectedLayerChanged",
     BASE_LAYER_CHANGED:            "baseLayerChanged",
     BASE_LAYER_LOADED_FROM_SERVER: "baseLayersLoadedFromServer",
     DATA_COLLECTION_ADDED:         "dataCollectionAdded",

--- a/web-app/js/portal/details/NcwmsScaleRangeControls.js
+++ b/web-app/js/portal/details/NcwmsScaleRangeControls.js
@@ -43,7 +43,7 @@ Portal.details.NcwmsScaleRangeControls = Ext.extend(Ext.Panel, {
         this.addEvents('colourScaleUpdated');
         Portal.details.NcwmsScaleRangeControls.superclass.initComponent.call(this);
 
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.SELECTED_LAYER_CHANGED, this.loadScaleFromLayer, this);
+        this.dataCollection.getLayerState().on('selectedlayerchanged', this.loadScaleFromLayer, this);
     },
 
     makeSmallIndentInputBox: function(fieldLabel) {

--- a/web-app/js/portal/details/StylePanel.js
+++ b/web-app/js/portal/details/StylePanel.js
@@ -26,7 +26,7 @@ Portal.details.StylePanel = Ext.extend(Ext.Container, {
 
         this._initWithLayer();
 
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.SELECTED_LAYER_CHANGED, this._initWithLayer, this);
+        this.dataCollection.getLayerState().on('selectedlayerchanged', this._initWithLayer, this);
     },
 
     _createControls: function() {

--- a/web-app/js/portal/details/SubsetItemsWrapperPanel.js
+++ b/web-app/js/portal/details/SubsetItemsWrapperPanel.js
@@ -41,10 +41,20 @@ Portal.details.SubsetItemsWrapperPanel = Ext.extend(Ext.Panel, {
                 this.errorToolItem,
                 this.spinnerToolItem,
                 this.deleteToolItem
-            ]
+            ],
+            listeners: {
+                expand: this._onExpand
+            }
         }, cfg);
 
         Portal.details.SubsetItemsWrapperPanel.superclass.constructor.call(this, config);
+    },
+
+    _onExpand: function() {
+        Ext.MsgBus.publish(
+            PORTAL_EVENTS.DATA_COLLECTION_SELECTED,
+            this.dataCollection
+        );
     },
 
     _onLayerLoadStart: function() {

--- a/web-app/js/portal/details/SubsetPanelAccordion.js
+++ b/web-app/js/portal/details/SubsetPanelAccordion.js
@@ -43,15 +43,7 @@ Portal.details.SubsetPanelAccordion = Ext.extend(Ext.Panel, {
             map: this.map,
             dataCollection: dataCollection,
             dataCollectionStore: this.dataCollectionStore,
-            id: dataCollection.getUuid(),
-            listeners: {
-                expand: function(panel) {
-                    Ext.MsgBus.publish(
-                        PORTAL_EVENTS.SELECTED_LAYER_CHANGED,
-                        dataCollection.getLayerState().getSelectedLayer()
-                    );
-                }
-            }
+            id: dataCollection.getUuid()
         });
     }
 });

--- a/web-app/js/portal/search/FacetMapPanel.js
+++ b/web-app/js/portal/search/FacetMapPanel.js
@@ -15,7 +15,7 @@ Portal.search.FacetMapPanel = Ext.extend(Portal.common.MapPanel, {
 
         var layerStore = new GeoExt.data.LayerStore({
             layers: [
-                Portal.search.FacetedSearchResultsMiniMap.prototype._getBaseLayer()
+                new OpenLayers.Layer.MiniMapBaseLayer()
             ]
         });
 

--- a/web-app/js/portal/search/FacetMapPanel.js
+++ b/web-app/js/portal/search/FacetMapPanel.js
@@ -13,7 +13,11 @@ Portal.search.FacetMapPanel = Ext.extend(Portal.common.MapPanel, {
 
     constructor: function (cfg) {
 
-        var layerStore = new Portal.data.LayerStore();
+        var layerStore = new GeoExt.data.LayerStore({
+            layers: [
+                Portal.search.FacetedSearchResultsMiniMap.prototype._getBaseLayer()
+            ]
+        });
 
         var config = Ext.apply({
             layers: layerStore

--- a/web-app/js/portal/search/FacetedSearchResultsMiniMap.js
+++ b/web-app/js/portal/search/FacetedSearchResultsMiniMap.js
@@ -51,12 +51,7 @@ Portal.search.FacetedSearchResultsMiniMap = Ext.extend(OpenLayers.Map, {
     },
 
     _getBaseLayer: function() {
-        return new OpenLayers.Layer.WMS(
-            Portal.app.appConfig.minimap.baselayer.name,
-            Portal.app.appConfig.minimap.baselayer.url,
-            { layers: Portal.app.appConfig.minimap.baselayer.params.layers },
-            { wrapDateLine: true }
-        );
+        return new OpenLayers.Layer.MiniMapBaseLayer();
     },
 
     _getExtentLayer: function() {

--- a/web-app/js/portal/ui/MapPanel.js
+++ b/web-app/js/portal/ui/MapPanel.js
@@ -41,10 +41,6 @@ Portal.ui.MapPanel = Ext.extend(Portal.common.MapPanel, {
             });
         }, this);
 
-        Ext.MsgBus.subscribe(PORTAL_EVENTS.SELECTED_LAYER_CHANGED, function (subject, message) {
-            this.onSelectedLayerChanged(message);
-        }, this);
-
         Ext.MsgBus.subscribe(PORTAL_EVENTS.BASE_LAYER_CHANGED, function(subject, message) {
             this.onBaseLayerChanged(message);
         }, this);
@@ -53,12 +49,6 @@ Portal.ui.MapPanel = Ext.extend(Portal.common.MapPanel, {
             this.reset();
             this._closeFeatureInfoPopup();
         }, this);
-    },
-
-    onSelectedLayerChanged: function (openLayer) {
-        if (!openLayer) {
-            this.map.resetSpatialConstraint();
-        }
     },
 
     onBaseLayerChanged: function(openLayer) {

--- a/web-app/js/portal/ui/Viewport.js
+++ b/web-app/js/portal/ui/Viewport.js
@@ -13,7 +13,7 @@ Portal.ui.Viewport = Ext.extend(Ext.Viewport, {
         // approximate height of viewport main tabs. css will impact on this buffer
         this.viewportTabsHeight = 180;
 
-        var layerStore = new Portal.data.LayerStore();
+        var layerStore = this._newLayerStore();
         var mapPanel = new Portal.ui.MapPanel({layers: layerStore});
         var dataCollectionStore = new Portal.data.DataCollectionStore({
             layerStore: layerStore
@@ -50,6 +50,10 @@ Portal.ui.Viewport = Ext.extend(Ext.Viewport, {
         );
 
         Portal.ui.Viewport.superclass.constructor.call(this, config);
+    },
+
+    _newLayerStore: function() {
+        return new Portal.data.LayerStore();
     },
 
     /**

--- a/web-app/js/portal/ui/openlayers/layer/MiniMapBaseLayer.js
+++ b/web-app/js/portal/ui/openlayers/layer/MiniMapBaseLayer.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2015 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+OpenLayers.Layer.MiniMapBaseLayer = OpenLayers.Class(OpenLayers.Layer.WMS, {
+    initialize: function() {
+        OpenLayers.Layer.WMS.prototype.initialize.apply(this, [
+            Portal.app.appConfig.minimap.baselayer.name,
+            Portal.app.appConfig.minimap.baselayer.url,
+            { layers: Portal.app.appConfig.minimap.baselayer.params.layers },
+            { wrapDateLine: true }
+        ]);
+    }
+});


### PR DESCRIPTION
Removed global `SELECTED_LAYER_CHANGED` event, preferring to use `DATA_COLLECTION_SELECTED`, or `DataCollection` scoped `selectedlayerchange` event, where appropriate.

This is a step towards making the portal "data collection centric" (rather than layer centric, as was the case previously).