### PR TITLE
fix #1940 - bogus link parsing

### DIFF
--- a/src/test/javascript/portal/cart/DownloadPanelItemTemplateSpec.js
+++ b/src/test/javascript/portal/cart/DownloadPanelItemTemplateSpec.js
@@ -23,9 +23,11 @@ describe('Portal.cart.DownloadPanelItemTemplate', function () {
         mockDataInjection = {
             uuid: '42',
             title: 'the title',
-            pointOfTruthLink: {
-                href: 'point of truth url'
-            },
+            pointOfTruthLink: [
+                {
+                    href: 'point of truth url'
+                }
+            ],
             dataMarkup: 'markup!',
             dataFilters: 'Filters!',
             linkedFiles: [
@@ -243,7 +245,7 @@ describe('Portal.cart.DownloadPanelItemTemplate', function () {
         it('creates links', function() {
             var values = {
                 linkedFiles: [
-                    {url: href, title: text}
+                    {href: href, title: text}
                 ]
             };
             var html = tpl._getFileListEntries(values);
@@ -259,9 +261,11 @@ describe('Portal.cart.DownloadPanelItemTemplate', function () {
         beforeEach(function() {
             values = {
                 title: "Rottnest ...QC'd (is bad for embedding in a function)",
-                pointOfTruthLink: {
-                    href: "http://geonetwork"
-                }
+                pointOfTruthLink: [
+                    {
+                        href: "http://geonetwork"
+                    }
+                ]
             };
         });
 

--- a/src/test/javascript/portal/details/InfoPanelSpec.js
+++ b/src/test/javascript/portal/details/InfoPanelSpec.js
@@ -15,10 +15,10 @@ describe("Portal.details.InfoPanel", function() {
     beforeEach(function() {
 
         var mockLinks = [{
-            url: "http://www.google.com",
+            href: "http://www.google.com",
             title: ""
         }, {
-            url: "http://imos.aodn.org.au",
+            href: "http://imos.aodn.org.au",
             title: "Portal"
         }];
 

--- a/web-app/js/portal/cart/DownloadPanelItemTemplate.js
+++ b/web-app/js/portal/cart/DownloadPanelItemTemplate.js
@@ -77,7 +77,7 @@ Portal.cart.DownloadPanelItemTemplate = Ext.extend(Ext.XTemplate, {
                 cleanStringForFunctionParameter(record.title)
             );
 
-            markup = this._makeExternalLinkMarkup(record.pointOfTruthLink.href, OpenLayers.i18n('metadataLinkText'), trackUsageText);
+            markup = this._makeExternalLinkMarkup(record.pointOfTruthLink[0].href, OpenLayers.i18n('metadataLinkText'), trackUsageText);
         }
 
         return markup;
@@ -200,7 +200,7 @@ Portal.cart.DownloadPanelItemTemplate = Ext.extend(Ext.XTemplate, {
     },
 
     _getSingleFileEntry: function(link) {
-        return this._makeExternalLinkMarkup(link.url, link.title);
+        return this._makeExternalLinkMarkup(link.href, link.title);
     },
 
     _makeExternalLinkMarkup: function(href, text, extras) {

--- a/web-app/js/portal/details/InfoPanel.js
+++ b/web-app/js/portal/details/InfoPanel.js
@@ -53,7 +53,7 @@ Portal.details.InfoPanel = Ext.extend(Ext.Container, {
                 linkText = link.title;
             }
 
-            linkHtml += String.format('<li><a class="external" href="{0}" target="_blank">{1}</a></li>\n', link.url, linkText);
+            linkHtml += String.format('<li><a class="external" href="{0}" target="_blank">{1}</a></li>\n', link.href, linkText);
         });
 
         return linkHtml;


### PR DESCRIPTION
parse correct links from metadata for step 2 and 3

an easy fix for a pretty critical issue (most links displayed are actually broken!!)