### PR TITLE
Introduced class `DataCollectionLayerAdapter`

### DIFF
--- a/grails-app/views/_js_includes.gsp
+++ b/grails-app/views/_js_includes.gsp
@@ -162,7 +162,7 @@
     <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'GeoNetworkRecordFetcher.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'GeoNetworkRecordStore.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'DataCollection.js')}"></script>
-    <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'DataCollectionLayers.js')}"></script>
+    <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'LayerSelectionModel.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'DataCollectionLayerAdapter.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'DataCollectionStore.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/mainMap', file: 'map.js')}"></script>

--- a/grails-app/views/_js_includes.gsp
+++ b/grails-app/views/_js_includes.gsp
@@ -163,6 +163,7 @@
     <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'GeoNetworkRecordStore.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'DataCollection.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'DataCollectionLayers.js')}"></script>
+    <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'DataCollectionLayerAdapter.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/data', file: 'DataCollectionStore.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/mainMap', file: 'map.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/common', file: 'GeoExt.ux.BaseLayerCombobox.js')}"></script>

--- a/src/test/javascript/portal/data/DataCollectionLayerAdapterSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionLayerAdapterSpec.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+
+describe("Portal.data.DataCollectionLayerAdapter", function() {
+    it('indicates loading', function() {
+        var layerState = {
+            getSelectedLayer: returns(new OpenLayers.Layer()),
+            on: noOp
+        };
+        var layerAdapter = new Portal.data.DataCollectionLayerAdapter({
+            layerState: layerState
+        });
+
+        layerState.getSelectedLayer = returns({
+            loading: true
+        });
+        expect(layerAdapter.isLoading()).toBe(true);
+
+        layerState.getSelectedLayer = returns({
+            loading: false
+        });
+        expect(layerAdapter.isLoading()).toBe(false);
+    });
+});

--- a/src/test/javascript/portal/data/DataCollectionLayerAdapterSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionLayerAdapterSpec.js
@@ -6,24 +6,24 @@
  */
 
 describe("Portal.data.DataCollectionLayerAdapter", function() {
-    var layerState;
+    var layerSelectionModel;
     var layerAdapter;
 
     beforeEach(function() {
-        spyOn(Portal.data.DataCollectionLayers.prototype, '_initLayers');
-        layerState = new Portal.data.DataCollectionLayers();
-        layerState.selectedLayer = new OpenLayers.Layer();
+        spyOn(Portal.data.LayerSelectionModel.prototype, '_initLayers');
+        layerSelectionModel = new Portal.data.LayerSelectionModel();
+        layerSelectionModel.selectedLayer = new OpenLayers.Layer();
 
         layerAdapter = new Portal.data.DataCollectionLayerAdapter({
-            layerState: layerState
+            layerSelectionModel: layerSelectionModel
         });
     });
 
     it('indicates loading', function() {
-        layerState.getSelectedLayer().loading = true;
+        layerSelectionModel.getSelectedLayer().loading = true;
         expect(layerAdapter.isLoading()).toBe(true);
 
-        layerState.getSelectedLayer().loading = false;
+        layerSelectionModel.getSelectedLayer().loading = false;
         expect(layerAdapter.isLoading()).toBe(false);
     });
 
@@ -34,7 +34,7 @@ describe("Portal.data.DataCollectionLayerAdapter", function() {
                 layerAdapter.on(eventName, eventListener);
 
                 var newLayer = new OpenLayers.Layer.Grid();
-                layerState.setSelectedLayer(newLayer);
+                layerSelectionModel.setSelectedLayer(newLayer);
 
                 newLayer.events.triggerEvent(eventName, newLayer);
 
@@ -46,9 +46,9 @@ describe("Portal.data.DataCollectionLayerAdapter", function() {
                 layerAdapter.on(eventName, eventListener);
 
                 var origLayer = new OpenLayers.Layer();
-                layerState.setSelectedLayer(origLayer);
+                layerSelectionModel.setSelectedLayer(origLayer);
 
-                layerState.setSelectedLayer(new OpenLayers.Layer());
+                layerSelectionModel.setSelectedLayer(new OpenLayers.Layer());
 
                 origLayer.events.triggerEvent(eventName, origLayer);
 

--- a/src/test/javascript/portal/data/DataCollectionLayersSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionLayersSpec.js
@@ -141,14 +141,6 @@ describe("Portal.data.DataCollectionLayersSpec", function() {
                 expect(eventListener).not.toHaveBeenCalled();
             });
         });
-
-        it('indicates loading', function() {
-            dataCollectionLayers.getSelectedLayer().loading = true;
-            expect(dataCollectionLayers.isLoading()).toBe(true);
-
-            dataCollectionLayers.getSelectedLayer().loading = false;
-            expect(dataCollectionLayers.isLoading()).toBe(false);
-        });
     });
 
     describe('isNcwms', function() {

--- a/src/test/javascript/portal/data/DataCollectionLayersSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionLayersSpec.js
@@ -114,33 +114,6 @@ describe("Portal.data.DataCollectionLayersSpec", function() {
                 expect(selectedLayerChangedListener).toHaveBeenCalledWith(newLayer, oldLayer);
             });
         });
-
-        Ext.each(['loadstart', 'loadend', 'tileerror'], function(eventName) {
-            it('forwards ' + eventName + ' event', function() {
-                var eventListener = jasmine.createSpy('eventListener');
-                dataCollectionLayers.on(eventName, eventListener);
-
-                var newLayer = new OpenLayers.Layer.Grid();
-                dataCollectionLayers.setSelectedLayer(newLayer);
-                newLayer.events.triggerEvent(eventName, newLayer);
-
-                expect(eventListener).toHaveBeenCalled();
-            });
-
-            it('does not forward deselected layer ' + eventName + ' event', function() {
-                var eventListener = jasmine.createSpy('eventListener');
-                dataCollectionLayers.on(eventName, eventListener);
-
-                var origLayer = new OpenLayers.Layer();
-                dataCollectionLayers.setSelectedLayer(origLayer);
-
-                dataCollectionLayers.setSelectedLayer(new OpenLayers.Layer());
-
-                origLayer.events.triggerEvent(eventName, origLayer);
-
-                expect(eventListener).not.toHaveBeenCalled();
-            });
-        });
     });
 
     describe('isNcwms', function() {

--- a/src/test/javascript/portal/data/DataCollectionSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionSpec.js
@@ -17,7 +17,7 @@ describe("Portal.data.DataCollection", function() {
 
     describe('getFiltersRequestParams()', function() {
         beforeEach(function() {
-            dataCollection.getLayerState = returns({
+            dataCollection.getLayerSelectionModel = returns({
                 getSelectedLayer: returns({
                     server: {uri: 'server url'}
                 })
@@ -57,15 +57,15 @@ describe("Portal.data.DataCollection", function() {
 
     describe('layerstate', function() {
         it('lazily initialises layer state', function() {
-            var layerState = dataCollection.getLayerState();
-            expect(layerState).toBeInstanceOf(Portal.data.DataCollectionLayers);
+            var layerSelectionModel = dataCollection.getLayerSelectionModel();
+            expect(layerSelectionModel).toBeInstanceOf(Portal.data.LayerSelectionModel);
 
             // Make sure we're reusing the same object.
-            expect(dataCollection.getLayerState()).toBe(layerState);
+            expect(dataCollection.getLayerSelectionModel()).toBe(layerSelectionModel);
         });
 
         it('returns correct WMS type', function() {
-            spyOn(dataCollection.getLayerState(), 'isNcwms').andReturn(true);
+            spyOn(dataCollection.getLayerSelectionModel(), 'isNcwms').andReturn(true);
             expect(dataCollection.isNcwms()).toBe(true);
         });
     });

--- a/src/test/javascript/portal/data/DataCollectionStoreSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionStoreSpec.js
@@ -19,8 +19,8 @@ describe("Portal.data.DataCollectionStoreSpec", function() {
             removeUsingOpenLayer: jasmine.createSpy('removeUsingOpenLayer')
         };
 
-        spyOn(Portal.data.DataCollectionLayers.prototype, '_initLayers');
-        spyOn(Portal.data.DataCollectionLayers.prototype, 'getSelectedLayer').andCallFake(function() {
+        spyOn(Portal.data.LayerSelectionModel.prototype, '_initLayers');
+        spyOn(Portal.data.LayerSelectionModel.prototype, 'getSelectedLayer').andCallFake(function() {
             this.selectedLayer = layer;
             return layer;
         });
@@ -45,9 +45,9 @@ describe("Portal.data.DataCollectionStoreSpec", function() {
         var newLayer = new OpenLayers.Layer();
 
         dataCollectionStore.add(dataCollection);
-        var layerState = dataCollection.getLayerState();
+        var layerSelectionModel = dataCollection.getLayerSelectionModel();
 
-        layerState.setSelectedLayer(newLayer);
+        layerSelectionModel.setSelectedLayer(newLayer);
 
         expect(layerStore.removeUsingOpenLayer).toHaveBeenCalledWith(oldLayer);
         expect(layerStore.addUsingOpenLayer).toHaveBeenCalledWith(newLayer);

--- a/src/test/javascript/portal/data/DataCollectionStoreSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionStoreSpec.js
@@ -46,7 +46,6 @@ describe("Portal.data.DataCollectionStoreSpec", function() {
 
         dataCollectionStore.add(dataCollection);
         var layerState = dataCollection.getLayerState();
-        spyOn(layerState, '_copyAttributesFromSelectedLayer');
 
         layerState.setSelectedLayer(newLayer);
 

--- a/src/test/javascript/portal/data/LayerSelectionModelSpec.js
+++ b/src/test/javascript/portal/data/LayerSelectionModelSpec.js
@@ -5,7 +5,7 @@
  *
  */
 
-describe("Portal.data.DataCollectionLayersSpec", function() {
+describe("Portal.data.LayerSelectionModelSpec", function() {
 
     var dataCollection;
     var dataCollectionLayers;
@@ -59,7 +59,7 @@ describe("Portal.data.DataCollectionLayersSpec", function() {
             get: returns('name')
         };
 
-        dataCollectionLayers = new Portal.data.DataCollectionLayers({
+        dataCollectionLayers = new Portal.data.LayerSelectionModel({
             dataCollection: dataCollection
         });
     });

--- a/src/test/javascript/portal/data/LayerStoreSpec.js
+++ b/src/test/javascript/portal/data/LayerStoreSpec.js
@@ -228,7 +228,7 @@ describe("Portal.data.LayerStore", function() {
 
         beforeEach(function() {
             dataCollection = {
-                getLayerState: returns({
+                getLayerSelectionModel: returns({
                     getSelectedLayer: noOp
                 })
             };
@@ -240,7 +240,7 @@ describe("Portal.data.LayerStore", function() {
             it('handles selected layer on ' + eventName, function() {
                 var selectedLayer = {};
 
-                dataCollection.getLayerState().getSelectedLayer = returns(selectedLayer);
+                dataCollection.getLayerSelectionModel().getSelectedLayer = returns(selectedLayer);
                 Ext.MsgBus.publish(eventName, dataCollection);
 
                 expect(layerStore._selectedLayerChanged).toHaveBeenCalledWith(eventName, selectedLayer);

--- a/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/data/WfsDownloadHandlerSpec.js
@@ -45,7 +45,7 @@ describe('Portal.cart.WfsDownloadHandler', function () {
                 };
                 var dummyFilters = ['filters'];
                 var dummyCollection = {
-                    getLayerState: returns({
+                    getLayerSelectionModel: returns({
                         getSelectedLayer: returns(dummyLayer)
                     }),
                     getFilters: returns(dummyFilters)

--- a/src/test/javascript/portal/details/DataCollectionDetailsPanelSpec.js
+++ b/src/test/javascript/portal/details/DataCollectionDetailsPanelSpec.js
@@ -7,6 +7,7 @@
 describe("Portal.details.DataCollectionDetailsPanel", function() {
     var panel;
     var layer;
+    var layerAdapter;
     var layerState;
 
     var dataCollection;
@@ -15,11 +16,14 @@ describe("Portal.details.DataCollectionDetailsPanel", function() {
         spyOn(Portal.details.DataCollectionDetailsPanel.prototype, '_initSubsetItemsTabPanel').andReturn(new Ext.Panel());
 
         layer = new OpenLayers.Layer.WMS();
+        layerAdapter = {
+            isLoading: returns(false)
+        };
         layerState = new Ext.util.Observable();
-        layerState.isLoading = returns(false);
 
         dataCollection = {
             getTitle: returns('amazetion'),
+            getLayerAdapter: returns(layerAdapter),
             getLayerState: returns(layerState)
         };
 

--- a/src/test/javascript/portal/details/DataCollectionDetailsPanelSpec.js
+++ b/src/test/javascript/portal/details/DataCollectionDetailsPanelSpec.js
@@ -16,10 +16,10 @@ describe("Portal.details.DataCollectionDetailsPanel", function() {
         spyOn(Portal.details.DataCollectionDetailsPanel.prototype, '_initSubsetItemsTabPanel').andReturn(new Ext.Panel());
 
         layer = new OpenLayers.Layer.WMS();
-        layerAdapter = {
-            isLoading: returns(false)
-        };
-        layerState = new Ext.util.Observable();
+        layerAdapter = new Ext.util.Observable();
+        layerAdapter.isLoading = returns(false);
+
+        layerState = {};
 
         dataCollection = {
             getTitle: returns('amazetion'),
@@ -41,17 +41,17 @@ describe("Portal.details.DataCollectionDetailsPanel", function() {
         });
 
         it('responds to loadstart', function() {
-            layerState.fireEvent('loadstart');
+            layerAdapter.fireEvent('loadstart');
             expect(panel._onLayerLoadStart).toHaveBeenCalled();
         });
 
         it('responds to loadend', function() {
-            layerState.fireEvent('loadend');
+            layerAdapter.fireEvent('loadend');
             expect(panel._onLayerLoadEnd).toHaveBeenCalled();
         });
 
         it('responds to tileerror', function() {
-            layerState.fireEvent('tileerror');
+            layerAdapter.fireEvent('tileerror');
             expect(panel._onLayerLoadError).toHaveBeenCalled();
         });
     });

--- a/src/test/javascript/portal/details/DataCollectionDetailsPanelSpec.js
+++ b/src/test/javascript/portal/details/DataCollectionDetailsPanelSpec.js
@@ -8,7 +8,7 @@ describe("Portal.details.DataCollectionDetailsPanel", function() {
     var panel;
     var layer;
     var layerAdapter;
-    var layerState;
+    var layerSelectionModel;
 
     var dataCollection;
 
@@ -19,12 +19,12 @@ describe("Portal.details.DataCollectionDetailsPanel", function() {
         layerAdapter = new Ext.util.Observable();
         layerAdapter.isLoading = returns(false);
 
-        layerState = {};
+        layerSelectionModel = {};
 
         dataCollection = {
             getTitle: returns('amazetion'),
             getLayerAdapter: returns(layerAdapter),
-            getLayerState: returns(layerState)
+            getLayerSelectionModel: returns(layerSelectionModel)
         };
 
         panel = new Portal.details.DataCollectionDetailsPanel({

--- a/src/test/javascript/portal/details/LayerControlPanelSpec.js
+++ b/src/test/javascript/portal/details/LayerControlPanelSpec.js
@@ -4,7 +4,7 @@ describe("Portal.details.LayerControlPanel", function() {
     var layerControlPanel;
     var layers;
     var layerAdapter;
-    var layerState;
+    var layerSelectionModel;
     var selectedLayer;
 
     beforeEach(function() {
@@ -13,7 +13,7 @@ describe("Portal.details.LayerControlPanel", function() {
         layerAdapter = {
             isLoading: returns(false)
         };
-        layerState = {
+        layerSelectionModel = {
             getLayers: returns(layers),
             getSelectedLayer: function() {
                 return selectedLayer;
@@ -24,7 +24,7 @@ describe("Portal.details.LayerControlPanel", function() {
         dataCollection = {
             getTitle: returns('Data Collection Title'),
             getLayerAdapter: returns(layerAdapter),
-            getLayerState: returns(layerState)
+            getLayerSelectionModel: returns(layerSelectionModel)
         };
 
         layerControlPanel = new Portal.details.LayerControlPanel({
@@ -56,7 +56,7 @@ describe("Portal.details.LayerControlPanel", function() {
         });
 
         it('sets selected layer when selected', function() {
-            spyOn(dataCollection.getLayerState(), 'setSelectedLayer');
+            spyOn(dataCollection.getLayerSelectionModel(), 'setSelectedLayer');
             spyOn(window, 'trackLayerControlUsage');
             addLayers();
 
@@ -71,13 +71,13 @@ describe("Portal.details.LayerControlPanel", function() {
         });
 
         it('sends google analytics tracking information when selected', function() {
-            spyOn(dataCollection.getLayerState(), 'setSelectedLayer');
+            spyOn(dataCollection.getLayerSelectionModel(), 'setSelectedLayer');
             addLayers();
 
             var layerSelectComponent = layerControlPanel._newLayerSelectorComponent();
 
             layerSelectComponent.fireEvent('change', layerSelectComponent, layerSelectComponent.items[0]);
-            expect(dataCollection.getLayerState().setSelectedLayer).toHaveBeenCalledWith(layers[0]);
+            expect(dataCollection.getLayerSelectionModel().setSelectedLayer).toHaveBeenCalledWith(layers[0]);
         });
 
         var addLayers = function() {

--- a/src/test/javascript/portal/details/LayerControlPanelSpec.js
+++ b/src/test/javascript/portal/details/LayerControlPanelSpec.js
@@ -3,12 +3,16 @@ describe("Portal.details.LayerControlPanel", function() {
     var dataCollection;
     var layerControlPanel;
     var layers;
+    var layerAdapter;
     var layerState;
     var selectedLayer;
 
     beforeEach(function() {
         layers = [];
 
+        layerAdapter = {
+            isLoading: returns(false)
+        };
         layerState = {
             getLayers: returns(layers),
             getSelectedLayer: function() {
@@ -19,6 +23,7 @@ describe("Portal.details.LayerControlPanel", function() {
 
         dataCollection = {
             getTitle: returns('Data Collection Title'),
+            getLayerAdapter: returns(layerAdapter),
             getLayerState: returns(layerState)
         };
 

--- a/src/test/javascript/portal/details/NcWmsPanelSpec.js
+++ b/src/test/javascript/portal/details/NcWmsPanelSpec.js
@@ -12,7 +12,7 @@ describe('Portal.details.NcWmsPanel', function() {
     var dataCollection;
 
     var layer;
-    var layerState;
+    var layerSelectionModel;
 
     beforeEach(function() {
         map = new OpenLayers.SpatialConstraintMap();
@@ -27,13 +27,13 @@ describe('Portal.details.NcWmsPanel', function() {
         layer.processTemporalExtent = noOp;
         layer.map = map;
 
-        layerState = new Ext.util.Observable();
-        layerState.getSelectedLayer = returns(layer);
+        layerSelectionModel = new Ext.util.Observable();
+        layerSelectionModel.getSelectedLayer = returns(layer);
 
         dataCollection = {
             getUuid: returns(45678),
             setFilters: jasmine.createSpy('setFilters'),
-            getLayerState: returns(layerState)
+            getLayerSelectionModel: returns(layerSelectionModel)
         };
 
         ncwmsPanel = new Portal.details.NcWmsPanel({
@@ -162,7 +162,7 @@ describe('Portal.details.NcWmsPanel', function() {
 
         it('responds to selectedlayerchanged event', function() {
             spyOn(ncwmsPanel, '_onSelectedLayerChanged');
-            ncwmsPanel.dataCollection.getLayerState().fireEvent('selectedlayerchanged', newLayer);
+            ncwmsPanel.dataCollection.getLayerSelectionModel().fireEvent('selectedlayerchanged', newLayer);
 
             expect(ncwmsPanel._onSelectedLayerChanged).toHaveBeenCalledWith(newLayer);
         });

--- a/src/test/javascript/portal/details/NcwmsScaleRangeControlsSpec.js
+++ b/src/test/javascript/portal/details/NcwmsScaleRangeControlsSpec.js
@@ -8,17 +8,21 @@ describe('Portal.details.NcWmsScaleRangeControls', function() {
     describe('loadScaleFromLayer', function() {
 
         var controls;
+        var layerAdapter;
         var layerState;
         var dataCollection;
 
         beforeEach(function() {
 
-            layerState = {
-                on: noOp,
+            layerAdapter = {
                 getScaleRange: returns({})
+            };
+            layerState = {
+                on: noOp
             };
 
             dataCollection = {
+                getLayerAdapter: returns(layerAdapter),
                 getLayerState: returns(layerState)
             };
 
@@ -31,7 +35,7 @@ describe('Portal.details.NcWmsScaleRangeControls', function() {
 
         it('no param range', function() {
 
-            layerState.getScaleRange = returns({});
+            layerAdapter.getScaleRange = returns({});
 
             controls.loadScaleFromLayer();
             expect(controls.colourScaleMax.getValue()).toBeUndefined();
@@ -40,7 +44,7 @@ describe('Portal.details.NcWmsScaleRangeControls', function() {
 
         it('param range', function() {
 
-            layerState.getScaleRange = returns({
+            layerAdapter.getScaleRange = returns({
                 min: '2.3',
                 max: '6.7'
             });
@@ -54,7 +58,7 @@ describe('Portal.details.NcWmsScaleRangeControls', function() {
             controls.colourScaleMin.setValue('2');
             controls.colourScaleMax.setValue('5');
 
-            layerState.getScaleRange = returns({});
+            layerAdapter.getScaleRange = returns({});
 
             controls.loadScaleFromLayer();
             expect(controls.colourScaleMax.getValue()).toBeUndefined();

--- a/src/test/javascript/portal/details/NcwmsScaleRangeControlsSpec.js
+++ b/src/test/javascript/portal/details/NcwmsScaleRangeControlsSpec.js
@@ -9,7 +9,7 @@ describe('Portal.details.NcWmsScaleRangeControls', function() {
 
         var controls;
         var layerAdapter;
-        var layerState;
+        var layerSelectionModel;
         var dataCollection;
 
         beforeEach(function() {
@@ -17,13 +17,13 @@ describe('Portal.details.NcWmsScaleRangeControls', function() {
             layerAdapter = {
                 getScaleRange: returns({})
             };
-            layerState = {
+            layerSelectionModel = {
                 on: noOp
             };
 
             dataCollection = {
                 getLayerAdapter: returns(layerAdapter),
-                getLayerState: returns(layerState)
+                getLayerSelectionModel: returns(layerSelectionModel)
             };
 
             controls = new Portal.details.NcWmsScaleRangeControls({

--- a/src/test/javascript/portal/details/StylePanelSpec.js
+++ b/src/test/javascript/portal/details/StylePanelSpec.js
@@ -25,16 +25,21 @@ describe("Portal.details.StylePanel", function() {
 
     var stylePanel;
     var dataCollection;
+    var layerAdapter;
     var layerState;
 
     beforeEach(function() {
-        layerState = {
-            on: noOp,
-            getScaleRange: returns({}),
+        layerAdapter = {
             setStyle: jasmine.createSpy('setStyle')
         };
 
+        layerState = {
+            on: noOp,
+            getScaleRange: returns({})
+        };
+
         dataCollection = {
+            getLayerAdapter: returns(layerAdapter),
             getLayerState: returns(layerState),
             getTitle: returns('Data Collection Title')
         };
@@ -61,7 +66,7 @@ describe("Portal.details.StylePanel", function() {
 
         it('sets style and refreshes legend', function() {
             expect(stylePanel.refreshLegend).toHaveBeenCalled();
-            expect(layerState.setStyle).toHaveBeenCalledWith('pink swirls');
+            expect(layerAdapter.setStyle).toHaveBeenCalledWith('pink swirls');
         });
 
         it('tracks action to google analytics', function() {

--- a/src/test/javascript/portal/details/StylePanelSpec.js
+++ b/src/test/javascript/portal/details/StylePanelSpec.js
@@ -26,21 +26,21 @@ describe("Portal.details.StylePanel", function() {
     var stylePanel;
     var dataCollection;
     var layerAdapter;
-    var layerState;
+    var layerSelectionModel;
 
     beforeEach(function() {
         layerAdapter = {
             setStyle: jasmine.createSpy('setStyle')
         };
 
-        layerState = {
+        layerSelectionModel = {
             on: noOp,
             getScaleRange: returns({})
         };
 
         dataCollection = {
             getLayerAdapter: returns(layerAdapter),
-            getLayerState: returns(layerState),
+            getLayerSelectionModel: returns(layerSelectionModel),
             getTitle: returns('Data Collection Title')
         };
 
@@ -146,7 +146,7 @@ describe("Portal.details.StylePanel", function() {
 
         it("Returns empty array if layer.styles is undefined", function() {
 
-            dataCollection.getLayerState = returns({
+            dataCollection.getLayerSelectionModel = returns({
                 getSelectedLayer: returns({styles: undefined})
             });
 
@@ -161,7 +161,7 @@ describe("Portal.details.StylePanel", function() {
                 return String.format('{0} {1} {2} {3}', a, b, c, d);
             };
 
-            dataCollection.getLayerState = returns({
+            dataCollection.getLayerSelectionModel = returns({
                 getSelectedLayer: returns({
                     isNcwms: returns(true),
                     styles: [

--- a/src/test/javascript/portal/filter/FilterServiceSpec.js
+++ b/src/test/javascript/portal/filter/FilterServiceSpec.js
@@ -19,7 +19,7 @@ describe("Portal.filter.FilterService", function() {
         failureCallback = jasmine.createSpy('failureCallback');
         callbackScope = {};
         testDataCollection = {
-            getLayerState: returns({
+            getLayerSelectionModel: returns({
                 getSelectedLayer: returns({server: {}})
             }),
             setFilters: noOp,

--- a/src/test/javascript/portal/filter/ui/BooleanFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/BooleanFilterPanelSpec.js
@@ -27,7 +27,7 @@ describe("Portal.filter.ui.BooleanFilterPanel", function() {
             },
             dataCollection: {
                 getTitle: returns('Collection title'),
-                getLayerState: returns({
+                getLayerSelectionModel: returns({
                     getSelectedLayer: returns({
                         name: 'test layer',
                         getDownloadCql: returns("")

--- a/src/test/javascript/portal/filter/ui/ComboFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/ComboFilterPanelSpec.js
@@ -26,7 +26,7 @@ describe("Portal.filter.ui.ComboFilterPanel", function() {
             },
             dataCollection: {
                 getTitle: returns('Collection title'),
-                getLayerState: returns({
+                getLayerSelectionModel: returns({
                     getSelectedLayer: returns({
                         name: 'test layer',
                         getDownloadCql: returns("")

--- a/src/test/javascript/portal/filter/ui/DateFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/DateFilterPanelSpec.js
@@ -25,7 +25,7 @@ describe("Portal.filter.ui.DateFilterPanel", function() {
             },
             dataCollection: {
                 getTitle: returns('Collection title'),
-                getLayerState: returns({
+                getLayerSelectionModel: returns({
                     getSelectedLayer: returns({
                         name: 'layerName',
                         getDownloadCql: returns("")

--- a/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
@@ -19,7 +19,7 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
 
         filterGroupPanel = new Portal.filter.ui.FilterGroupPanel({
             dataCollection: {
-                getLayerState: returns({
+                getLayerSelectionModel: returns({
                     getSelectedLayer: returns(layer)
                 }),
                 getFiltersRequestParams: noOp

--- a/src/test/javascript/portal/filter/ui/NumberFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/NumberFilterPanelSpec.js
@@ -33,7 +33,7 @@ describe("Portal.filter.ui.NumberFilterPanel", function() {
             },
             dataCollection: {
                 getTitle: returns('Collection title'),
-                getLayerState: returns({
+                getLayerSelectionModel: returns({
                     getSelectedLayer: returns({
                         name: 'test layer'
                     })

--- a/web-app/js/portal/cart/WfsDownloadHandler.js
+++ b/web-app/js/portal/cart/WfsDownloadHandler.js
@@ -41,7 +41,7 @@ Portal.cart.WfsDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
                 collection.getFilters(),
                 _this._resourceHref(),
                 _this._resourceName(),
-                collection.getLayerState().getSelectedLayer().getCsvDownloadFormat()
+                collection.getLayerSelectionModel().getSelectedLayer().getCsvDownloadFormat()
             );
         };
     }

--- a/web-app/js/portal/common/LayerOpacitySliderFixed.js
+++ b/web-app/js/portal/common/LayerOpacitySliderFixed.js
@@ -54,7 +54,7 @@ Portal.common.LayerOpacitySliderFixed = Ext.extend(GeoExt.LayerOpacitySlider, {
 
     getLayer: function(layer) {
         // Superclass is expecting either a OpenLayer.Layer or a GeoExt.data.LayerRecord,
-        // but we're using a DataCollectionLayers object masquerading as a Layer (for now).
+        // but we're using a LayerSelectionModel object masquerading as a Layer (for now).
         return layer;
     }
 });

--- a/web-app/js/portal/data/DataCollection.js
+++ b/web-app/js/portal/data/DataCollection.js
@@ -68,7 +68,7 @@ Portal.data.DataCollection = function() {
     };
 
     constructor.prototype.getFiltersRequestParams = function() {
-        var layer = this.getLayerState().getSelectedLayer();
+        var layer = this.getLayerSelectionModel().getSelectedLayer();
         var layerName = this.getDownloadLayerName();
 
         return {
@@ -85,7 +85,7 @@ Portal.data.DataCollection = function() {
     constructor.prototype.updateFilters = function() {
 
         // Update layer with new values
-        var layer = this.getLayerState().getSelectedLayer();
+        var layer = this.getLayerSelectionModel().getSelectedLayer();
 
         if (layer.updateCqlFilter) {
             layer.updateCqlFilter(this.getFilters());
@@ -136,20 +136,20 @@ Portal.data.DataCollection = function() {
         }
     };
 
-    constructor.prototype.getLayerState = function() {
-        if (!this.layerState) {
-            this.layerState = new Portal.data.DataCollectionLayers({
+    constructor.prototype.getLayerSelectionModel = function() {
+        if (!this.layerSelectionModel) {
+            this.layerSelectionModel = new Portal.data.LayerSelectionModel({
                 dataCollection: this
             });
         }
 
-        return this.layerState;
+        return this.layerSelectionModel;
     };
 
     constructor.prototype.getLayerAdapter = function() {
         if (!this.layerAdapter) {
             this.layerAdapter = new Portal.data.DataCollectionLayerAdapter({
-                layerState: this.getLayerState()
+                layerSelectionModel: this.getLayerSelectionModel()
             });
         }
 
@@ -157,7 +157,7 @@ Portal.data.DataCollection = function() {
     };
 
     constructor.prototype.isNcwms = function() {
-        return this.getLayerState().isNcwms();
+        return this.getLayerSelectionModel().isNcwms();
     };
 
     return constructor;

--- a/web-app/js/portal/data/DataCollection.js
+++ b/web-app/js/portal/data/DataCollection.js
@@ -146,6 +146,16 @@ Portal.data.DataCollection = function() {
         return this.layerState;
     };
 
+    constructor.prototype.getLayerAdapter = function() {
+        if (!this.layerAdapter) {
+            this.layerAdapter = new Portal.data.DataCollectionLayerAdapter({
+                layerState: this.getLayerState()
+            });
+        }
+
+        return this.layerAdapter;
+    };
+
     constructor.prototype.isNcwms = function() {
         return this.getLayerState().isNcwms();
     };

--- a/web-app/js/portal/data/DataCollectionLayerAdapter.js
+++ b/web-app/js/portal/data/DataCollectionLayerAdapter.js
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2015 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+
+Ext.namespace('Portal.data');
+
+//
+// This class implements various OpenLayers.Layer functions using a DataCollection (and its associated layers).
+// It allows client code to essentially treat a DataCollection as it would a Layer, without having to use code
+// such as:
+//
+//    dataCollection.getLayerState().getSelectedLayer()...
+//
+// all over the place.
+//
+Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
+
+    constructor: function(config) {
+        Ext.apply(this, config);
+
+        // TODO: rename - conflicts with `LayerState` class.
+        this._layerState = {};
+
+        this._copyAttributesFromSelectedLayer();
+        this.layerState.on('selectedlayerchanged', function(newlayer) {
+            console.log('copyAttrs');
+            this._copyAttributesFromSelectedLayer();
+        }, this);
+
+        Portal.data.DataCollectionLayers.superclass.constructor.call(this, config);
+    },
+
+    getSelectedLayer: function() {
+        return this.layerState.getSelectedLayer();
+    },
+
+    _eachLayer: function(fn, scope) {
+        this.layerState._eachLayer(fn, scope);
+    },
+
+    isLoading: function() {
+        return this.getSelectedLayer().loading;
+    },
+
+    _setLayerProperty: function(key, value) {
+        this._layerProperties()[key] = value;
+    },
+
+    _getLayerProperty: function(key) {
+        return this._layerProperties()[key];
+    },
+
+    _layerProperties: function() {
+
+        var layer = this.getSelectedLayer();
+        var key = layer.id;
+
+        if (!this._layerState) {
+            this._layerState = {};
+        }
+
+        if (this._layerState[key] == undefined) {
+            this._layerState[key] = {};
+        }
+
+        return this._layerState[key];
+    },
+
+    _copyAttributesFromSelectedLayer: function() {
+        Ext.each([
+            'bboxMaxX',
+            'bboxMaxY',
+            'bboxMinX',
+            'bboxMinY',
+            'opacity',
+            'projection'
+        ], function(attr) {
+            this[attr] = this.getSelectedLayer()[attr];
+        }, this);
+    },
+
+    _is130: function() {
+        return this.getSelectedLayer()._is130();
+    },
+
+    setOpacity: function(opacity) {
+        this._eachLayer(function(layer) {
+            layer.setOpacity(opacity);
+        });
+    },
+
+    setVisibility: function(visible) {
+        this._eachLayer(function(layer) {
+            layer.setVisibility(visible);
+        });
+    },
+
+    hasBoundingBox: function() {
+        return this.getSelectedLayer().hasBoundingBox();
+    },
+
+    setScaleRange: function(min, max) {
+
+        var layer = this.getSelectedLayer();
+
+        this._setLayerProperty('scaleRange', {
+            min: min,
+            max: max
+        });
+
+        layer.mergeNewParams({
+            COLORSCALERANGE: min + "," + max
+        });
+    },
+
+    getScaleRange: function() {
+        return this._getLayerProperty('scaleRange') || {};
+    },
+
+    setStyle: function(style) {
+        this._setLayerProperty('style', style);
+
+        this.getSelectedLayer().mergeNewParams({
+            styles: style
+        });
+    },
+
+    getStyle: function() {
+        return this._getLayerProperty('style') || this.getSelectedLayer().defaultStyle;
+    }
+});

--- a/web-app/js/portal/data/DataCollectionLayerAdapter.js
+++ b/web-app/js/portal/data/DataCollectionLayerAdapter.js
@@ -23,10 +23,14 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
 
         this._layerProperties = {};
 
-        this._onSelectedLayerChanged(this.getSelectedLayer());
+        this._onSelectedLayerChanged(this._getSelectedLayer());
         this.layerState.on('selectedlayerchanged', this._onSelectedLayerChanged, this);
 
         Portal.data.DataCollectionLayers.superclass.constructor.call(this, config);
+    },
+
+    _getSelectedLayer: function() {
+        return this.layerState.getSelectedLayer();
     },
 
     _onSelectedLayerChanged: function(newLayer, oldLayer) {
@@ -40,7 +44,7 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
     },
 
     _onLayerEvent: function(eventName) {
-        this.fireEvent(eventName, this.getSelectedLayer());
+        this.fireEvent(eventName, this._getSelectedLayer());
     },
 
     _onLayerLoadStart: function() {
@@ -53,10 +57,6 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
 
     _onLayerTileError: function() {
         this._onLayerEvent('tileerror');
-    },
-
-    getSelectedLayer: function() {
-        return this.layerState.getSelectedLayer();
     },
 
     _eachLayer: function(fn, scope) {
@@ -83,7 +83,7 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
     },
 
     isLoading: function() {
-        return this.getSelectedLayer().loading;
+        return this._getSelectedLayer().loading;
     },
 
     _setLayerProperty: function(key, value) {
@@ -96,7 +96,7 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
 
     _getLayerProperties: function() {
 
-        var layer = this.getSelectedLayer();
+        var layer = this._getSelectedLayer();
         var key = layer.id;
 
         if (!this._layerProperties) {
@@ -119,12 +119,12 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
             'opacity',
             'projection'
         ], function(attr) {
-            this[attr] = this.getSelectedLayer()[attr];
+            this[attr] = this._getSelectedLayer()[attr];
         }, this);
     },
 
     _is130: function() {
-        return this.getSelectedLayer()._is130();
+        return this._getSelectedLayer()._is130();
     },
 
     setOpacity: function(opacity) {
@@ -140,12 +140,12 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
     },
 
     hasBoundingBox: function() {
-        return this.getSelectedLayer().hasBoundingBox();
+        return this._getSelectedLayer().hasBoundingBox();
     },
 
     setScaleRange: function(min, max) {
 
-        var layer = this.getSelectedLayer();
+        var layer = this._getSelectedLayer();
 
         this._setLayerProperty('scaleRange', {
             min: min,
@@ -164,12 +164,12 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
     setStyle: function(style) {
         this._setLayerProperty('style', style);
 
-        this.getSelectedLayer().mergeNewParams({
+        this._getSelectedLayer().mergeNewParams({
             styles: style
         });
     },
 
     getStyle: function() {
-        return this._getLayerProperty('style') || this.getSelectedLayer().defaultStyle;
+        return this._getLayerProperty('style') || this._getSelectedLayer().defaultStyle;
     }
 });

--- a/web-app/js/portal/data/DataCollectionLayerAdapter.js
+++ b/web-app/js/portal/data/DataCollectionLayerAdapter.js
@@ -12,7 +12,7 @@ Ext.namespace('Portal.data');
 // It allows client code to essentially treat a DataCollection as it would a Layer, without having to use code
 // such as:
 //
-//    dataCollection.getLayerState().getSelectedLayer()...
+//    dataCollection.getLayerSelectionModel().getSelectedLayer()...
 //
 // all over the place.
 //
@@ -24,13 +24,13 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
         this._layerProperties = {};
 
         this._onSelectedLayerChanged(this._getSelectedLayer());
-        this.layerState.on('selectedlayerchanged', this._onSelectedLayerChanged, this);
+        this.layerSelectionModel.on('selectedlayerchanged', this._onSelectedLayerChanged, this);
 
-        Portal.data.DataCollectionLayers.superclass.constructor.call(this, config);
+        Portal.data.LayerSelectionModel.superclass.constructor.call(this, config);
     },
 
     _getSelectedLayer: function() {
-        return this.layerState.getSelectedLayer();
+        return this.layerSelectionModel.getSelectedLayer();
     },
 
     _onSelectedLayerChanged: function(newLayer, oldLayer) {
@@ -60,7 +60,7 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
     },
 
     _eachLayer: function(fn, scope) {
-        this.layerState._eachLayer(fn, scope);
+        this.layerSelectionModel._eachLayer(fn, scope);
     },
 
     _registerLayerEventListeners: function(layer) {

--- a/web-app/js/portal/data/DataCollectionLayerAdapter.js
+++ b/web-app/js/portal/data/DataCollectionLayerAdapter.js
@@ -24,8 +24,7 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
         this._layerProperties = {};
 
         this._copyAttributesFromSelectedLayer();
-        this.layerState.on('selectedlayerchanged', function(newlayer) {
-            console.log('copyAttrs');
+        this.layerState.on('selectedlayerchanged', function() {
             this._copyAttributesFromSelectedLayer();
         }, this);
 

--- a/web-app/js/portal/data/DataCollectionLayerAdapter.js
+++ b/web-app/js/portal/data/DataCollectionLayerAdapter.js
@@ -21,8 +21,7 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
     constructor: function(config) {
         Ext.apply(this, config);
 
-        // TODO: rename - conflicts with `LayerState` class.
-        this._layerState = {};
+        this._layerProperties = {};
 
         this._copyAttributesFromSelectedLayer();
         this.layerState.on('selectedlayerchanged', function(newlayer) {
@@ -46,27 +45,27 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
     },
 
     _setLayerProperty: function(key, value) {
-        this._layerProperties()[key] = value;
+        this._getLayerProperties()[key] = value;
     },
 
     _getLayerProperty: function(key) {
-        return this._layerProperties()[key];
+        return this._getLayerProperties()[key];
     },
 
-    _layerProperties: function() {
+    _getLayerProperties: function() {
 
         var layer = this.getSelectedLayer();
         var key = layer.id;
 
-        if (!this._layerState) {
-            this._layerState = {};
+        if (!this._layerProperties) {
+            this._layerProperties = {};
         }
 
-        if (this._layerState[key] == undefined) {
-            this._layerState[key] = {};
+        if (this._layerProperties[key] == undefined) {
+            this._layerProperties[key] = {};
         }
 
-        return this._layerState[key];
+        return this._layerProperties[key];
     },
 
     _copyAttributesFromSelectedLayer: function() {

--- a/web-app/js/portal/data/DataCollectionLayers.js
+++ b/web-app/js/portal/data/DataCollectionLayers.js
@@ -13,7 +13,7 @@ Portal.data.DataCollectionLayers = Ext.extend(Ext.util.Observable, {
         Ext.apply(this, config);
         this._initLayers();
 
-        this._layerState = {};
+        // this._layerState = {};
 
         Portal.data.DataCollectionLayers.superclass.constructor.call(this, config);
     },
@@ -48,35 +48,33 @@ Portal.data.DataCollectionLayers = Ext.extend(Ext.util.Observable, {
         var oldLayer = this.selectedLayer;
         this.selectedLayer = newLayer;
 
-        this._copyAttributesFromSelectedLayer();
-
         this._registerLayerEventListeners();
         this.fireEvent('selectedlayerchanged', this.selectedLayer, oldLayer);
     },
 
-    isLoading: function() {
-        return this.getSelectedLayer().loading;
-    },
+    // isLoading: function() {
+    //     return this.getSelectedLayer().loading;
+    // },
 
-    _setLayerProperty: function(key, value) {
-        this._layerProperties()[key] = value;
-    },
+    // _setLayerProperty: function(key, value) {
+    //     this._layerProperties()[key] = value;
+    // },
 
-    _getLayerProperty: function(key) {
-        return this._layerProperties()[key];
-    },
+    // _getLayerProperty: function(key) {
+    //     return this._layerProperties()[key];
+    // },
 
-    _layerProperties: function() {
+    // _layerProperties: function() {
 
-        var layer = this.getSelectedLayer();
-        var key = layer.id;
+    //     var layer = this.getSelectedLayer();
+    //     var key = layer.id;
 
-        if (this._layerState[key] == undefined) {
-            this._layerState[key] = {};
-        }
+    //     if (this._layerState[key] == undefined) {
+    //         this._layerState[key] = {};
+    //     }
 
-        return this._layerState[key];
-    },
+    //     return this._layerState[key];
+    // },
 
     _registerLayerEventListeners: function() {
         this._updateLayerEventListeners('on');
@@ -144,71 +142,71 @@ Portal.data.DataCollectionLayers = Ext.extend(Ext.util.Observable, {
         return layerDescriptor.toOpenLayer();
     },
 
-    //
-    // TODO: Following functions to be replaced by `LayerGroup`?
-    //
-    _copyAttributesFromSelectedLayer: function() {
-        Ext.each([
-            'bboxMaxX',
-            'bboxMaxY',
-            'bboxMinX',
-            'bboxMinY',
-            'opacity',
-            'projection'
-        ], function(attr) {
-            this[attr] = this.getSelectedLayer()[attr];
-        }, this);
-    },
+    // //
+    // // TODO: Following functions to be replaced by `LayerGroup`?
+    // //
+    // _copyAttributesFromSelectedLayer: function() {
+    //     Ext.each([
+    //         'bboxMaxX',
+    //         'bboxMaxY',
+    //         'bboxMinX',
+    //         'bboxMinY',
+    //         'opacity',
+    //         'projection'
+    //     ], function(attr) {
+    //         this[attr] = this.getSelectedLayer()[attr];
+    //     }, this);
+    // },
 
-    _is130: function() {
-        return this.getSelectedLayer()._is130();
-    },
+    // _is130: function() {
+    //     return this.getSelectedLayer()._is130();
+    // },
 
-    setOpacity: function(opacity) {
-        this._eachLayer(function(layer) {
-            layer.setOpacity(opacity);
-        });
-    },
+    // setOpacity: function(opacity) {
+    //     this._eachLayer(function(layer) {
+    //         layer.setOpacity(opacity);
+    //     });
+    // },
 
-    setVisibility: function(visible) {
-        this._eachLayer(function(layer) {
-            layer.setVisibility(visible);
-        });
-    },
+    // setVisibility: function(visible) {
+    //     this._eachLayer(function(layer) {
+    //         layer.setVisibility(visible);
+    //     });
+    // },
 
-    hasBoundingBox: function() {
-        return this.getSelectedLayer().hasBoundingBox();
-    },
+    // hasBoundingBox: function() {
+    //     return this.getSelectedLayer().hasBoundingBox();
+    // },
 
-    setScaleRange: function(min, max) {
+    // setScaleRange: function(min, max) {
 
-        var layer = this.getSelectedLayer();
+    //     var layer = this.getSelectedLayer();
 
-        this._setLayerProperty('scaleRange', {
-            min: min,
-            max: max
-        });
+    //     this._setLayerProperty('scaleRange', {
+    //         min: min,
+    //         max: max
+    //     });
 
-        layer.mergeNewParams({
-            COLORSCALERANGE: min + "," + max
-        });
-    },
+    //     layer.mergeNewParams({
+    //         COLORSCALERANGE: min + "," + max
+    //     });
+    // },
 
-    getScaleRange: function() {
-        return this._getLayerProperty('scaleRange') || {};
-    },
+    // getScaleRange: function() {
+    //     return this._getLayerProperty('scaleRange') || {};
+    // },
 
-    setStyle: function(style) {
+    // setStyle: function(style) {
 
-        this._setLayerProperty('style', style);
+    //     this._setLayerProperty('style', style);
 
-        this.getSelectedLayer().mergeNewParams({
-            styles: style
-        });
-    },
+    //     this.getSelectedLayer().mergeNewParams({
+    //         styles: style
+    //     });
+    // },
 
-    getStyle: function() {
+    // getStyle: function() {
 
-        return this._getLayerProperty('style') || this.getSelectedLayer().defaultStyle;
-    }
+    //     return this._getLayerProperty('style') || this.getSelectedLayer().defaultStyle;
+    // }
 });

--- a/web-app/js/portal/data/DataCollectionLayers.js
+++ b/web-app/js/portal/data/DataCollectionLayers.js
@@ -13,8 +13,6 @@ Portal.data.DataCollectionLayers = Ext.extend(Ext.util.Observable, {
         Ext.apply(this, config);
         this._initLayers();
 
-        // this._layerState = {};
-
         Portal.data.DataCollectionLayers.superclass.constructor.call(this, config);
     },
 
@@ -51,30 +49,6 @@ Portal.data.DataCollectionLayers = Ext.extend(Ext.util.Observable, {
         this._registerLayerEventListeners();
         this.fireEvent('selectedlayerchanged', this.selectedLayer, oldLayer);
     },
-
-    // isLoading: function() {
-    //     return this.getSelectedLayer().loading;
-    // },
-
-    // _setLayerProperty: function(key, value) {
-    //     this._layerProperties()[key] = value;
-    // },
-
-    // _getLayerProperty: function(key) {
-    //     return this._layerProperties()[key];
-    // },
-
-    // _layerProperties: function() {
-
-    //     var layer = this.getSelectedLayer();
-    //     var key = layer.id;
-
-    //     if (this._layerState[key] == undefined) {
-    //         this._layerState[key] = {};
-    //     }
-
-    //     return this._layerState[key];
-    // },
 
     _registerLayerEventListeners: function() {
         this._updateLayerEventListeners('on');
@@ -140,73 +114,5 @@ Portal.data.DataCollectionLayers = Ext.extend(Ext.util.Observable, {
         );
 
         return layerDescriptor.toOpenLayer();
-    },
-
-    // //
-    // // TODO: Following functions to be replaced by `LayerGroup`?
-    // //
-    // _copyAttributesFromSelectedLayer: function() {
-    //     Ext.each([
-    //         'bboxMaxX',
-    //         'bboxMaxY',
-    //         'bboxMinX',
-    //         'bboxMinY',
-    //         'opacity',
-    //         'projection'
-    //     ], function(attr) {
-    //         this[attr] = this.getSelectedLayer()[attr];
-    //     }, this);
-    // },
-
-    // _is130: function() {
-    //     return this.getSelectedLayer()._is130();
-    // },
-
-    // setOpacity: function(opacity) {
-    //     this._eachLayer(function(layer) {
-    //         layer.setOpacity(opacity);
-    //     });
-    // },
-
-    // setVisibility: function(visible) {
-    //     this._eachLayer(function(layer) {
-    //         layer.setVisibility(visible);
-    //     });
-    // },
-
-    // hasBoundingBox: function() {
-    //     return this.getSelectedLayer().hasBoundingBox();
-    // },
-
-    // setScaleRange: function(min, max) {
-
-    //     var layer = this.getSelectedLayer();
-
-    //     this._setLayerProperty('scaleRange', {
-    //         min: min,
-    //         max: max
-    //     });
-
-    //     layer.mergeNewParams({
-    //         COLORSCALERANGE: min + "," + max
-    //     });
-    // },
-
-    // getScaleRange: function() {
-    //     return this._getLayerProperty('scaleRange') || {};
-    // },
-
-    // setStyle: function(style) {
-
-    //     this._setLayerProperty('style', style);
-
-    //     this.getSelectedLayer().mergeNewParams({
-    //         styles: style
-    //     });
-    // },
-
-    // getStyle: function() {
-
-    //     return this._getLayerProperty('style') || this.getSelectedLayer().defaultStyle;
-    // }
+    }
 });

--- a/web-app/js/portal/data/DataCollectionLayers.js
+++ b/web-app/js/portal/data/DataCollectionLayers.js
@@ -41,48 +41,9 @@ Portal.data.DataCollectionLayers = Ext.extend(Ext.util.Observable, {
     },
 
     setSelectedLayer: function(newLayer) {
-        this._unregisterLayerEventListeners();
-
         var oldLayer = this.selectedLayer;
         this.selectedLayer = newLayer;
-
-        this._registerLayerEventListeners();
         this.fireEvent('selectedlayerchanged', this.selectedLayer, oldLayer);
-    },
-
-    _registerLayerEventListeners: function() {
-        this._updateLayerEventListeners('on');
-    },
-
-    _unregisterLayerEventListeners: function() {
-        this._updateLayerEventListeners('un');
-    },
-
-    _updateLayerEventListeners: function(fn) {
-        if (this.selectedLayer) {
-            this.selectedLayer.events[fn]({
-                'loadstart': this._onLayerLoadStart,
-                'loadend': this._onLayerLoadEnd,
-                'tileerror': this._onLayerTileError,
-                scope: this
-            });
-        }
-    },
-
-    _onLayerEvent: function(eventName) {
-        this.fireEvent(eventName, this.selectedLayer);
-    },
-
-    _onLayerLoadStart: function() {
-        this._onLayerEvent('loadstart');
-    },
-
-    _onLayerLoadEnd: function() {
-        this._onLayerEvent('loadend');
-    },
-
-    _onLayerTileError: function() {
-        this._onLayerEvent('tileerror');
     },
 
     _initLayers: function() {

--- a/web-app/js/portal/data/DataCollectionStore.js
+++ b/web-app/js/portal/data/DataCollectionStore.js
@@ -53,16 +53,16 @@ Portal.data.DataCollectionStore = Ext.extend(Ext.data.Store, {
         var _this = this;
 
         Ext.each(dataCollections, function(dataCollection) {
-            var layerState = dataCollection.getLayerState();
+            var layerSelectionModel = dataCollection.getLayerSelectionModel();
 
             this.layerStore.addUsingOpenLayer(
-                layerState.getSelectedLayer(),
+                layerSelectionModel.getSelectedLayer(),
                 function(layerRecord) {
                     _this._recordLoaded(dataCollection);
                 }
             );
 
-            layerState.on('selectedlayerchanged', function(newLayer, oldLayer) {
+            layerSelectionModel.on('selectedlayerchanged', function(newLayer, oldLayer) {
                 if (oldLayer) {
                     this.layerStore.removeUsingOpenLayer(oldLayer);
                 }
@@ -91,6 +91,6 @@ Portal.data.DataCollectionStore = Ext.extend(Ext.data.Store, {
     },
 
     _removeFromLayerStore: function(dataCollection) {
-        this.layerStore.removeUsingOpenLayer(dataCollection.getLayerState().getSelectedLayer());
+        this.layerStore.removeUsingOpenLayer(dataCollection.getLayerSelectionModel().getSelectedLayer());
     }
 });

--- a/web-app/js/portal/data/LayerSelectionModel.js
+++ b/web-app/js/portal/data/LayerSelectionModel.js
@@ -7,13 +7,13 @@
 
 Ext.namespace('Portal.data');
 
-Portal.data.DataCollectionLayers = Ext.extend(Ext.util.Observable, {
+Portal.data.LayerSelectionModel = Ext.extend(Ext.util.Observable, {
 
     constructor: function(config) {
         Ext.apply(this, config);
         this._initLayers();
 
-        Portal.data.DataCollectionLayers.superclass.constructor.call(this, config);
+        Portal.data.LayerSelectionModel.superclass.constructor.call(this, config);
     },
 
     isNcwms: function() {

--- a/web-app/js/portal/data/LayerStore.js
+++ b/web-app/js/portal/data/LayerStore.js
@@ -26,7 +26,7 @@ Portal.data.LayerStore = Ext.extend(GeoExt.data.LayerStore, {
     },
 
     _linkToOpenLayer: function(layerLink, dataCollection) {
-        return Portal.data.DataCollectionLayers.prototype._linkToOpenLayer(layerLink, dataCollection);
+        return Portal.data.LayerSelectionModel.prototype._linkToOpenLayer(layerLink, dataCollection);
     },
 
     _addUsingDescriptor: function(layerDescriptor, layerRecordCallback) {
@@ -103,7 +103,7 @@ Portal.data.LayerStore = Ext.extend(GeoExt.data.LayerStore, {
     },
 
     _onDataCollectionChanged: function(eventName, dataCollection) {
-        this._selectedLayerChanged(eventName, dataCollection.getLayerState().getSelectedLayer());
+        this._selectedLayerChanged(eventName, dataCollection.getLayerSelectionModel().getSelectedLayer());
     },
 
     _selectedLayerChanged: function(eventName, openLayer) {

--- a/web-app/js/portal/details/DataCollectionDetailsPanel.js
+++ b/web-app/js/portal/details/DataCollectionDetailsPanel.js
@@ -13,17 +13,19 @@ Portal.details.DataCollectionDetailsPanel = Ext.extend(Ext.Panel, {
 
         var tabPanelForLayer = this._initSubsetItemsTabPanel(cfg);
 
-        this.createTools(cfg.dataCollection.getLayerAdapter());
+        var layerAdapter = cfg.dataCollection.getLayerAdapter();
 
-        cfg.dataCollection.getLayerState().on('loadstart', function() {
+        this.createTools(layerAdapter);
+
+        layerAdapter.on('loadstart', function() {
             this._onLayerLoadStart();
         }, this);
 
-        cfg.dataCollection.getLayerState().on('loadend', function() {
+        layerAdapter.on('loadend', function() {
             this._onLayerLoadEnd();
         }, this);
 
-        cfg.dataCollection.getLayerState().on('tileerror', function() {
+        layerAdapter.on('tileerror', function() {
             this._onLayerLoadError();
         }, this);
 

--- a/web-app/js/portal/details/DataCollectionDetailsPanel.js
+++ b/web-app/js/portal/details/DataCollectionDetailsPanel.js
@@ -13,7 +13,7 @@ Portal.details.DataCollectionDetailsPanel = Ext.extend(Ext.Panel, {
 
         var tabPanelForLayer = this._initSubsetItemsTabPanel(cfg);
 
-        this.createTools(cfg.dataCollection.getLayerState());
+        this.createTools(cfg.dataCollection.getLayerAdapter());
 
         cfg.dataCollection.getLayerState().on('loadstart', function() {
             this._onLayerLoadStart();
@@ -90,7 +90,7 @@ Portal.details.DataCollectionDetailsPanel = Ext.extend(Ext.Panel, {
         });
     },
 
-    createTools: function(layerState) {
+    createTools: function(layer) {
 
         this.errorToolItem = {
             id: 'errorToolItem',
@@ -101,7 +101,7 @@ Portal.details.DataCollectionDetailsPanel = Ext.extend(Ext.Panel, {
         this.spinnerToolItem = {
             id: 'spinnerToolItem',
             styles: 'fa-spin fa-spinner',
-            hidden: !layerState.isLoading(),
+            hidden: !layer.isLoading(),
             title: OpenLayers.i18n('loadingMessage')
         };
         this.deleteToolItem = {

--- a/web-app/js/portal/details/LayerControlPanel.js
+++ b/web-app/js/portal/details/LayerControlPanel.js
@@ -73,16 +73,16 @@ Portal.details.LayerControlPanel = Ext.extend(Ext.Container, {
     },
 
     _newLayerSelectorComponent: function() {
-        if (this.dataCollection.getLayerState().getLayers().length <= 1) {
+        if (this.dataCollection.getLayerSelectionModel().getLayers().length <= 1) {
             return undefined;
         }
 
         var items = [];
-        Ext.each(this.dataCollection.getLayerState().getLayers(), function(openLayer) {
+        Ext.each(this.dataCollection.getLayerSelectionModel().getLayers(), function(openLayer) {
             items.push({
                 boxLabel: openLayer.wmsName,
                 name: 'selectedLayer',
-                checked: openLayer == this.dataCollection.getLayerState().getSelectedLayer(),
+                checked: openLayer == this.dataCollection.getLayerSelectionModel().getSelectedLayer(),
                 layer: openLayer
             });
         }, this);
@@ -98,7 +98,7 @@ Portal.details.LayerControlPanel = Ext.extend(Ext.Container, {
     },
 
     _radioGroupChanged: function(radioGroup, checkedRadio) {
-        this.dataCollection.getLayerState().setSelectedLayer(checkedRadio.layer);
+        this.dataCollection.getLayerSelectionModel().setSelectedLayer(checkedRadio.layer);
 
          trackLayerControlUsage(
              'changeLayerTrackingAction',

--- a/web-app/js/portal/details/LayerControlPanel.js
+++ b/web-app/js/portal/details/LayerControlPanel.js
@@ -12,7 +12,7 @@ Portal.details.LayerControlPanel = Ext.extend(Ext.Container, {
     initComponent: function() {
         this.items = [];
 
-        this.layer = this.dataCollection.getLayerState();
+        this.layer = this.dataCollection.getLayerAdapter();
 
         var layerSelector = this._newLayerSelectorComponent();
         if (layerSelector) {

--- a/web-app/js/portal/details/NcWmsPanel.js
+++ b/web-app/js/portal/details/NcWmsPanel.js
@@ -18,9 +18,9 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Container, {
 
         Ext.apply(this, cfg);
 
-        this.layer = this.dataCollection.getLayerState().getSelectedLayer();
+        this.layer = this.dataCollection.getLayerSelectionModel().getSelectedLayer();
 
-        this.dataCollection.getLayerState().on('selectedlayerchanged', function(newLayer) {
+        this.dataCollection.getLayerSelectionModel().on('selectedlayerchanged', function(newLayer) {
             this._onSelectedLayerChanged(newLayer);
         }, this);
 

--- a/web-app/js/portal/details/NcWmsScaleRangeControls.js
+++ b/web-app/js/portal/details/NcWmsScaleRangeControls.js
@@ -62,8 +62,8 @@ Portal.details.NcWmsScaleRangeControls = Ext.extend(Ext.Panel, {
 
     loadScaleFromLayer: function() {
 
-        var layerState = this.dataCollection.getLayerState();
-        var range = layerState.getScaleRange();
+        var layer = this.dataCollection.getLayerAdapter();
+        var range = layer.getScaleRange();
 
         this.colourScaleMin.setValue(range.min);
         this.colourScaleMax.setValue(range.max);
@@ -85,10 +85,10 @@ Portal.details.NcWmsScaleRangeControls = Ext.extend(Ext.Panel, {
 
         if (this._canSubmit()) {
 
-            var layerState = this.dataCollection.getLayerState();
+            var layer = this.dataCollection.getLayerAdapter();
             var min = this.colourScaleMin.getValue();
             var max = this.colourScaleMax.getValue();
-            layerState.setScaleRange(min, max);
+            layer.setScaleRange(min, max);
 
             this.fireEvent('colourScaleUpdated');
         }

--- a/web-app/js/portal/details/NcWmsScaleRangeControls.js
+++ b/web-app/js/portal/details/NcWmsScaleRangeControls.js
@@ -43,7 +43,7 @@ Portal.details.NcWmsScaleRangeControls = Ext.extend(Ext.Panel, {
         this.addEvents('colourScaleUpdated');
         Portal.details.NcWmsScaleRangeControls.superclass.initComponent.call(this);
 
-        this.dataCollection.getLayerState().on('selectedlayerchanged', this.loadScaleFromLayer, this);
+        this.dataCollection.getLayerSelectionModel().on('selectedlayerchanged', this.loadScaleFromLayer, this);
     },
 
     makeSmallIndentInputBox: function(fieldLabel) {

--- a/web-app/js/portal/details/StylePanel.js
+++ b/web-app/js/portal/details/StylePanel.js
@@ -134,7 +134,7 @@ Portal.details.StylePanel = Ext.extend(Ext.Container, {
 
     setChosenStyle: function(styleCombo, record) {
         var styleName = record.get('styleName');
-        this.dataCollection.getLayerState().setStyle(styleName);
+        this.dataCollection.getLayerAdapter().setStyle(styleName);
         this.refreshLegend();
 
         trackLayerControlUsage('layerControlTrackingActionStyle', styleName, this.dataCollection.getTitle());
@@ -142,7 +142,7 @@ Portal.details.StylePanel = Ext.extend(Ext.Container, {
 
     refreshLegend: function() {
 
-        var styleName = this.dataCollection.getLayerState().getStyle() || '';
+        var styleName = this.dataCollection.getLayerAdapter().getStyle() || '';
         var palette = this._getPalette(styleName);
 
         var layer = this.dataCollection.getLayerState().getSelectedLayer();

--- a/web-app/js/portal/details/StylePanel.js
+++ b/web-app/js/portal/details/StylePanel.js
@@ -26,7 +26,7 @@ Portal.details.StylePanel = Ext.extend(Ext.Container, {
 
         this._initWithLayer();
 
-        this.dataCollection.getLayerState().on('selectedlayerchanged', this._initWithLayer, this);
+        this.dataCollection.getLayerSelectionModel().on('selectedlayerchanged', this._initWithLayer, this);
     },
 
     _createControls: function() {
@@ -78,7 +78,7 @@ Portal.details.StylePanel = Ext.extend(Ext.Container, {
 
     _initWithLayer: function() {
 
-        var layer = this.dataCollection.getLayerState().getSelectedLayer();
+        var layer = this.dataCollection.getLayerSelectionModel().getSelectedLayer();
 
         if (layer.isNcwms()) {
             this.ncwmsScaleRangeControls.loadScaleFromLayer();
@@ -118,7 +118,7 @@ Portal.details.StylePanel = Ext.extend(Ext.Container, {
 
     _processStyleData: function() {
         var data = [];
-        var layer = this.dataCollection.getLayerState().getSelectedLayer();
+        var layer = this.dataCollection.getLayerSelectionModel().getSelectedLayer();
 
         Ext.each(layer.styles, function(style) {
 
@@ -145,7 +145,7 @@ Portal.details.StylePanel = Ext.extend(Ext.Container, {
         var styleName = this.dataCollection.getLayerAdapter().getStyle() || '';
         var palette = this._getPalette(styleName);
 
-        var layer = this.dataCollection.getLayerState().getSelectedLayer();
+        var layer = this.dataCollection.getLayerSelectionModel().getSelectedLayer();
         var url = this.buildGetLegend(layer, styleName, palette, false);
 
         this.legendImage.setUrl(url);

--- a/web-app/js/portal/filter/FilterService.js
+++ b/web-app/js/portal/filter/FilterService.js
@@ -72,7 +72,7 @@ Portal.filter.FilterService = Ext.extend(Object, {
 
     loadFilterRange: function(filterId, dataCollection, successCallback, failureCallback, callbackScope) {
 
-        var layer = dataCollection.getLayerState().getSelectedLayer();
+        var layer = dataCollection.getLayerSelectionModel().getSelectedLayer();
 
         var params = {
             filter: filterId,


### PR DESCRIPTION
This class can be used when we want a data collection to behave somewhat like a single layer (in terms of getting and setting certain attributes, like opacity, for example).