### PR TITLE
Support collection availability in Geonetwork

### DIFF
--- a/src/test/javascript/portal/service/CatalogSearcherSpec.js
+++ b/src/test/javascript/portal/service/CatalogSearcherSpec.js
@@ -70,6 +70,23 @@ describe('Portal.service.CatalogSearcher', function() {
         });
     });
 
+    describe('extra search filters', function() {
+        it('when healthy=true passed', function() {
+            var url = "http://imos.aodn.org.au/aodn-portal/home?healthy=true";
+            expect(searcher._getCollectionAvailabilityParams(url)).toEqual({ filters: 'collectionavailability'});
+        });
+
+        it('when healthy=false passed', function() {
+            var url = "http://imos.aodn.org.au/aodn-portal/home?healthy=false";
+            expect(searcher._getCollectionAvailabilityParams(url)).toEqual({ filters: '!collectionavailability'});
+        });
+
+        it('when nothing passed', function() {
+            var url = "http://imos.aodn.org.au/aodn-portal/home";
+            expect(searcher._getCollectionAvailabilityParams(url)).toEqual({});
+        });
+    });
+
     describe('search', function() {
 
         describe('query', function() {

--- a/web-app/js/portal/service/CatalogSearcher.js
+++ b/web-app/js/portal/service/CatalogSearcher.js
@@ -212,6 +212,21 @@ Portal.service.CatalogSearcher = Ext.extend(Ext.util.Observable, {
         return deepestFacets;
     },
 
+    _getCollectionAvailabilityParams: function(url) {
+        var getParams = url.split("#")[0].split("?");
+        var params = Ext.urlDecode(getParams[1]);
+
+        if (params.healthy === "true") {
+            return { filters: "collectionavailability" };
+        }
+        else if (params.healthy === "false") {
+            return { filters: "!collectionavailability" };
+        }
+        else {
+            return {};
+        }
+    },
+
     _getParams: function(page) {
         //--- Add search defaults (e.g. map layers only)
         var params = Ext.apply({}, this.defaultParams);
@@ -240,6 +255,7 @@ Portal.service.CatalogSearcher = Ext.extend(Ext.util.Observable, {
 
         //--- Add required base parameters (e.g. fast=index)
         Ext.apply(params, this.baseParams);
+        Ext.apply(params, this._getCollectionAvailabilityParams(document.URL));
 
         return params;
     }


### PR DESCRIPTION
 * Do not pass any `filters=` values by default, for backward
   compatibility
 * Pass `filters=collectionavaiability` if passed `healthy=true`
   this will show all healthy layers
 * Pass `filters=!collectionavaiability` if passed `healthy=false`
   this will show all broken layers