### PR TITLE
Remove knowledge of ncwmsParams from DataCollection

### DIFF
--- a/src/test/javascript/portal/cart/GogoduckDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/cart/GogoduckDownloadHandlerSpec.js
@@ -83,14 +83,21 @@ describe('Portal.cart.GogoduckDownloadHandler', function () {
             clickHandler = handler._getUrlGeneratorFunction();
 
             testCollection = {
-                getNcwmsParams: returns({
-                    dateRangeStart: moment.utc('2000-01-01T01:01:01'),
-                    dateRangeEnd: moment.utc('2014-12-23T23:59:59'),
-                    latitudeRangeStart: -42,
-                    latitudeRangeEnd: -20,
-                    longitudeRangeStart: 160,
-                    longitudeRangeEnd: 170
-                })
+                getFilters: returns([
+                    {
+                        isNcwmsParams: true,
+                        dateRangeStart: moment.utc('2000-01-01T01:01:01'),
+                        dateRangeEnd: moment.utc('2014-12-23T23:59:59'),
+                        latitudeRangeStart: -42,
+                        latitudeRangeEnd: -20,
+                        longitudeRangeStart: 160,
+                        longitudeRangeEnd: 170
+                    },
+                    {
+                        type: Portal.filter.DateFilter,
+                        comment: 'Should be safely ignored for URL building'
+                    }
+                ])
             };
             testHandlerParams = {
                 emailAddress: 'bob@example.com'
@@ -123,10 +130,11 @@ describe('Portal.cart.GogoduckDownloadHandler', function () {
         });
 
         it('builds the correct URL if no area is specified', function() {
-            testCollection.getNcwmsParams = returns({
+            testCollection.getFilters = returns([{
+                isNcwmsParams: true,
                 dateRangeStart: moment.utc('2000-01-01T01:01:01'),
                 dateRangeEnd: moment.utc('2014-12-23T23:59:59')
-            });
+            }]);
 
             url = clickHandler(testCollection, testHandlerParams);
             json = jsonFromUrl(url, expectedUrlStart);
@@ -140,12 +148,13 @@ describe('Portal.cart.GogoduckDownloadHandler', function () {
         });
 
         it('builds the correct URL is no dates are specified', function() {
-            testCollection.getNcwmsParams = returns({
+            testCollection.getFilters = returns([{
+                isNcwmsParams: true,
                 latitudeRangeStart: -42,
                 latitudeRangeEnd: -20,
                 longitudeRangeStart: 160,
                 longitudeRangeEnd: 170
-            });
+            }]);
 
             url = clickHandler(testCollection, testHandlerParams);
             json = jsonFromUrl(url, expectedUrlStart);

--- a/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
+++ b/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
@@ -20,14 +20,21 @@ describe('Portal.cart.NcWmsInjector', function() {
         endDate = moment.utc(Date.UTC(2014, 11, 21, 22, 30, 30, 500));
         dataCollection = {
             uuid: 9,
-            getNcwmsParams: returns({
-                dateRangeStart: startDate,
-                dateRangeEnd: endDate,
-                latitudeRangeStart: '-10',
-                latitudeRangeEnd: '40',
-                longitudeRangeEnd: '180',
-                longitudeRangeStart: '150'
-            })
+            getFilters: returns([
+                {
+                    isNcwmsParams: true,
+                    dateRangeStart: startDate,
+                    dateRangeEnd: endDate,
+                    latitudeRangeStart: '-10',
+                    latitudeRangeEnd: '40',
+                    longitudeRangeEnd: '180',
+                    longitudeRangeStart: '150'
+                },
+                {
+                    type: Portal.filter.DateFilter,
+                    comment: 'Should be safely ignored for URL building'
+                }
+            ])
         };
     });
 
@@ -38,9 +45,10 @@ describe('Portal.cart.NcWmsInjector', function() {
         });
 
         it('returns a default message when no defined date', function() {
-            dataCollection.getNcwmsParams = returns({
+            dataCollection.getFilters = returns([{
+                isNcwmsParams: true,
                 dateRangeStart: null
-            });
+            }]);
 
             expect(injector._getDataFilterEntry(dataCollection)).toEqual(OpenLayers.i18n("emptyDownloadPlaceholder"));
         });
@@ -53,10 +61,11 @@ describe('Portal.cart.NcWmsInjector', function() {
 
         it('indicates temporal range', function() {
 
-            dataCollection.getNcWmsParams = returns({
+            dataCollection.getFilters = returns([{
+                isNcwmsParams: true,
                 dateRangeStart: moment.utc(Date.UTC(2013, 10, 20, 0, 30, 0, 0)),
                 dateRangeEnd: moment.utc(Date.UTC(2014, 11, 21, 10, 30, 30, 500))
-            });
+            }]);
 
             var entry = injector._getDataFilterEntry(dataCollection);
             expect(entry).toContain(dateLabel);

--- a/src/test/javascript/portal/data/DataCollectionSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionSpec.js
@@ -8,78 +8,11 @@
 describe("Portal.data.DataCollection", function() {
 
     var dataCollection;
-    var expectedDateFilterConfig;
-    var testDateFilter;
 
     beforeEach(function() {
         dataCollection = new Portal.data.DataCollection();
         spyOn(dataCollection, 'getWmsLayerLinks').andReturn([]);
         spyOn(dataCollection, 'setFilters');
-        spyOn(Portal.filter, 'DateFilter').andReturn(testDateFilter);
-
-        testDateFilter = {};
-    });
-
-    describe('updateNcwmsParams', function() {
-
-        beforeEach(function() {
-            expectedDateFilterConfig = {
-                name: 'time',
-                value: {},
-                visualised: true
-            };
-        });
-
-        it('updated start date', function() {
-
-            var testStartDate = moment();
-
-            dataCollection.updateNcwmsParams(testStartDate, moment('invalid date'), null);
-
-            expect(dataCollection.ncwmsParams).toEqual({
-                dateRangeStart: testStartDate
-            });
-
-            expectedDateFilterConfig.value.fromDate = testStartDate.toDate();
-
-            expect(Portal.filter.DateFilter).toHaveBeenCalledWith(expectedDateFilterConfig);
-            expect(dataCollection.setFilters).toHaveBeenCalledWith([testDateFilter]);
-        });
-
-        it('updated end date', function() {
-
-            var testEndDate = moment();
-
-            dataCollection.updateNcwmsParams(moment('invalid date'), testEndDate, null);
-
-            expect(dataCollection.ncwmsParams).toEqual({
-                dateRangeEnd: testEndDate
-            });
-
-            expectedDateFilterConfig.value.toDate = testEndDate.toDate();
-
-            expect(Portal.filter.DateFilter).toHaveBeenCalledWith(expectedDateFilterConfig);
-            expect(dataCollection.setFilters).toHaveBeenCalledWith([testDateFilter]);
-        });
-
-        it('update geometry', function() {
-
-            dataCollection.updateNcwmsParams(null, null, {
-                getBounds: returns({
-                    bottom: 4,
-                    left: 3,
-                    right: 2,
-                    top: 1
-                })
-            });
-
-            expect(dataCollection.ncwmsParams).toEqual({
-                longitudeRangeStart: 3,
-                longitudeRangeEnd: 2,
-                latitudeRangeStart: 4,
-                latitudeRangeEnd: 1
-            });
-        });
     });
 
     describe('getFiltersRequestParams()', function() {

--- a/web-app/js/portal/cart/GogoduckDownloadHandler.js
+++ b/web-app/js/portal/cart/GogoduckDownloadHandler.js
@@ -63,7 +63,7 @@ Portal.cart.GogoduckDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
         return function(collection, handlerParams) {
 
             var gogoduckUrl = _this._buildGogoduckUrl(
-                collection.getNcwmsParams(),
+                collection.getFilters(),
                 _this._resourceName(),
                 _this._resourceHref(),
                 handlerParams.emailAddress
@@ -77,7 +77,10 @@ Portal.cart.GogoduckDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
         };
     },
 
-    _buildGogoduckUrl: function(aggregationParams, layerName, serverUrl, notificationEmailAddress) {
+    _buildGogoduckUrl: function(filters, layerName, serverUrl, notificationEmailAddress) {
+        var aggregationParams = filters.filter(function(filter) {
+            return filter.isNcwmsParams;
+        })[0];
 
         var args = {
             layerName: layerName,

--- a/web-app/js/portal/cart/NcWmsInjector.js
+++ b/web-app/js/portal/cart/NcWmsInjector.js
@@ -10,8 +10,11 @@ Ext.namespace('Portal.cart');
 Portal.cart.NcWmsInjector = Ext.extend(Portal.cart.BaseInjector, {
 
     _getDataFilterEntry: function(collection) {
+        var filters = collection.getFilters();
+        var params = filters.filter(function(filter) {
+            return filter.isNcwmsParams;
+        })[0];
 
-        var params = collection.getNcwmsParams();
         var areaString = "";
         var dateString = "";
 

--- a/web-app/js/portal/data/DataCollection.js
+++ b/web-app/js/portal/data/DataCollection.js
@@ -97,50 +97,6 @@ Portal.data.DataCollection = function() {
         return this.filters || [];
     };
 
-    constructor.prototype.getNcwmsParams = function() {
-
-        return this.ncwmsParams || {};
-    };
-
-    constructor.prototype.updateNcwmsParams = function(dateRangeStart, dateRangeEnd, geometry) {
-
-        var newNcwmsParams = {};
-        var newFilterValue = {};
-
-        if (dateRangeStart && dateRangeStart.isValid()) {
-            newNcwmsParams.dateRangeStart = dateRangeStart;
-            newFilterValue.fromDate = dateRangeStart.toDate();
-        }
-
-        if (dateRangeEnd && dateRangeEnd.isValid()) {
-            newNcwmsParams.dateRangeEnd = dateRangeEnd;
-            newFilterValue.toDate = dateRangeEnd.toDate();
-        }
-
-        if (geometry) {
-            var bounds = geometry.getBounds();
-
-            newNcwmsParams.latitudeRangeStart = bounds.bottom;
-            newNcwmsParams.longitudeRangeStart = bounds.left;
-            newNcwmsParams.latitudeRangeEnd = bounds.top;
-            newNcwmsParams.longitudeRangeEnd = bounds.right;
-        }
-
-        this.ncwmsParams = newNcwmsParams;
-
-        // We also set a Filters equivalent of the date values for BODAAC CQL building
-        // This will disappear when https://github.com/aodn/backlog/issues/191 is done
-        var dateFilter = new Portal.filter.DateFilter({
-            name: 'time',
-            value: newFilterValue,
-            visualised: true
-        });
-
-        this.setFilters([
-            dateFilter
-        ]);
-    };
-
     constructor.prototype._getRawLinks = function() { // Todo - DN: 'raw' here because they haven't gone thorugh the LayerStore. What is a better name?
         return this.getMetadataRecord().get('links');
     };

--- a/web-app/js/portal/details/NcWmsPanel.js
+++ b/web-app/js/portal/details/NcWmsPanel.js
@@ -324,7 +324,46 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Container, {
         var dateRangeStart = this._getDateFromPicker(this.startDateTimePicker);
         var dateRangeEnd = this._getDateFromPicker(this.endDateTimePicker);
 
-        this.dataCollection.updateNcwmsParams(dateRangeStart, dateRangeEnd, geometry);
+        this.dataCollection.setFilters(this._ncwmsParamsAsFilters(dateRangeStart, dateRangeEnd, geometry));
+    },
+
+    _ncwmsParamsAsFilters: function(dateRangeStart, dateRangeEnd, geometry) {
+
+        var newFilterValue = {};
+        var ncwmsParamsAsFilter = {
+            isNcwmsParams: true,
+            hasValue: function() { return false; } // From the Portal.filter.Filter interface. Prevents filter from being used in CQL or displayed to user
+        };
+
+        if (dateRangeStart && dateRangeStart.isValid()) {
+            ncwmsParamsAsFilter.dateRangeStart = dateRangeStart;
+            newFilterValue.fromDate = dateRangeStart.toDate();
+        }
+
+        if (dateRangeEnd && dateRangeEnd.isValid()) {
+            ncwmsParamsAsFilter.dateRangeEnd = dateRangeEnd;
+            newFilterValue.toDate = dateRangeEnd.toDate();
+        }
+
+        if (geometry) {
+            var bounds = geometry.getBounds();
+
+            ncwmsParamsAsFilter.latitudeRangeStart = bounds.bottom;
+            ncwmsParamsAsFilter.longitudeRangeStart = bounds.left;
+            ncwmsParamsAsFilter.latitudeRangeEnd = bounds.top;
+            ncwmsParamsAsFilter.longitudeRangeEnd = bounds.right;
+        }
+
+        var realDateFilter = new Portal.filter.DateFilter({
+            name: 'time',
+            value: newFilterValue,
+            visualised: true
+        });
+
+        return [
+            realDateFilter,
+            ncwmsParamsAsFilter
+        ];
     },
 
     _attachTemporalEvents: function() {


### PR DESCRIPTION
We have removed references to ncwmsParams from DataCollection. We now
convert ncwmsParams into a list of filters and store them as such.
Then when they are used (2 places) we decode them back into ncwmsParams.
These conversion steps will be eliminated when
https://github.com/aodn/backlog/issues/191 is completed.