### PR TITLE
Wps service

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/AsyncDownloadController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/AsyncDownloadController.groovy
@@ -45,7 +45,7 @@ class AsyncDownloadController {
         }
         catch (Exception e) {
             log.error "Problem registering new aggregator job with type '$aggregatorServiceString' and parameters: '$params'", e
-            render text: 'Problem registering new aggregator job', status: HTTP_500_INTERNAL_SERVER_ERROR
+            render text: "Problem registering new aggregator job", status: HTTP_500_INTERNAL_SERVER_ERROR
         }
     }
 }

--- a/grails-app/controllers/au/org/emii/portal/AsyncDownloadController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/AsyncDownloadController.groovy
@@ -5,12 +5,15 @@ import static au.org.emii.portal.HttpUtils.Status.*
 class AsyncDownloadController {
 
     def gogoduckService
+    def wpsService
     def downloadAuthService
 
     AsyncDownloadService getAggregatorService(aggregatorService) {
         switch (aggregatorService) {
-            case "gogoduck":
+            case 'gogoduck':
                 return gogoduckService
+            case 'wps':
+                return wpsService
             default:
                 throw new Exception("Cannot find aggregatorService for '$aggregatorService'")
         }

--- a/grails-app/services/au/org/emii/portal/GogoduckService.groovy
+++ b/grails-app/services/au/org/emii/portal/GogoduckService.groovy
@@ -8,7 +8,7 @@ class GogoduckService extends AsyncDownloadService {
 
     def grailsApplication
 
-    def getConnection() {
+    def getConnection(params) {
         return _gogoduckConnection()
     }
 

--- a/grails-app/services/au/org/emii/portal/GogoduckService.groovy
+++ b/grails-app/services/au/org/emii/portal/GogoduckService.groovy
@@ -2,56 +2,48 @@ package au.org.emii.portal
 
 import grails.converters.JSON
 import groovyx.net.http.HTTPBuilder
-import groovyx.net.http.HttpResponseException
 import org.apache.http.util.EntityUtils
 
 class GogoduckService extends AsyncDownloadService {
 
-    static transactional = true
-
     def grailsApplication
 
-    String registerJob(params) throws HttpResponseException {
-
-        def jobParameters = params.jobParameters
-
-        if (!jobParameters) {
-            throw new Exception("No parameters passed to gogoduckService")
-        }
-
-        def responseText
-
-        _gogoduckConnection().post([
-            body: _roundUpEndTime(jobParameters),
-            requestContentType: groovyx.net.http.ContentType.JSON
-            ]) { response ->
-                responseText = EntityUtils.toString(response.getEntity());
-            }
-
-        return responseText
+    def getConnection() {
+        return _gogoduckConnection()
     }
 
     def _gogoduckConnection() {
+        def conn = new HTTPBuilder("${grailsApplication.config.gogoduck.url}/job/")
+        conn.contentType = groovyx.net.http.ContentType.JSON
 
-        def registerJobUrl = "${grailsApplication.config.gogoduck.url}/job/"
+        return conn
+    }
 
-        return new HTTPBuilder(registerJobUrl)
+    def getBody(params) {
+        String.valueOf(_getJobParameters(params) as JSON)
+    }
+
+    def onResponseSuccess = { resp, json ->
+        return json as JSON
+    }
+
+    def _getJobParameters(params) {
+        if (!params.jobParameters) {
+            throw new Exception("No parameters passed to ${this.class.simpleName}")
+        }
+
+        return _roundUpEndTime(JSON.parse(params.jobParameters))
     }
 
     // This is to compensate for a lack of precision in the timestamps that NcWMS publishes
     // (millisecond, whereas the NetCDF files can contain more precise timestamps).
-    def _roundUpEndTime(jobParametersAsString) {
-
-        def jobParameters = JSON.parse(jobParametersAsString)
-
-        if (jobParameters?.subsetDescriptor?.temporalExtent?.end) {
+    def _roundUpEndTime(jobParams) {
+        if (jobParams?.subsetDescriptor?.temporalExtent?.end) {
             def endTime =
-                jobParameters.subsetDescriptor.temporalExtent.end.replace('Z', '999Z')
-            jobParameters.subsetDescriptor.temporalExtent.end = endTime
-
-            return (jobParameters as JSON).toString()
+                jobParams.subsetDescriptor.temporalExtent.end.replace('Z', '999Z')
+            jobParams.subsetDescriptor.temporalExtent.end = endTime
         }
 
-        return jobParametersAsString
+        return jobParams
     }
 }

--- a/grails-app/services/au/org/emii/portal/WpsService.groovy
+++ b/grails-app/services/au/org/emii/portal/WpsService.groovy
@@ -1,0 +1,30 @@
+package au.org.emii.portal
+
+import grails.gsp.PageRenderer
+import groovyx.net.http.*
+
+import static groovyx.net.http.Method.POST
+import static groovyx.net.http.ContentType.XML
+
+class WpsService extends AsyncDownloadService {
+
+    def groovyPageRenderer
+
+    def getConnection(params) {
+        def conn = new HTTPBuilder(params.server)
+        conn.contentType = XML
+
+        return conn
+    }
+
+    def getBody(params) {
+        def body = groovyPageRenderer.render(template: '/wps/asyncRequest.xml', model: params)
+        log.debug("Request body: ${body}")
+
+        return body
+    }
+
+    def onResponseSuccess = { resp, xmlReader ->
+        return new groovy.xml.StreamingMarkupBuilder().bindNode(xmlReader).toString()
+    }
+}

--- a/grails-app/views/wps/_asyncRequest.xml.gsp
+++ b/grails-app/views/wps/_asyncRequest.xml.gsp
@@ -9,28 +9,16 @@
   <ows:Identifier>gs:NetcdfOutput</ows:Identifier>
 
   <wps:DataInputs>
-    <wps:Input>
-      <ows:Identifier>namespace</ows:Identifier>
-      <wps:Data>
-        <wps:LiteralData>imos</wps:LiteralData>
-      </wps:Data>
-    </wps:Input>
-    <wps:Input>
-      <ows:Identifier>typeName</ows:Identifier>
-      <wps:Data>
-        <wps:LiteralData>${typeName}</wps:LiteralData>
-      </wps:Data>
-    </wps:Input>
+    <g:each in="${jobParams}" var="id, value">
 
-    <g:if test="${cqlFilter}">
       <wps:Input>
-        <ows:Identifier>cqlFilter</ows:Identifier>
+        <ows:Identifier>${id}</ows:Identifier>
         <wps:Data>
-          <wps:LiteralData>${cqlFilter}</wps:LiteralData>
+          <wps:LiteralData>${value}</wps:LiteralData>
         </wps:Data>
       </wps:Input>
-    </g:if>
 
+    </g:each>
   </wps:DataInputs>
 
   <wps:ResponseForm>

--- a/grails-app/views/wps/_asyncRequest.xml.gsp
+++ b/grails-app/views/wps/_asyncRequest.xml.gsp
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<wps:Execute service="WPS" version="1.0.0"
+  xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1"
+  xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsExecute_request.xsd">
+
+
+  <ows:Identifier>gs:NetcdfOutput</ows:Identifier>
+
+  <wps:DataInputs>
+    <wps:Input>
+      <ows:Identifier>namespace</ows:Identifier>
+      <wps:Data>
+        <wps:LiteralData>imos</wps:LiteralData>
+      </wps:Data>
+    </wps:Input>
+    <wps:Input>
+      <ows:Identifier>typeName</ows:Identifier>
+      <wps:Data>
+        <wps:LiteralData>${typeName}</wps:LiteralData>
+      </wps:Data>
+    </wps:Input>
+
+    <g:if test="${cqlFilter}">
+      <wps:Input>
+        <ows:Identifier>cqlFilter</ows:Identifier>
+        <wps:Data>
+          <wps:LiteralData>${cqlFilter}</wps:LiteralData>
+        </wps:Data>
+      </wps:Input>
+    </g:if>
+
+  </wps:DataInputs>
+
+  <wps:ResponseForm>
+    <wps:ResponseDocument storeExecuteResponse="true"
+      lineage="false" status="true">
+      <wps:Output asReference="true" mimeType="application/zip">
+        <ows:Identifier>result</ows:Identifier>
+      </wps:Output>
+    </wps:ResponseDocument>
+  </wps:ResponseForm>
+
+</wps:Execute>

--- a/src/groovy/au/org/emii/portal/AsyncDownloadService.groovy
+++ b/src/groovy/au/org/emii/portal/AsyncDownloadService.groovy
@@ -7,6 +7,19 @@
 
 package au.org.emii.portal
 
+import groovyx.net.http.HttpResponseException
+
+import static groovyx.net.http.Method.POST
+
 abstract class AsyncDownloadService {
-    abstract String registerJob(params)
+    abstract def getConnection()
+    abstract def getBody(params)
+
+    String registerJob(params) throws HttpResponseException {
+        connection.request(POST) { req ->
+            body = getBody(params)
+            response.success = onResponseSuccess
+            // TODO: failure
+        }
+    }
 }

--- a/src/groovy/au/org/emii/portal/AsyncDownloadService.groovy
+++ b/src/groovy/au/org/emii/portal/AsyncDownloadService.groovy
@@ -12,14 +12,13 @@ import groovyx.net.http.HttpResponseException
 import static groovyx.net.http.Method.POST
 
 abstract class AsyncDownloadService {
-    abstract def getConnection()
+    abstract def getConnection(params)
     abstract def getBody(params)
 
     String registerJob(params) throws HttpResponseException {
-        connection.request(POST) { req ->
+        getConnection(params).request(POST) { req ->
             body = getBody(params)
             response.success = onResponseSuccess
-            // TODO: failure
         }
     }
 }

--- a/test/unit/au/org/emii/portal/AsyncDownloadControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/AsyncDownloadControllerTests.groovy
@@ -8,6 +8,7 @@ class AsyncDownloadControllerTests extends ControllerUnitTestCase {
 
     def downloadAuthService
     def gogoduckService
+    def wpsService
 
     protected void setUp() {
         super.setUp()
@@ -21,10 +22,10 @@ class AsyncDownloadControllerTests extends ControllerUnitTestCase {
         gogoduckService = mockFor(GogoduckService)
         gogoduckService.demand.registerJob { params -> return "gogoduck_rendered_text" }
         controller.gogoduckService = gogoduckService.createMock()
-    }
 
-    protected void tearDown() {
-        super.tearDown()
+        wpsService = mockFor(WpsService)
+        wpsService.demand.registerJob { params -> return "wps_rendered_text" }
+        controller.wpsService = wpsService.createMock()
     }
 
     void testRegisterJobBadChallengeResponse() {
@@ -92,4 +93,8 @@ class AsyncDownloadControllerTests extends ControllerUnitTestCase {
         assertEquals HTTP_500_INTERNAL_SERVER_ERROR, controller.renderArgs.status
     }
 
+    void testGetAggregatorService() {
+        assertEquals controller.gogoduckService, controller.getAggregatorService('gogoduck')
+        assertEquals controller.wpsService, controller.getAggregatorService('wps')
+    }
 }

--- a/test/unit/au/org/emii/portal/AsyncDownloadServiceTests.groovy
+++ b/test/unit/au/org/emii/portal/AsyncDownloadServiceTests.groovy
@@ -1,0 +1,44 @@
+package au.org.emii.portal
+
+import grails.test.*
+
+class AsyncDownloadServiceTests extends GrailsUnitTestCase {
+
+    AsyncDownloadService service
+
+    void testRegisterJob() {
+
+        def requestCalled = false
+        service = new AsyncDownloadService() {
+            def getBody(params) {}
+            def getConnection() {
+                [
+                    request: { method, handler ->
+                        requestCalled = true
+                    }
+                ]
+            }
+        }
+
+        service.registerJob()
+
+        assertTrue requestCalled
+    }
+
+    void testGetJobParametersEmptyParams() {
+        service = new AsyncDownloadService() {
+            def getBody(params) {}
+            def getConnection() {}
+        }
+
+        def testParams = [jobParameters: ""]
+
+        // Verify an exception is thrown when empty params passed
+        try {
+            service.getJobParameters(testParams)
+            fail()
+        }
+        catch (Exception e) {
+        }
+    }
+}

--- a/test/unit/au/org/emii/portal/AsyncDownloadServiceTests.groovy
+++ b/test/unit/au/org/emii/portal/AsyncDownloadServiceTests.groovy
@@ -11,7 +11,7 @@ class AsyncDownloadServiceTests extends GrailsUnitTestCase {
         def requestCalled = false
         service = new AsyncDownloadService() {
             def getBody(params) {}
-            def getConnection() {
+            def getConnection(params) {
                 [
                     request: { method, handler ->
                         requestCalled = true
@@ -28,7 +28,7 @@ class AsyncDownloadServiceTests extends GrailsUnitTestCase {
     void testGetJobParametersEmptyParams() {
         service = new AsyncDownloadService() {
             def getBody(params) {}
-            def getConnection() {}
+            def getConnection(params) {}
         }
 
         def testParams = [jobParameters: ""]

--- a/test/unit/au/org/emii/portal/WpsServiceTests.groovy
+++ b/test/unit/au/org/emii/portal/WpsServiceTests.groovy
@@ -23,7 +23,7 @@ class WpsServiceTests extends GrailsUnitTestCase {
     }
 
     void testGetBody() {
-        def requestParams = [ typeName: 'an awesome layer', cqlFilter: 'some cql' ]
+        def params = [ jobParams: [ typeName: 'an awesome layer', cqlFilter: 'some cql' ] ]
         def called = false
 
         service.groovyPageRenderer = [
@@ -31,11 +31,11 @@ class WpsServiceTests extends GrailsUnitTestCase {
                 called = true
 
                 assertEquals '/wps/asyncRequest.xml', args.template
-                assertEquals requestParams, args.model
+                assertEquals params, args.model
             }
         ]
 
-        service.getBody(requestParams)
+        service.getBody(params)
 
         assertTrue called
     }

--- a/test/unit/au/org/emii/portal/WpsServiceTests.groovy
+++ b/test/unit/au/org/emii/portal/WpsServiceTests.groovy
@@ -1,0 +1,42 @@
+package au.org.emii.portal
+
+import grails.test.*
+
+class WpsServiceTests extends GrailsUnitTestCase {
+    WpsService service
+
+    @Override
+    void setUp() {
+        super.setUp()
+
+        service = new WpsService()
+
+    }
+
+    void testGetConnection() {
+
+        def connection = service.getConnection([ server: 'myserver' ])
+
+        assertNotNull connection
+        assertEquals 'myserver', String.valueOf(connection.uri)
+        assertEquals groovyx.net.http.ContentType.XML, connection.contentType
+    }
+
+    void testGetBody() {
+        def requestParams = [ typeName: 'an awesome layer', cqlFilter: 'some cql' ]
+        def called = false
+
+        service.groovyPageRenderer = [
+            render: { args ->
+                called = true
+
+                assertEquals '/wps/asyncRequest.xml', args.template
+                assertEquals requestParams, args.model
+            }
+        ]
+
+        service.getBody(requestParams)
+
+        assertTrue called
+    }
+}


### PR DESCRIPTION
This PR makes it possible for the portal to send WPS requests to a WPS enabled geoserver, with a request such as the following:

```
curl "http://localhost:8080/aodn-portal/asyncDownload?aggregatorService=wps&jobParams.namespace=imos&jobParams.typeName=anmn_ts_timeseries_data&jobParams.cqlFilter=INTERSECTS(geom%2CPOLYGON((113.33%20-34.09%2C113.33%20-30.98%2C131.11%20-30.98%2C131.11%20-34.09%2C113.33%20-34.09)))%20AND%20TIME%20%26gt%3B%3D%20%272009-01-13T23%3A00%3A00Z%27%20AND%20TIME%20%26lt%3B%3D%20%272009-02-01T00%3A00%3A00Z%27&server=http://geoserver-systest.aodn.org.au/geoserver/wps"
```

Note: this request format has changed slightly due to c4d92003886cbc -  specifically the extra level of hierarchy in the request `jobParams`.
