### PR TITLE
lengthen timeout for collapsing panels- accordion layout

### DIFF
--- a/web-app/js/portal/prototypes/NonCollapsingAccordionLayout.js
+++ b/web-app/js/portal/prototypes/NonCollapsingAccordionLayout.js
@@ -36,7 +36,7 @@ Ext.ux.NonCollapsingAccordionLayout = Ext.extend(Ext.layout.Accordion, {
             // fixes #1823
             setTimeout(function() {
                 panelToCollapse.collapse();
-            }, 400);
+            }, 800);
         }
         else {
             panelToCollapse.collapse();


### PR DESCRIPTION
Increasing the timeout on requesting collapse for panels which should be closed but still have the property collapsed set to true as the Ext expand animation still executes.
Tested on my own machine and demonstrated the bug with a timeout of 400ms. 
800ms seems to fix the bug without any adverse side affects at the moment. There may be times when this isn't enough, but given the now fairly extreme measures required to create the bug I think we could stop here?
Fixes #1823 