### PR TITLE
Fix for #1985

### DIFF
--- a/web-app/js/portal/filter/ui/FilterGroupPanel.js
+++ b/web-app/js/portal/filter/ui/FilterGroupPanel.js
@@ -14,6 +14,7 @@ Portal.filter.ui.FilterGroupPanel = Ext.extend(Ext.Container, {
         this.loadingMessage = this._createLoadingMessageContainer();
         var config = Ext.apply({
             autoDestroy: true,
+            autoHeight: true,
             cls: 'filterGroupPanel',
             items: [
                 this.loadingMessage


### PR DESCRIPTION
FilterGroupPanel has height 'auto' to avoid excess spacing at the bottom.