### PR TITLE
Fixes #2019

### DIFF
--- a/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
+++ b/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
@@ -25,10 +25,10 @@ describe('Portal.cart.NcWmsInjector', function() {
                     isNcwmsParams: true,
                     dateRangeStart: startDate,
                     dateRangeEnd: endDate,
-                    latitudeRangeStart: '-10',
-                    latitudeRangeEnd: '40',
-                    longitudeRangeEnd: '180',
-                    longitudeRangeStart: '150'
+                    latitudeRangeStart: 0,
+                    latitudeRangeEnd: 40,
+                    longitudeRangeEnd: 180,
+                    longitudeRangeStart: -150
                 },
                 {
                     type: Portal.filter.DateFilter,
@@ -57,6 +57,7 @@ describe('Portal.cart.NcWmsInjector', function() {
 
             var entry = injector._getDataFilterEntry(dataCollection);
             expect(entry).toContain(OpenLayers.i18n("spatialExtentHeading"));
+            expect(entry).toContain('-150W 0S 180E 40N');
         });
 
         it('indicates temporal range', function() {

--- a/web-app/js/portal/cart/NcWmsInjector.js
+++ b/web-app/js/portal/cart/NcWmsInjector.js
@@ -12,7 +12,7 @@ Portal.cart.NcWmsInjector = Ext.extend(Portal.cart.BaseInjector, {
         var areaString = "";
         var dateString = "";
 
-        if (params && params.latitudeRangeStart) {
+        if (params && params.latitudeRangeStart != undefined) {
 
             var bboxString = String.format(
                 '{0},{1},{2},{3}',


### PR DESCRIPTION
The test for whether a spatial extent is enterred used truthiness and therefor
a value of 0 was considered false (e.g. not set). By checking against undefined
we allow people to enter a latitude of 0.