### PR TITLE
Remove dependency on `getSelectedLayer()` where possible

### DIFF
--- a/src/test/javascript/portal/cart/DownloadPanelSpec.js
+++ b/src/test/javascript/portal/cart/DownloadPanelSpec.js
@@ -229,9 +229,6 @@ describe("Portal.cart.DownloadPanel", function() {
         return {
             getUuid: returns(uuid),
             getTitle: returns("Argo"),
-            getSelectedLayer: returns({
-                isNcwms: noOp
-            }),
             getDataDownloadHandlers: returns([])
         };
     };

--- a/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
@@ -9,6 +9,7 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
 
     var handler;
     var options;
+    var testCollection;
 
     var createHandler = function(onlineResource) {
         handler = new Portal.cart.BodaacDownloadHandler(onlineResource);
@@ -16,11 +17,14 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
     };
 
     beforeEach(function() {
-
+        spyOn(OpenLayers.Layer.WMS.prototype, '_buildGetFeatureRequestUrl').andReturn('the_url');
         createHandler({
             href: 'geoserver_url',
             name: 'layer_name#field_name'
         });
+        testCollection = {
+            getFilters: returns([])
+        };
     });
 
     describe('getDownloadOptions', function() {
@@ -72,21 +76,10 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
     describe('the url generator function', function() {
 
         var urlFn;
-        var testCollection;
-        var buildUrlSpy = jasmine.createSpy('_buildGetFeatureRequestUrl');
 
         beforeEach(function() {
 
             urlFn = handler._getUrlGeneratorFunction();
-
-            testCollection = {
-                getLayerState: returns({
-                    getSelectedLayer: returns({
-                        _buildGetFeatureRequestUrl: buildUrlSpy
-                    })
-                }),
-                getFilters: returns([])
-            };
 
             spyOn(Portal.filter.combiner, 'BodaacCqlBuilder').andReturn({
                 buildCql: returns('the_cql')
@@ -97,7 +90,7 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
 
         it('builds the correct URL', function() {
 
-            expect(buildUrlSpy).toHaveBeenCalledWith(
+            expect(OpenLayers.Layer.WMS.prototype._buildGetFeatureRequestUrl).toHaveBeenCalledWith(
                 'geoserver_url',
                 'layer_name',
                 'csv',
@@ -107,21 +100,6 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
     });
 
     describe('the estimate download size params', function() {
-
-        var testCollection;
-
-        beforeEach(function() {
-
-            testCollection = {
-                getLayerState: returns({
-                    getSelectedLayer: returns({
-                        _buildGetFeatureRequestUrl: returns('the_url')
-                    })
-                }),
-                getFilters: returns([])
-            };
-        });
-
         it('build the correct params object', function() {
 
             var params = handler.getDownloadEstimateParams(testCollection);

--- a/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
@@ -17,7 +17,7 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
     };
 
     beforeEach(function() {
-        spyOn(OpenLayers.Layer.WMS.prototype, 'buildGetFeatureRequestUrl').andReturn('the_url');
+        spyOn(OpenLayers.Layer.WMS, 'buildGetFeatureRequestUrl').andReturn('the_url');
         createHandler({
             href: 'geoserver_url',
             name: 'layer_name#field_name'
@@ -90,7 +90,7 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
 
         it('builds the correct URL', function() {
 
-            expect(OpenLayers.Layer.WMS.prototype.buildGetFeatureRequestUrl).toHaveBeenCalledWith(
+            expect(OpenLayers.Layer.WMS.buildGetFeatureRequestUrl).toHaveBeenCalledWith(
                 'geoserver_url',
                 'layer_name',
                 'csv',

--- a/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/BodaacDownloadHandlerSpec.js
@@ -17,7 +17,7 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
     };
 
     beforeEach(function() {
-        spyOn(OpenLayers.Layer.WMS.prototype, '_buildGetFeatureRequestUrl').andReturn('the_url');
+        spyOn(OpenLayers.Layer.WMS.prototype, 'buildGetFeatureRequestUrl').andReturn('the_url');
         createHandler({
             href: 'geoserver_url',
             name: 'layer_name#field_name'
@@ -90,7 +90,7 @@ describe('Portal.cart.BodaacDownloadHandler', function () {
 
         it('builds the correct URL', function() {
 
-            expect(OpenLayers.Layer.WMS.prototype._buildGetFeatureRequestUrl).toHaveBeenCalledWith(
+            expect(OpenLayers.Layer.WMS.prototype.buildGetFeatureRequestUrl).toHaveBeenCalledWith(
                 'geoserver_url',
                 'layer_name',
                 'csv',

--- a/src/test/javascript/portal/data/DataCollectionLayersSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionLayersSpec.js
@@ -141,6 +141,14 @@ describe("Portal.data.DataCollectionLayersSpec", function() {
                 expect(eventListener).not.toHaveBeenCalled();
             });
         });
+
+        it('indicates loading', function() {
+            dataCollectionLayers.getSelectedLayer().loading = true;
+            expect(dataCollectionLayers.isLoading()).toBe(true);
+
+            dataCollectionLayers.getSelectedLayer().loading = false;
+            expect(dataCollectionLayers.isLoading()).toBe(false);
+        });
     });
 
     describe('isNcwms', function() {

--- a/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
@@ -37,8 +37,10 @@ describe('Portal.cart.WfsDownloadHandler', function () {
                 expect(downloadOption.handlerParams).not.toBeNull();
 
                 var downloadHandler = downloadOption.handler;
+
+                spyOn(OpenLayers.Layer.WMS.prototype, 'getFeatureRequestUrl');
+
                 var dummyLayer = {
-                    getFeatureRequestUrl: jasmine.createSpy('getFeatureRequestUrl'),
                     getCsvDownloadFormat: jasmine.createSpy('getCsvDownloadFormat').andReturn('csv')
                 };
                 var dummyFilters = ['filters'];
@@ -52,7 +54,7 @@ describe('Portal.cart.WfsDownloadHandler', function () {
                 downloadHandler(dummyCollection);
 
                 expect(dummyLayer.getCsvDownloadFormat).toHaveBeenCalled();
-                expect(dummyLayer.getFeatureRequestUrl).toHaveBeenCalledWith(dummyFilters, 'server_url', 'layer_name', 'csv');
+                expect(OpenLayers.Layer.WMS.prototype.getFeatureRequestUrl).toHaveBeenCalledWith(dummyFilters, 'server_url', 'layer_name', 'csv');
             });
         });
 

--- a/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
@@ -38,7 +38,7 @@ describe('Portal.cart.WfsDownloadHandler', function () {
 
                 var downloadHandler = downloadOption.handler;
 
-                spyOn(OpenLayers.Layer.WMS.prototype, 'getFeatureRequestUrl');
+                spyOn(OpenLayers.Layer.WMS, 'getFeatureRequestUrl');
 
                 var dummyLayer = {
                     getCsvDownloadFormat: jasmine.createSpy('getCsvDownloadFormat').andReturn('csv')
@@ -54,7 +54,7 @@ describe('Portal.cart.WfsDownloadHandler', function () {
                 downloadHandler(dummyCollection);
 
                 expect(dummyLayer.getCsvDownloadFormat).toHaveBeenCalled();
-                expect(OpenLayers.Layer.WMS.prototype.getFeatureRequestUrl).toHaveBeenCalledWith(dummyFilters, 'server_url', 'layer_name', 'csv');
+                expect(OpenLayers.Layer.WMS.getFeatureRequestUrl).toHaveBeenCalledWith(dummyFilters, 'server_url', 'layer_name', 'csv');
             });
         });
 

--- a/src/test/javascript/portal/details/SubsetItemsWrapperPanelSpec.js
+++ b/src/test/javascript/portal/details/SubsetItemsWrapperPanelSpec.js
@@ -16,7 +16,7 @@ describe("Portal.details.SubsetItemsWrapperPanel", function() {
 
         layer = new OpenLayers.Layer.WMS();
         layerState = new Ext.util.Observable();
-        layerState.getSelectedLayer = returns(layer);
+        layerState.isLoading = returns(false);
 
         dataCollection = {
             getTitle: returns('amazetion'),

--- a/src/test/javascript/portal/prototypes/OpenLayersSpec.js
+++ b/src/test/javascript/portal/prototypes/OpenLayersSpec.js
@@ -58,9 +58,9 @@ describe('OpenLayers', function() {
 
         describe('getFeatureRequestUrl', function() {
 
-            it('calls _buildGetFeatureRequestUrl correctly', function() {
+            it('calls buildGetFeatureRequestUrl correctly', function() {
 
-                spyOn(openLayer, '_buildGetFeatureRequestUrl');
+                spyOn(openLayer, 'buildGetFeatureRequestUrl');
                 spyOn(Portal.filter.combiner, 'DataDownloadCqlBuilder').andReturn({
                     buildCql: returns('download filters')
                 });
@@ -70,22 +70,22 @@ describe('OpenLayers', function() {
                 openLayer.getFeatureRequestUrl(testFilters, 'wms_uri', 'layerName', 'csv');
 
                 expect(Portal.filter.combiner.DataDownloadCqlBuilder).toHaveBeenCalledWith({filters: testFilters});
-                expect(openLayer._buildGetFeatureRequestUrl).toHaveBeenCalledWith('wms_uri', 'layerName', 'csv', 'download filters');
+                expect(openLayer.buildGetFeatureRequestUrl).toHaveBeenCalledWith('wms_uri', 'layerName', 'csv', 'download filters');
             });
         });
 
-        describe('_buildGetFeatureRequestUrl', function() {
+        describe('buildGetFeatureRequestUrl', function() {
 
             it('does not add a ? if not required', function() {
 
-                var getFeatureUrl = openLayer._buildGetFeatureRequestUrl("wfs_url?a=b");
+                var getFeatureUrl = openLayer.buildGetFeatureRequestUrl("wfs_url?a=b");
 
                 expect(getFeatureUrl.startsWith('wfs_url?a=b&')).toBe(true);
             });
 
             it('adds a ? if required', function() {
 
-                var getFeatureUrl = openLayer._buildGetFeatureRequestUrl("wfs_url");
+                var getFeatureUrl = openLayer.buildGetFeatureRequestUrl("wfs_url");
 
                 expect(getFeatureUrl.startsWith('wfs_url?')).toBe(true);
             });
@@ -99,7 +99,7 @@ describe('OpenLayers', function() {
                     '&REQUEST=GetFeature' +
                     '&VERSION=1.0.0';
 
-                var getFeatureUrl = openLayer._buildGetFeatureRequestUrl('wfs_url', 'type_name', 'txt');
+                var getFeatureUrl = openLayer.buildGetFeatureRequestUrl('wfs_url', 'type_name', 'txt');
 
                 expect(getFeatureUrl).toBe(expectedUrl);
             });
@@ -114,7 +114,7 @@ describe('OpenLayers', function() {
                     '&VERSION=1.0.0' +
                     '&CQL_FILTER=cql%20%25%3A%2F';
 
-                var getFeatureUrl = openLayer._buildGetFeatureRequestUrl('wfs_url', 'type_name', 'csv', 'cql %:/');
+                var getFeatureUrl = openLayer.buildGetFeatureRequestUrl('wfs_url', 'type_name', 'csv', 'cql %:/');
 
                 expect(getFeatureUrl).toBe(expectedUrl);
             });

--- a/src/test/javascript/portal/prototypes/OpenLayersSpec.js
+++ b/src/test/javascript/portal/prototypes/OpenLayersSpec.js
@@ -60,17 +60,17 @@ describe('OpenLayers', function() {
 
             it('calls buildGetFeatureRequestUrl correctly', function() {
 
-                spyOn(openLayer, 'buildGetFeatureRequestUrl');
+                spyOn(OpenLayers.Layer.WMS, 'buildGetFeatureRequestUrl');
                 spyOn(Portal.filter.combiner, 'DataDownloadCqlBuilder').andReturn({
                     buildCql: returns('download filters')
                 });
 
                 var testFilters = ['filters'];
 
-                openLayer.getFeatureRequestUrl(testFilters, 'wms_uri', 'layerName', 'csv');
+                OpenLayers.Layer.WMS.getFeatureRequestUrl(testFilters, 'wms_uri', 'layerName', 'csv');
 
                 expect(Portal.filter.combiner.DataDownloadCqlBuilder).toHaveBeenCalledWith({filters: testFilters});
-                expect(openLayer.buildGetFeatureRequestUrl).toHaveBeenCalledWith('wms_uri', 'layerName', 'csv', 'download filters');
+                expect(OpenLayers.Layer.WMS.buildGetFeatureRequestUrl).toHaveBeenCalledWith('wms_uri', 'layerName', 'csv', 'download filters');
             });
         });
 
@@ -78,14 +78,14 @@ describe('OpenLayers', function() {
 
             it('does not add a ? if not required', function() {
 
-                var getFeatureUrl = openLayer.buildGetFeatureRequestUrl("wfs_url?a=b");
+                var getFeatureUrl = OpenLayers.Layer.WMS.buildGetFeatureRequestUrl("wfs_url?a=b");
 
                 expect(getFeatureUrl.startsWith('wfs_url?a=b&')).toBe(true);
             });
 
             it('adds a ? if required', function() {
 
-                var getFeatureUrl = openLayer.buildGetFeatureRequestUrl("wfs_url");
+                var getFeatureUrl = OpenLayers.Layer.WMS.buildGetFeatureRequestUrl("wfs_url");
 
                 expect(getFeatureUrl.startsWith('wfs_url?')).toBe(true);
             });
@@ -99,7 +99,7 @@ describe('OpenLayers', function() {
                     '&REQUEST=GetFeature' +
                     '&VERSION=1.0.0';
 
-                var getFeatureUrl = openLayer.buildGetFeatureRequestUrl('wfs_url', 'type_name', 'txt');
+                var getFeatureUrl = OpenLayers.Layer.WMS.buildGetFeatureRequestUrl('wfs_url', 'type_name', 'txt');
 
                 expect(getFeatureUrl).toBe(expectedUrl);
             });
@@ -114,7 +114,7 @@ describe('OpenLayers', function() {
                     '&VERSION=1.0.0' +
                     '&CQL_FILTER=cql%20%25%3A%2F';
 
-                var getFeatureUrl = openLayer.buildGetFeatureRequestUrl('wfs_url', 'type_name', 'csv', 'cql %:/');
+                var getFeatureUrl = OpenLayers.Layer.WMS.buildGetFeatureRequestUrl('wfs_url', 'type_name', 'csv', 'cql %:/');
 
                 expect(getFeatureUrl).toBe(expectedUrl);
             });

--- a/web-app/js/portal/cart/BodaacDownloadHandler.js
+++ b/web-app/js/portal/cart/BodaacDownloadHandler.js
@@ -77,8 +77,7 @@ Portal.cart.BodaacDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
                 filters: collection.getFilters()
             });
 
-            var wmsLayer = collection.getLayerState().getSelectedLayer();
-            return wmsLayer._buildGetFeatureRequestUrl(
+            return OpenLayers.Layer.WMS.prototype._buildGetFeatureRequestUrl(
                 _this._resourceHref(),
                 _this._layerName(),
                 OpenLayers.Layer.DOWNLOAD_FORMAT_CSV,

--- a/web-app/js/portal/cart/BodaacDownloadHandler.js
+++ b/web-app/js/portal/cart/BodaacDownloadHandler.js
@@ -77,7 +77,7 @@ Portal.cart.BodaacDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
                 filters: collection.getFilters()
             });
 
-            return OpenLayers.Layer.WMS.prototype._buildGetFeatureRequestUrl(
+            return OpenLayers.Layer.WMS.prototype.buildGetFeatureRequestUrl(
                 _this._resourceHref(),
                 _this._layerName(),
                 OpenLayers.Layer.DOWNLOAD_FORMAT_CSV,

--- a/web-app/js/portal/cart/BodaacDownloadHandler.js
+++ b/web-app/js/portal/cart/BodaacDownloadHandler.js
@@ -77,7 +77,7 @@ Portal.cart.BodaacDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
                 filters: collection.getFilters()
             });
 
-            return OpenLayers.Layer.WMS.prototype.buildGetFeatureRequestUrl(
+            return OpenLayers.Layer.WMS.buildGetFeatureRequestUrl(
                 _this._resourceHref(),
                 _this._layerName(),
                 OpenLayers.Layer.DOWNLOAD_FORMAT_CSV,

--- a/web-app/js/portal/cart/PythonDownloadHandler.js
+++ b/web-app/js/portal/cart/PythonDownloadHandler.js
@@ -37,7 +37,7 @@ Portal.cart.PythonDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
         var _this = this;
 
         return function(collection) {
-            return OpenLayers.Layer.WMS.prototype.getFeatureRequestUrl(
+            return OpenLayers.Layer.WMS.getFeatureRequestUrl(
                 collection.getFilters(),
                 _this._resourceHref(),
                 _this._resourceName(),

--- a/web-app/js/portal/cart/PythonDownloadHandler.js
+++ b/web-app/js/portal/cart/PythonDownloadHandler.js
@@ -37,7 +37,7 @@ Portal.cart.PythonDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
         var _this = this;
 
         return function(collection) {
-            return collection.getLayerState().getSelectedLayer().getFeatureRequestUrl(
+            return OpenLayers.Layer.WMS.prototype.getFeatureRequestUrl(
                 collection.getFilters(),
                 _this._resourceHref(),
                 _this._resourceName(),

--- a/web-app/js/portal/cart/WfsDownloadHandler.js
+++ b/web-app/js/portal/cart/WfsDownloadHandler.js
@@ -37,7 +37,7 @@ Portal.cart.WfsDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
         var _this = this;
 
         return function(collection) {
-            return collection.getLayerState().getSelectedLayer().getFeatureRequestUrl(
+            return OpenLayers.Layer.WMS.prototype.getFeatureRequestUrl(
                 collection.getFilters(),
                 _this._resourceHref(),
                 _this._resourceName(),

--- a/web-app/js/portal/cart/WfsDownloadHandler.js
+++ b/web-app/js/portal/cart/WfsDownloadHandler.js
@@ -37,7 +37,7 @@ Portal.cart.WfsDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
         var _this = this;
 
         return function(collection) {
-            return OpenLayers.Layer.WMS.prototype.getFeatureRequestUrl(
+            return OpenLayers.Layer.WMS.getFeatureRequestUrl(
                 collection.getFilters(),
                 _this._resourceHref(),
                 _this._resourceName(),

--- a/web-app/js/portal/data/DataCollectionLayers.js
+++ b/web-app/js/portal/data/DataCollectionLayers.js
@@ -54,6 +54,10 @@ Portal.data.DataCollectionLayers = Ext.extend(Ext.util.Observable, {
         this.fireEvent('selectedlayerchanged', this.selectedLayer, oldLayer);
     },
 
+    isLoading: function() {
+        return this.getSelectedLayer().loading;
+    },
+
     _setLayerProperty: function(key, value) {
         this._layerProperties()[key] = value;
     },

--- a/web-app/js/portal/details/SubsetItemsWrapperPanel.js
+++ b/web-app/js/portal/details/SubsetItemsWrapperPanel.js
@@ -13,7 +13,7 @@ Portal.details.SubsetItemsWrapperPanel = Ext.extend(Ext.Panel, {
 
         var tabPanelForLayer = this._initSubsetItemsTabPanel(cfg);
 
-        this.createTools(cfg.dataCollection.getLayerState().getSelectedLayer());
+        this.createTools(cfg.dataCollection.getLayerState());
 
         cfg.dataCollection.getLayerState().on('loadstart', function() {
             this._onLayerLoadStart();
@@ -90,7 +90,7 @@ Portal.details.SubsetItemsWrapperPanel = Ext.extend(Ext.Panel, {
         });
     },
 
-    createTools: function(layer) {
+    createTools: function(layerState) {
 
         this.errorToolItem = {
             id: 'errorToolItem',
@@ -101,7 +101,7 @@ Portal.details.SubsetItemsWrapperPanel = Ext.extend(Ext.Panel, {
         this.spinnerToolItem = {
             id: 'spinnerToolItem',
             styles: 'fa-spin fa-spinner',
-            hidden: !layer.loading,
+            hidden: !layerState.isLoading(),
             title: OpenLayers.i18n('loadingMessage')
         };
         this.deleteToolItem = {

--- a/web-app/js/portal/prototypes/OpenLayers.js
+++ b/web-app/js/portal/prototypes/OpenLayers.js
@@ -113,7 +113,7 @@ OpenLayers.Layer.WMS.prototype.getFeatureRequestUrl = function(filters, serverUr
         filters: filters
     });
 
-    return this._buildGetFeatureRequestUrl(
+    return this.buildGetFeatureRequestUrl(
         serverUrl,
         layerName,
         outputFormat,
@@ -121,7 +121,7 @@ OpenLayers.Layer.WMS.prototype.getFeatureRequestUrl = function(filters, serverUr
     );
 };
 
-OpenLayers.Layer.WMS.prototype._buildGetFeatureRequestUrl = function(baseUrl, layerName, outputFormat, downloadFilter) {
+OpenLayers.Layer.WMS.prototype.buildGetFeatureRequestUrl = function(baseUrl, layerName, outputFormat, downloadFilter) {
 
     var wfsUrl = baseUrl;
     wfsUrl += (wfsUrl.indexOf('?') !== -1) ? "&" : "?";

--- a/web-app/js/portal/prototypes/OpenLayers.js
+++ b/web-app/js/portal/prototypes/OpenLayers.js
@@ -107,13 +107,13 @@ OpenLayers.Layer.WMS.prototype.formatFeatureInfoHtml = function(resp, options) {
     return formatGetFeatureInfo(resp, options);
 };
 
-OpenLayers.Layer.WMS.prototype.getFeatureRequestUrl = function(filters, serverUrl, layerName, outputFormat) {
+OpenLayers.Layer.WMS.getFeatureRequestUrl = function(filters, serverUrl, layerName, outputFormat) {
 
     var builder = new Portal.filter.combiner.DataDownloadCqlBuilder({
         filters: filters
     });
 
-    return this.buildGetFeatureRequestUrl(
+    return OpenLayers.Layer.WMS.buildGetFeatureRequestUrl(
         serverUrl,
         layerName,
         outputFormat,
@@ -121,7 +121,7 @@ OpenLayers.Layer.WMS.prototype.getFeatureRequestUrl = function(filters, serverUr
     );
 };
 
-OpenLayers.Layer.WMS.prototype.buildGetFeatureRequestUrl = function(baseUrl, layerName, outputFormat, downloadFilter) {
+OpenLayers.Layer.WMS.buildGetFeatureRequestUrl = function(baseUrl, layerName, outputFormat, downloadFilter) {
 
     var wfsUrl = baseUrl;
     wfsUrl += (wfsUrl.indexOf('?') !== -1) ? "&" : "?";


### PR DESCRIPTION
It's preferable for components to be driven off DataCollection and only off selected layer where absolutely necessary.