### PR TITLE
Avoid generating URLs with hashes

### DIFF
--- a/grails-app/views/header/_viewPortLink.gsp
+++ b/grails-app/views/header/_viewPortLink.gsp
@@ -6,8 +6,8 @@
 
 --%>
 <div class="viewPortTab viewPortTabDisabled" id="viewPortTab${stepIndex}">
-  <a href="#" >
+  <button>
     <h1>${stepIndex + 1}</h1>
     <h2>${description}</h2>
-  </a>
+  </button>
 </div>

--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -306,6 +306,15 @@ Site navigation
     margin: 0;
 }
 
+.viewPortTab button {
+    background-color: inherit;
+    border: none;
+}
+
+.viewPortTabActive button{
+    cursor: pointer;
+}
+
 .viewPortTab h1 {
     line-height: 26px;
     float: left;

--- a/web-app/js/portal/jquery.js
+++ b/web-app/js/portal/jquery.js
@@ -50,7 +50,7 @@ jQuery( window ).load(function() {
         .live("mouseenter", function(){
             var tabId = $(this).attr('id');
             var tabIdInt = parseInt(tabId.substr(tabId.length - 1));
-            jQuery(this).children('a').each(
+            jQuery(this).children('button').each(
                 function() {
                     var events = jQuery(this).data('events');
                     if (events == undefined || typeof (events.click) != "object") {


### PR DESCRIPTION
Stops the issue of appended hashes appearing on the Step1-2-3 links by using button tags instead of links.
See:
https://github.com/aodn/aodn-portal/issues/1958