### PR TITLE
Server check changes

### DIFF
--- a/src/test/javascript/portal/common/LayerDescriptorSpec.js
+++ b/src/test/javascript/portal/common/LayerDescriptorSpec.js
@@ -10,14 +10,12 @@ describe("Portal.common.LayerDescriptor", function() {
     it('from javascript object', function() {
         var layerDescAsDecodedJSON = {
             name: 'satellite',
-            server: {
-                uri: 'http://tilecache.emii.org.au/cgi-bin/tilecache.cgi'
-            }
+            href: 'http://tilecache.emii.org.au/cgi-bin/tilecache.cgi'
         };
 
         var layerDesc = new Portal.common.LayerDescriptor(layerDescAsDecodedJSON);
         expect(layerDesc.name).toBe('satellite');
-        expect(layerDesc.server.uri).toBe('http://tilecache.emii.org.au/cgi-bin/tilecache.cgi');
+        expect(layerDesc.href).toBe('http://tilecache.emii.org.au/cgi-bin/tilecache.cgi');
     });
 
     describe('toOpenLayer', function() {
@@ -26,9 +24,10 @@ describe("Portal.common.LayerDescriptor", function() {
 
         beforeEach(function() {
             layerDesc = new Portal.common.LayerDescriptor({
+                href: 'http://tilecache.emii.org.au/cgi-bin/tilecache.cgi',
                 "isBaseLayer": true,
                 "server": {
-                    "uri": "http://tilecache.emii.org.au/cgi-bin/tilecache.cgi"
+                    "uri": "http://tilecache.emii.org.au/"
                 }
             });
         });

--- a/src/test/javascript/portal/data/ServerSpec.js
+++ b/src/test/javascript/portal/data/ServerSpec.js
@@ -30,7 +30,7 @@ describe('Portal.data.Server', function() {
 
         it('returns info for known server', function() {
             expect(Portal.data.Server.getInfo('http://server1')).toBe(server1Info);
-            expect(Portal.data.Server.getInfo('http://server2')).toBe(server2Info);
+            expect(Portal.data.Server.getInfo('http://server2/someExtraPath')).toBe(server2Info);
         });
 
         it('returns undefined for unknown server', function() {

--- a/web-app/js/portal/common/LayerDescriptor.js
+++ b/web-app/js/portal/common/LayerDescriptor.js
@@ -28,7 +28,7 @@ Portal.common.LayerDescriptor = Ext.extend(Object, {
     toOpenLayer: function(optionOverrides, paramOverrides) {
         var openLayer = new this.openLayerClass(
             this.title,
-            this.server.uri,
+            this.href || this.server.uri,
             new Portal.ui.openlayers.LayerParams(this, paramOverrides),
             new Portal.ui.openlayers.LayerOptions(this, optionOverrides)
         );

--- a/web-app/js/portal/data/Server.js
+++ b/web-app/js/portal/data/Server.js
@@ -24,7 +24,7 @@ Portal.data.Server = {
         var serverInfo;
 
         Ext.each(Portal.app.appConfig.knownServers, function(server) {
-            if (server.uri == uri) {
+            if (uri.startsWith(server.uri)) {
                 serverInfo = server;
                 return false;
             }


### PR DESCRIPTION
This PR has some changes which I made yesterday when working with Ming (@fxmzb123) to get the TPAC layers working in the Portal. They are served from THREDDS-embedded ncWMS. The problem was that there is an extra dataset name after the base URL. So for example, if we used the THREDDS ncWMS, we'd have something like this:
http://thredds.aodn.org.au/wms/abos
http://thredds.aodn.org.au/wms/anmn
http://thredds.aodn.org.au/wms/agro
... etc.

So to make it work we could have added a known server for every dataset (which would be ugly and brittle), or we could change the code so that a configured server with 'http://thredds.aodn.org.au/wms' would match any dataset that it serves.

There are two changes in this PR.
1. Changing known Server comparison method
Previously we compared the server URL from the metadata record link with the URL from the configured Server in the Portal config (`uri` and `server.uri`, respectively, in Server _getConfig() function). We compared them with equality but the change proposes that we just check that the server URL specified in the metadata record just *starts with* the configured server URL.
2. In LayerDescriptor we use the URL from the metadata link rather than from the server we pulled from config. Previously, it wouldn't have really mattered which we used because they had the exact same value. But with change number (1) this is required so that the Portal goes on to use the URL with the dataset name in it. The `... || this.server.uri` fallback is so that base layers from config continue to work.

So these are basically my thoughts:
1. I haven't used this code for very long so it may still have bugs. Perhaps we would only merge this after the release next iteration so it gets a full 2 weeks of dev use first? If there are bugs with tiles/ajax requests it's most likely to do with the changes in LayerDescriptor, I think.
2. I think the changes to how we find known servers is probably pretty good. But it **introduces a security risk** if the Portal is misconfigured. If someone configures a know server in the Portal with the URI as "" or "http" then the Portal will essentially become an open proxy. Perhaps we could check that in the config file by trying to create a URL Object from each configured URL? I think that would guarantee that they're all at least valid URLs with hosts configured.
3. If people are happy with (1) and (2) I think this change is ok to be merged. It doesn't add anything THREDDs-specific and I don't think it really changes the way anything works.