### PR TITLE
Remove get_____Links from DataCollection

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -271,6 +271,10 @@ portal {
             "WWW:DOWNLOAD-1.0-http--downloaddata",
             "WWW:LINK-1.0-http--downloaddata"
         ]
+
+        metadataRecord = [
+            "WWW:LINK-1.0-http--metadata-URL"
+        ]
     }
 
     mapGetFeatureInfoBuffer = 10

--- a/src/test/javascript/portal/cart/BaseInjectorSpec.js
+++ b/src/test/javascript/portal/cart/BaseInjectorSpec.js
@@ -11,25 +11,29 @@ describe('Portal.cart.BaseInjector', function() {
     var dataCollection;
 
     beforeEach(function() {
+        Portal.app.appConfig.portal.metadataProtocols.metadataRecord = 'metadataRecord';
+        Portal.app.appConfig.portal.metadataProtocols.dataFile = 'dataFile';
 
         injector = new Portal.cart.BaseInjector();
 
         dataCollection = {
             uuid: 9,
-            getMetadataRecord: returns({
-                data: {
-                    pointOfTruthLink: 'Link!'
-                }
-            }),
             getDataDownloadHandlers: returns([]),
-            _getFilteredLinks: returns('Downloadable link!')
+            _getFilteredLinks: function(protocols) {
+                if (protocols == 'dataFile') {
+                    return 'Downloadable link!';
+                }
+                else if (protocols == 'metadataRecord') {
+                    return 'Metadata record link!'
+                }
+            }
         }
     });
 
     describe('getPointOfTruthLinks', function() {
 
         it('returns point of truth links as appropriate', function() {
-            expect(injector._getPointOfTruthLink(dataCollection)).toEqual('Link!');
+            expect(injector._getPointOfTruthLink(dataCollection)).toEqual('Metadata record link!');
         });
     });
 

--- a/src/test/javascript/portal/cart/BaseInjectorSpec.js
+++ b/src/test/javascript/portal/cart/BaseInjectorSpec.js
@@ -19,7 +19,7 @@ describe('Portal.cart.BaseInjector', function() {
         dataCollection = {
             uuid: 9,
             getDataDownloadHandlers: returns([]),
-            _getFilteredLinks: function(protocols) {
+            getLinksByProtocol: function(protocols) {
                 if (protocols == 'dataFile') {
                     return 'Downloadable link!';
                 }

--- a/src/test/javascript/portal/cart/BaseInjectorSpec.js
+++ b/src/test/javascript/portal/cart/BaseInjectorSpec.js
@@ -22,7 +22,7 @@ describe('Portal.cart.BaseInjector', function() {
                 }
             }),
             getDataDownloadHandlers: returns([]),
-            getDataFileLinks: returns('Downloadable link!')
+            _getFilteredLinks: returns('Downloadable link!')
         }
     });
 

--- a/src/test/javascript/portal/cart/NoDataInjectorSpec.js
+++ b/src/test/javascript/portal/cart/NoDataInjectorSpec.js
@@ -19,7 +19,7 @@ describe('Portal.cart.NoDataInjector', function() {
 
         dataCollection = {
             uuid: 9,
-            _getFilteredLinks: function(protocols) {
+            getLinksByProtocol: function(protocols) {
                 if (protocols == 'dataFile') {
                     return 'Downloadable link!';
                 }

--- a/src/test/javascript/portal/cart/NoDataInjectorSpec.js
+++ b/src/test/javascript/portal/cart/NoDataInjectorSpec.js
@@ -12,17 +12,21 @@ describe('Portal.cart.NoDataInjector', function() {
     var dataCollection;
 
     beforeEach(function() {
+        Portal.app.appConfig.portal.metadataProtocols.metadataRecord = 'metadataRecord';
+        Portal.app.appConfig.portal.metadataProtocols.dataFile = 'dataFile';
 
         injector = new Portal.cart.NoDataInjector();
 
         dataCollection = {
             uuid: 9,
-            getMetadataRecord: returns({
-                data: {
-                    pointOfTruthLink: 'Link!'
+            _getFilteredLinks: function(protocols) {
+                if (protocols == 'dataFile') {
+                    return 'Downloadable link!';
                 }
-            }),
-            _getFilteredLinks: returns('Downloadable link!')
+                else if (protocols == 'metadataRecord') {
+                    return 'Metadata record link!'
+                }
+            }
         }
     });
 
@@ -46,7 +50,7 @@ describe('Portal.cart.NoDataInjector', function() {
     describe('getPointOfTruthLinks', function() {
 
         it('returns point of truth links as appropriate', function() {
-            expect(injector._getPointOfTruthLink(dataCollection)).toEqual('Link!');
+            expect(injector._getPointOfTruthLink(dataCollection)).toEqual('Metadata record link!');
         });
     });
 

--- a/src/test/javascript/portal/cart/NoDataInjectorSpec.js
+++ b/src/test/javascript/portal/cart/NoDataInjectorSpec.js
@@ -22,7 +22,7 @@ describe('Portal.cart.NoDataInjector', function() {
                     pointOfTruthLink: 'Link!'
                 }
             }),
-            getDataFileLinks: returns('Downloadable link!')
+            _getFilteredLinks: returns('Downloadable link!')
         }
     });
 

--- a/src/test/javascript/portal/data/DataCollectionSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionSpec.js
@@ -35,6 +35,29 @@ describe("Portal.data.DataCollection", function() {
         });
 
         describe('getDownloadLayerName()', function() {
+            beforeEach(function() {
+                testWfsLayerLinks = [{
+                    data: {name: 'imos:wfs_layer1'}
+                }, {
+                    data: {name: 'imos:wfs_layer2'}
+                }];
+
+                testWmsLayerLinks = [{
+                    data: {name: 'aodn:wms_layer1'}
+                }, {
+                    data: {name: 'aodn:wms_layer2'}
+                }];
+
+                dataCollection.getLinksByProtocol = function(protocols) {
+                    if (protocols == 'wfs') {
+                        return testWfsLayerLinks;
+                    }
+                    else if (protocols == 'wms') {
+                        return testWmsLayerLinks;
+                    }
+                };
+            });
+
             it('uses WFS link if present', function() {
                 expect(dataCollection.getFiltersRequestParams().layer).toBe('imos:wfs_layer');
             });

--- a/src/test/javascript/portal/data/DataCollectionSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionSpec.js
@@ -11,26 +11,27 @@ describe("Portal.data.DataCollection", function() {
 
     beforeEach(function() {
         dataCollection = new Portal.data.DataCollection();
-        spyOn(dataCollection, 'getWmsLayerLinks').andReturn([]);
         spyOn(dataCollection, 'setFilters');
     });
 
     describe('getFiltersRequestParams()', function() {
+        var testWfsLayerLinks;
+        var testWmsLayerLinks;
+
         beforeEach(function() {
+            Portal.app.appConfig.portal.metadataProtocols.wfs = 'wfs';
+            Portal.app.appConfig.portal.metadataProtocols.wms = 'wms';
+
             dataCollection.getLayerSelectionModel = returns({
                 getSelectedLayer: returns({
                     server: {uri: 'server url'}
                 })
             });
-            dataCollection.getWfsLayerLinks = returns([{
-                data: {name: 'imos:wfs_layer'}
-            }]);
-            dataCollection.getWmsLayerLinks = returns([{
-                data: {name: 'aodn:wms_layer'}
-            }]);
         });
 
         it('uses uri from selected layer from layer state', function() {
+            dataCollection.getDownloadLayerName = returns('layerName');
+
             expect(dataCollection.getFiltersRequestParams().server).toBe('server url');
         });
 
@@ -59,26 +60,30 @@ describe("Portal.data.DataCollection", function() {
             });
 
             it('uses WFS link if present', function() {
-                expect(dataCollection.getFiltersRequestParams().layer).toBe('imos:wfs_layer');
+                expect(dataCollection.getFiltersRequestParams().layer).toBe('imos:wfs_layer1');
             });
 
             it('uses WMS link otherwise', function() {
-                dataCollection.getWfsLayerLinks = returns([]);
+                testWfsLayerLinks = [];
 
-                expect(dataCollection.getFiltersRequestParams().layer).toBe('aodn:wms_layer');
+                expect(dataCollection.getFiltersRequestParams().layer).toBe('aodn:wms_layer1');
             });
 
             it('uses WFS link with workspace name from WMS link if missing', function() {
-                dataCollection.getWfsLayerLinks = returns([{
-                    data: {name: 'wfs_layer'} // No namespace
-                }]);
+                testWfsLayerLinks = [{
+                    data: {name: 'wfs_layer1'} // No namespace
+                }];
 
-                expect(dataCollection.getFiltersRequestParams().layer).toBe('aodn:wfs_layer');
+                expect(dataCollection.getFiltersRequestParams().layer).toBe('aodn:wfs_layer1');
             });
         });
     });
 
     describe('layerstate', function() {
+        beforeEach(function() {
+            spyOn(dataCollection, 'getLinksByProtocol').andReturn([]);
+        });
+
         it('lazily initialises layer state', function() {
             var layerSelectionModel = dataCollection.getLayerSelectionModel();
             expect(layerSelectionModel).toBeInstanceOf(Portal.data.LayerSelectionModel);

--- a/src/test/javascript/portal/data/LayerSelectionModelSpec.js
+++ b/src/test/javascript/portal/data/LayerSelectionModelSpec.js
@@ -5,7 +5,7 @@
  *
  */
 
-describe("Portal.data.LayerSelectionModelSpec", function() {
+describe("Portal.data.LayerSelectionModel", function() {
 
     var dataCollection;
     var dataCollectionLayers;
@@ -55,7 +55,7 @@ describe("Portal.data.LayerSelectionModelSpec", function() {
         }).records;
 
         dataCollection = {
-            getWmsLayerLinks: returns(linkRecords),
+            _getFilteredLinks: returns(linkRecords),
             get: returns('name')
         };
 

--- a/src/test/javascript/portal/data/LayerSelectionModelSpec.js
+++ b/src/test/javascript/portal/data/LayerSelectionModelSpec.js
@@ -55,7 +55,7 @@ describe("Portal.data.LayerSelectionModel", function() {
         }).records;
 
         dataCollection = {
-            _getFilteredLinks: returns(linkRecords),
+            getLinksByProtocol: returns(linkRecords),
             get: returns('name')
         };
 

--- a/src/test/javascript/portal/details/InfoPanelSpec.js
+++ b/src/test/javascript/portal/details/InfoPanelSpec.js
@@ -30,9 +30,9 @@ describe("Portal.details.InfoPanel", function() {
             dataCollection: {
                 getMetadataRecord: returns({
                     get: returns("Abstract & information")
-                }),
-                getWebPageLinks: returns(mockLinkRecords)
-            }
+                })
+            },
+            _getLinkRecords: returns(mockLinkRecords)
         });
     });
 

--- a/web-app/js/portal/cart/BaseInjector.js
+++ b/web-app/js/portal/cart/BaseInjector.js
@@ -26,11 +26,11 @@ Portal.cart.BaseInjector = Ext.extend(Object, {
     },
 
     _getMetadataLinks: function(dataCollection) {
-        return dataCollection._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.dataFile);
+        return dataCollection.getLinksByProtocol(Portal.app.appConfig.portal.metadataProtocols.dataFile);
     },
 
     _getPointOfTruthLink: function(dataCollection) {
-        return dataCollection._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.metadataRecord);
+        return dataCollection.getLinksByProtocol(Portal.app.appConfig.portal.metadataProtocols.metadataRecord);
     },
 
     _getDataMarkup: function(dataCollection) {

--- a/web-app/js/portal/cart/BaseInjector.js
+++ b/web-app/js/portal/cart/BaseInjector.js
@@ -30,7 +30,7 @@ Portal.cart.BaseInjector = Ext.extend(Object, {
     },
 
     _getPointOfTruthLink: function(dataCollection) {
-        return dataCollection.getMetadataRecord().data.pointOfTruthLink;
+        return dataCollection._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.metadataRecord);
     },
 
     _getDataMarkup: function(dataCollection) {

--- a/web-app/js/portal/cart/BaseInjector.js
+++ b/web-app/js/portal/cart/BaseInjector.js
@@ -26,7 +26,7 @@ Portal.cart.BaseInjector = Ext.extend(Object, {
     },
 
     _getMetadataLinks: function(dataCollection) {
-        return dataCollection.getDataFileLinks();
+        return dataCollection._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.dataFile);
     },
 
     _getPointOfTruthLink: function(dataCollection) {

--- a/web-app/js/portal/data/DataCollection.js
+++ b/web-app/js/portal/data/DataCollection.js
@@ -23,10 +23,6 @@ Portal.data.DataCollection = function() {
         return this.data.metadataRecord;
     };
 
-    constructor.prototype.getWmsLayerLinks = function() {
-        return this._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.wms);
-    };
-
     constructor.prototype.getDataDownloadHandlers = function() {
 
         var protocolHandlerConstructors = { // Todo - DN: Should this mapping live in config?
@@ -102,8 +98,9 @@ Portal.data.DataCollection = function() {
 
     constructor.prototype.getDownloadLayerName = function() {
         var wfsLayerLinks = this._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.wfs);
+        var wmsLayerLinks = this._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.wms);
         var firstWfsLink = wfsLayerLinks[0];
-        var firstWmsLink = this.getWmsLayerLinks()[0];
+        var firstWmsLink = wmsLayerLinks[0];
         var link = firstWfsLink || firstWmsLink;
 
         var _workspaceFromName = function(layerName) {

--- a/web-app/js/portal/data/DataCollection.js
+++ b/web-app/js/portal/data/DataCollection.js
@@ -31,10 +31,6 @@ Portal.data.DataCollection = function() {
         return this._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.wfs);
     };
 
-    constructor.prototype.getDataFileLinks = function() {
-        return this._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.dataFile);
-    };
-
     constructor.prototype.getDataDownloadHandlers = function() {
 
         var protocolHandlerConstructors = { // Todo - DN: Should this mapping live in config?

--- a/web-app/js/portal/data/DataCollection.js
+++ b/web-app/js/portal/data/DataCollection.js
@@ -85,7 +85,7 @@ Portal.data.DataCollection = function() {
         return this.getMetadataRecord().get('links');
     };
 
-    constructor.prototype._getFilteredLinks = function(protocols) {
+    constructor.prototype.getLinksByProtocol = function(protocols) {
 
         var linkStore = new Portal.search.data.LinkStore({
             data: { links: this._getRawLinks() }
@@ -97,8 +97,8 @@ Portal.data.DataCollection = function() {
     };
 
     constructor.prototype.getDownloadLayerName = function() {
-        var wfsLayerLinks = this._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.wfs);
-        var wmsLayerLinks = this._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.wms);
+        var wfsLayerLinks = this.getLinksByProtocol(Portal.app.appConfig.portal.metadataProtocols.wfs);
+        var wmsLayerLinks = this.getLinksByProtocol(Portal.app.appConfig.portal.metadataProtocols.wms);
         var firstWfsLink = wfsLayerLinks[0];
         var firstWmsLink = wmsLayerLinks[0];
         var link = firstWfsLink || firstWmsLink;

--- a/web-app/js/portal/data/DataCollection.js
+++ b/web-app/js/portal/data/DataCollection.js
@@ -27,10 +27,6 @@ Portal.data.DataCollection = function() {
         return this._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.wms);
     };
 
-    constructor.prototype.getWfsLayerLinks = function() {
-        return this._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.wfs);
-    };
-
     constructor.prototype.getDataDownloadHandlers = function() {
 
         var protocolHandlerConstructors = { // Todo - DN: Should this mapping live in config?
@@ -105,7 +101,8 @@ Portal.data.DataCollection = function() {
     };
 
     constructor.prototype.getDownloadLayerName = function() {
-        var firstWfsLink = this.getWfsLayerLinks()[0];
+        var wfsLayerLinks = this._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.wfs);
+        var firstWfsLink = wfsLayerLinks[0];
         var firstWmsLink = this.getWmsLayerLinks()[0];
         var link = firstWfsLink || firstWmsLink;
 

--- a/web-app/js/portal/data/DataCollection.js
+++ b/web-app/js/portal/data/DataCollection.js
@@ -35,10 +35,6 @@ Portal.data.DataCollection = function() {
         return this._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.dataFile);
     };
 
-    constructor.prototype.getWebPageLinks = function() {
-        return this._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.webPage);
-    };
-
     constructor.prototype.getDataDownloadHandlers = function() {
 
         var protocolHandlerConstructors = { // Todo - DN: Should this mapping live in config?

--- a/web-app/js/portal/data/LayerSelectionModel.js
+++ b/web-app/js/portal/data/LayerSelectionModel.js
@@ -49,7 +49,8 @@ Portal.data.LayerSelectionModel = Ext.extend(Ext.util.Observable, {
     _initLayers: function() {
         this.layerCache = [];
 
-        Ext.each(this.dataCollection.getWmsLayerLinks(), function(layerLink) {
+        var wmsLayerLinks = this.dataCollection.getLinksByProtocol(Portal.app.appConfig.portal.metadataProtocols.wms);
+        Ext.each(wmsLayerLinks, function(layerLink) {
             // TODO: rename LayerLink classes/vars appropriately - when is a layer link *really*
             // a layer link?
             var convertedLayerLink = Portal.search.data.LinkStore.prototype._convertLink(layerLink);

--- a/web-app/js/portal/details/InfoPanel.js
+++ b/web-app/js/portal/details/InfoPanel.js
@@ -62,6 +62,6 @@ Portal.details.InfoPanel = Ext.extend(Ext.Container, {
     },
 
     _getLinkRecords: function() {
-        return this.dataCollection.getWebPageLinks();
+        return this.dataCollection._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.webPage);
     }
 });

--- a/web-app/js/portal/details/InfoPanel.js
+++ b/web-app/js/portal/details/InfoPanel.js
@@ -62,6 +62,6 @@ Portal.details.InfoPanel = Ext.extend(Ext.Container, {
     },
 
     _getLinkRecords: function() {
-        return this.dataCollection._getFilteredLinks(Portal.app.appConfig.portal.metadataProtocols.webPage);
+        return this.dataCollection.getLinksByProtocol(Portal.app.appConfig.portal.metadataProtocols.webPage);
     }
 });

--- a/web-app/js/portal/details/InfoPanel.js
+++ b/web-app/js/portal/details/InfoPanel.js
@@ -27,7 +27,6 @@ Portal.details.InfoPanel = Ext.extend(Ext.Container, {
 
         var rawAbstract = this.dataCollection.getMetadataRecord().get('abstract');
         var abstract = Ext.util.Format.htmlEncode(rawAbstract);
-        var linkRecords = this.dataCollection.getWebPageLinks();
 
         return String.format(
             '<h4>{0}</h4>\n{1}' +
@@ -35,12 +34,13 @@ Portal.details.InfoPanel = Ext.extend(Ext.Container, {
             OpenLayers.i18n('abstractTitle'),
             abstract,
             OpenLayers.i18n('webpageLinksTitle'),
-            this._getHtmlForLinks(linkRecords)
+            this._getHtmlForLinks()
         );
     },
 
-    _getHtmlForLinks: function(linkRecords) {
+    _getHtmlForLinks: function() {
 
+        var linkRecords = this._getLinkRecords();
         var linkHtml = "";
 
         Ext.each(linkRecords, function(linkRecord) {
@@ -59,5 +59,9 @@ Portal.details.InfoPanel = Ext.extend(Ext.Container, {
         });
 
         return linkHtml;
+    },
+
+    _getLinkRecords: function() {
+        return this.dataCollection.getWebPageLinks();
     }
 });


### PR DESCRIPTION
This removes the individual get______Links() methods from DataCollection and has just one method getLinksByProtocol() which you can pass the protocols you are interested in. This new function is also used for getting the point-of-truth link from a DataCollection.