### PR TITLE
Fixes #1999

### DIFF
--- a/src/test/javascript/portal/data/DataCollectionSpec.js
+++ b/src/test/javascript/portal/data/DataCollectionSpec.js
@@ -8,9 +8,11 @@
 describe("Portal.data.DataCollection", function() {
 
     var dataCollection;
+    var isNcwmsSpy;
 
     beforeEach(function() {
         spyOn(Portal.data.DataCollection.prototype, '_loadFilters');
+        isNcwmsSpy = spyOn(Portal.data.DataCollection.prototype, 'isNcwms').andReturn(true);
         spyOn(Portal.utils.ObservableUtils, 'makeObservable');
         dataCollection = Portal.data.DataCollection.fromMetadataRecord({});
     });
@@ -20,8 +22,16 @@ describe("Portal.data.DataCollection", function() {
             expect(Portal.utils.ObservableUtils.makeObservable).toHaveBeenCalled();
         });
 
-        it('starts the Filters loading', function() {
+        it('starts the Filters loading if non-ncwms', function() {
+            isNcwmsSpy.andReturn(false);
+            dataCollection = Portal.data.DataCollection.fromMetadataRecord({});
             expect(dataCollection._loadFilters).toHaveBeenCalled();
+        });
+
+        it("doesn't start the Filters loading if non-ncwms", function() {
+            isNcwmsSpy.andReturn(true);
+            dataCollection = Portal.data.DataCollection.fromMetadataRecord({});
+            expect(dataCollection._loadFilters).not.toHaveBeenCalled();
         });
     });
 

--- a/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
@@ -12,6 +12,8 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
     var template;
 
     beforeEach(function() {
+        spyOn(Portal.data.DataCollection.prototype, 'isNcwms');
+
         facetedSearchDataView = new Portal.search.FacetedSearchResultsDataView({
             dataCollectionStore: {
                 getByUuid: noOp,

--- a/web-app/js/portal/data/DataCollection.js
+++ b/web-app/js/portal/data/DataCollection.js
@@ -24,11 +24,6 @@ Portal.data.DataCollection = function() {
     };
 
     constructor.prototype._loadFilters = function() {
-
-        if (this.isNcwms()) {
-            return;
-        }
-
         var filterService = new Portal.filter.FilterService();
         filterService.loadFilters(this, this._onFiltersLoadSuccess, this._onFiltersLoadFailure, this);
     };
@@ -144,7 +139,9 @@ Portal.data.DataCollection.fromMetadataRecord = function(metadataRecord) {
 
     Portal.utils.ObservableUtils.makeObservable(dataCollection);
 
-    dataCollection._loadFilters();
+    if (!dataCollection.isNcwms()) {
+        dataCollection._loadFilters();
+    }
 
     return dataCollection;
 };

--- a/web-app/js/portal/data/DataCollection.js
+++ b/web-app/js/portal/data/DataCollection.js
@@ -24,6 +24,11 @@ Portal.data.DataCollection = function() {
     };
 
     constructor.prototype._loadFilters = function() {
+
+        if (this.isNcwms()) {
+            return;
+        }
+
         var filterService = new Portal.filter.FilterService();
         filterService.loadFilters(this, this._onFiltersLoadSuccess, this._onFiltersLoadFailure, this);
     };


### PR DESCRIPTION
[![Alt text for your video](http://img.youtube.com/vi/n1EymCZSqFg/0.jpg)](http://www.youtube.com/watch?v=n1EymCZSqFg)

Don't attempt to load filters from the server for NcWms - currently, they are hard-coded in the client and trying to load from server just wipes out the desired filters with an empty list.  This in turn causes problems such as #1999.

Note that the proper fix is to treat NcWms collections like any other, i.e.:

* load filters from server
* model filters in exactly the same way as non-ncwms
* use the same UI components as non-ncwms

This can be reverted when *all* collections, [NcWms and non-NcWms, are treated the same as far as filtering is concerned](https://github.com/aodn/backlog/issues/191).