### PR TITLE
Fixes #1922

### DIFF
--- a/web-app/js/portal/details/NcWmsPanel.js
+++ b/web-app/js/portal/details/NcWmsPanel.js
@@ -278,6 +278,10 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Container, {
 
         datePicker.setValue(selectedDateTimeMoment);
 
+        if (datePicker.validate()) {
+            this._applyFilterValuesToCollection(); // Set this date on the collection now. Fixes #1922
+        }
+
         this.layer.loadTimeSeriesForDay(selectedDateTimeMoment);
         // Now we wait for the event of 'temporalextentloaded'
     },


### PR DESCRIPTION
The values applied to the collections temporal filter were not set until the times in a day were retrieved.
The Download Panel is not aware of the event of the days extent loading having completed, and so was never updated