### PR TITLE
Clean up of zoom to layer

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -240,7 +240,6 @@ portal {
 
     initialBbox = "110,-50,160,-3"
     defaultDatelineZoomBbox = "110,-50,160,-3"
-    enableDefaultDatelineZoom = false
 
     popupWidth = 550
     popupHeight = 325

--- a/src/test/javascript/portal/common/LayerDescriptorSpec.js
+++ b/src/test/javascript/portal/common/LayerDescriptorSpec.js
@@ -47,28 +47,4 @@ describe("Portal.common.LayerDescriptor", function() {
             expect(openLayerWithOptionOverrides.opacity).toBe(2);
         });
     });
-
-    describe('_setOpenLayerBounds', function() {
-        it('from dataCollection', function() {
-            var openLayer = {};
-
-            var dataCollection = {
-                getMetadataRecord: returns({
-                    data: { bbox: {
-                        geometries: [],
-                        getBounds: returns(new OpenLayers.Bounds(1,2,3,4))
-                    }}
-                })
-            };
-
-            var layerDescriptor = new Portal.common.LayerDescriptor({}, 'title', dataCollection);
-
-            layerDescriptor._setOpenLayerBounds(openLayer);
-
-            expect(openLayer.bboxMinX).toEqual(1);
-            expect(openLayer.bboxMinY).toEqual(2);
-            expect(openLayer.bboxMaxX).toEqual(3);
-            expect(openLayer.bboxMaxY).toEqual(4);
-        });
-    });
 });

--- a/src/test/javascript/portal/details/LayerControlPanelSpec.js
+++ b/src/test/javascript/portal/details/LayerControlPanelSpec.js
@@ -24,8 +24,13 @@ describe("Portal.details.LayerControlPanel", function() {
         dataCollection = {
             getTitle: returns('Data Collection Title'),
             getLayerAdapter: returns(layerAdapter),
-            getLayerSelectionModel: returns(layerSelectionModel)
+            getLayerSelectionModel: returns(layerSelectionModel),
+            bounds: true
         };
+
+        spyOn(Portal.details.LayerControlPanel.prototype, '_getCollectionBounds').andCallFake(function() {
+            return dataCollection.bounds;
+        });
 
         layerControlPanel = new Portal.details.LayerControlPanel({
             dataCollection: dataCollection
@@ -108,7 +113,7 @@ describe("Portal.details.LayerControlPanel", function() {
             spyOn(window, 'trackLayerControlUsage');
             layerControlPanel.layer = {
                 setVisibility: jasmine.createSpy('setVisibility')
-            }
+            };
         });
 
         it('sends google analytics tracking when checked', function() {
@@ -129,6 +134,37 @@ describe("Portal.details.LayerControlPanel", function() {
                 'off',
                 'Data Collection Title'
             );
+        });
+    });
+
+    describe('zoom to layer control', function() {
+        beforeEach(function() {
+            spyOn(Portal.details.LayerControlPanel.prototype, '_newZoomToDataButton').andCallThrough();
+        });
+
+        it('exists only when collection has bounds', function() {
+            dataCollection.bounds = true;
+            layerControlPanel = new Portal.details.LayerControlPanel({
+                dataCollection: dataCollection
+            });
+            expect(layerControlPanel._newZoomToDataButton).toHaveBeenCalled();
+        });
+
+        it("doesn't exist only when collection has bounds", function() {
+            dataCollection.bounds = false;
+            layerControlPanel = new Portal.details.LayerControlPanel({
+                dataCollection: dataCollection
+            });
+            expect(layerControlPanel._newZoomToDataButton).not.toHaveBeenCalled();
+        });
+
+        it('calls through to map.zoomToExtent', function() {
+            layerControlPanel.map = {
+                zoomToExtent: jasmine.createSpy('zoomToExtent')
+            };
+
+            layerControlPanel._zoomToLayer();
+            expect(layerControlPanel.map.zoomToExtent).toHaveBeenCalledWith(layerControlPanel._getCollectionBounds());
         });
     });
 });

--- a/src/test/javascript/portal/ui/MapPanelSpec.js
+++ b/src/test/javascript/portal/ui/MapPanelSpec.js
@@ -36,32 +36,6 @@ describe("Portal.ui.MapPanel", function() {
         });
     });
 
-    describe('zoom to layer tests', function() {
-
-        var openLayer = new OpenLayers.Layer.WMS();
-
-        beforeEach(function() {
-            spyOn(mapPanel.map, 'zoomToExtent');
-        });
-
-        it('zoomToExtent not called for layer without bounds', function() {
-
-            mapPanel.zoomToLayer(openLayer);
-            expect(mapPanel.map.zoomToExtent).not.toHaveBeenCalled();
-        });
-
-        it('zoomTo called for layer with bounds', function() {
-
-            openLayer.bboxMinX = 10;
-            openLayer.bboxMinY = 10;
-            openLayer.bboxMaxX = 20;
-            openLayer.bboxMaxY = 20;
-
-            mapPanel.zoomToLayer(openLayer);
-            expect(mapPanel.map.zoomToExtent).toHaveBeenCalled();
-        });
-    });
-
     describe('reset event', function() {
 
         it('should call reset()', function() {

--- a/web-app/js/portal/common/LayerDescriptor.js
+++ b/web-app/js/portal/common/LayerDescriptor.js
@@ -44,24 +44,10 @@ Portal.common.LayerDescriptor = Ext.extend(Object, {
         openLayer.server = this.server;
         openLayer.wmsName = this.name;
 
-        this._setOpenLayerBounds(openLayer);
         openLayer.projection = this.projection;
         openLayer.blacklist = this.blacklist;
         openLayer.abstractTrimmed = this.abstractTrimmed;
         openLayer.dimensions = this.dimensions;
         openLayer.params.QUERYABLE = true;
-    },
-
-    _setOpenLayerBounds: function(openLayer) {
-
-        if (this.dataCollection) {
-            var metadataRecord = this.dataCollection.getMetadataRecord();
-            var bounds = metadataRecord.data.bbox.getBounds();
-
-            openLayer.bboxMinX = bounds.left;
-            openLayer.bboxMinY = bounds.bottom;
-            openLayer.bboxMaxX = bounds.right;
-            openLayer.bboxMaxY = bounds.top;
-        }
     }
 });

--- a/web-app/js/portal/data/DataCollectionLayerAdapter.js
+++ b/web-app/js/portal/data/DataCollectionLayerAdapter.js
@@ -112,10 +112,6 @@ Portal.data.DataCollectionLayerAdapter = Ext.extend(Ext.util.Observable, {
 
     _copyAttributesFromSelectedLayer: function() {
         Ext.each([
-            'bboxMaxX',
-            'bboxMaxY',
-            'bboxMinX',
-            'bboxMinY',
             'opacity',
             'projection'
         ], function(attr) {

--- a/web-app/js/portal/details/LayerControlPanel.js
+++ b/web-app/js/portal/details/LayerControlPanel.js
@@ -21,7 +21,10 @@ Portal.details.LayerControlPanel = Ext.extend(Ext.Container, {
 
         this.items.push(this._newOpacitySliderContainer());
         this.items.push(this._newVisibilityCheckbox());
-        this.items.push(this._newZoomToDataButton());
+
+        if (this._getCollectionBounds()) {
+            this.items.push(this._newZoomToDataButton());
+        }
 
         Portal.details.LayerControlPanel.superclass.initComponent.call(this);
     },
@@ -128,6 +131,10 @@ Portal.details.LayerControlPanel = Ext.extend(Ext.Container, {
     },
 
     _zoomToLayer: function() {
-        this.map.mapPanel.zoomToLayer(this.layer);
+        this.map.zoomToExtent(this._getCollectionBounds());
+    },
+
+    _getCollectionBounds: function() {
+        return this.dataCollection.getMetadataRecord().data.bbox.getBounds();
     }
 });

--- a/web-app/js/portal/ui/MapPanel.js
+++ b/web-app/js/portal/ui/MapPanel.js
@@ -23,8 +23,6 @@ Portal.ui.MapPanel = Ext.extend(Portal.common.MapPanel, {
             split: true,
             header: false,
             initialBbox: portalConfig.initialBbox,
-            enableDefaultDatelineZoom: portalConfig.enableDefaultDatelineZoom,
-            defaultDatelineZoomBbox: portalConfig.defaultDatelineZoomBbox,
             hideLayerOptions: this.appConfig.hideLayerOptions
         }, cfg);
 
@@ -107,26 +105,6 @@ Portal.ui.MapPanel = Ext.extend(Portal.common.MapPanel, {
         this.mapOptions = new Portal.ui.openlayers.MapOptions(this.appConfig, this);
         this.map = this.mapOptions.newMap();
         this.map.setDefaultSpatialConstraintType(this.defaultSpatialConstraintType);
-    },
-
-    zoomToLayer: function(openLayer) {
-        if (openLayer && openLayer.hasBoundingBox()) {
-            // build openlayer bounding box
-            var bounds = null;
-            if (openLayer.bboxMinY == -180 && openLayer.bboxMaxY == 180 && this.enableDefaultDatelineZoom) {
-                // Geoserver can't represent bounding boxes that cross the date line - so, optionally, use a default
-                var defaultBbox = this.defaultDatelineZoomBbox.split(',');
-                bounds = new OpenLayers.Bounds(parseFloat(defaultBbox[1]), parseFloat(defaultBbox[0]), parseFloat(defaultBbox[3]), parseFloat(defaultBbox[2]));
-            }
-            else {
-                bounds = new OpenLayers.Bounds(openLayer.bboxMinX, openLayer.bboxMinY, openLayer.bboxMaxX, openLayer.bboxMaxY);
-            }
-
-            // ensure converted into this maps projection. convert metres into lat/lon etc
-            bounds.transform(new OpenLayers.Projection(openLayer.projection), this.map.getProjectionObject());
-
-            this.map.zoomToExtent(bounds);
-        }
     },
 
     getPanelX: function() {

--- a/web-app/js/portal/ui/openlayers/MapOptions.js
+++ b/web-app/js/portal/ui/openlayers/MapOptions.js
@@ -55,8 +55,6 @@ Portal.ui.openlayers.MapOptions = Ext.extend(Object, {
         this.displayProjection = new OpenLayers.Projection("EPSG:4326");
         this.prettyStateKeys = true; // for pretty permalinks,
         this.resolutions = [0.17578125, 0.087890625, 0.0439453125, 0.02197265625, 0.010986328125, 0.0054931640625, 0.00274658203125, 0.001373291015625, 0.0006866455078125, 0.00034332275390625, 0.000171661376953125];
-
-        this.mapPanel = mapPanel;
     },
 
     afterRender: function () {


### PR DESCRIPTION
Bounds are taken directly from the data collection, rather than storing in each layer and then taking from there - that's just a round-a-bout and unnecessary way of doing it now that most components are 'data collection centric'.

This also addresses a usability issue whereby the 'zoom to layer' control is only shown for collections having a geo extent defined.  Ordinarily this should be the case for *every* collection, although this is the safer option and can probably also help avoid confusion when developing new collections.  /cc @kereid @pblain change to functionality