### PR TITLE
Revert "Use phantomjs to execute tests"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,22 +279,6 @@
             </plugin>
 
             <plugin>
-                <groupId>com.github.klieber</groupId>
-                <artifactId>phantomjs-maven-plugin</artifactId>
-                <version>0.7</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>install</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <version>1.9.2</version>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>com.github.searls</groupId>
                 <artifactId>jasmine-maven-plugin</artifactId>
                 <version>1.3.1.2</version>
@@ -307,10 +291,6 @@
                 </executions>
                 <configuration>
                     <jsSrcDir>${project.basedir}/web-app/js</jsSrcDir>
-                    <webDriverClassName>org.openqa.selenium.phantomjs.PhantomJSDriver</webDriverClassName>
-                    <webDriverCapabilities>
-                        <phantomjs.binary.path>${phantomjs.binary}</phantomjs.binary.path>
-                    </webDriverCapabilities>
                     <sourceIncludes>
                         <include>jquery/jquery-1.6.min.js</include>
                         <include>jquery/jquery-autocomplete1.1.js</include>


### PR DESCRIPTION
This reverts commit 8abd85b65a7ced410d96e1e0745ad4564b55c5cd.

Phantomjs is intermittently hanging.

e.g.: https://travis-ci.org/aodn/aodn-portal/builds/77274087

So, we go back to html unit for now.
There's some discussion about this problem on phantomjs github issues, but no resolution.