### PR TITLE
Tiny modifications required to work with ncwms plugin

### DIFF
--- a/src/test/javascript/portal/ui/openlayers/layer/NcWmsSpec.js
+++ b/src/test/javascript/portal/ui/openlayers/layer/NcWmsSpec.js
@@ -44,7 +44,7 @@ describe("OpenLayers.Layer.NcWms", function() {
 
         it('time specified', function() {
             cachedLayer.setTime(time);
-            expect(cachedLayer.params['TIME']).toBe(time.utc().format('YYYY-MM-DDTHH:mm:ss.SSS'));
+            expect(cachedLayer.params['TIME']).toBe(time.utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
         });
     });
 

--- a/web-app/js/portal/ui/openlayers/layer/NcWms.js
+++ b/web-app/js/portal/ui/openlayers/layer/NcWms.js
@@ -21,6 +21,7 @@ OpenLayers.Layer.NcWms = OpenLayers.Class(OpenLayers.Layer.WMS, {
 
         this.pendingRequests = new Portal.utils.Set();
 
+        params['SERVICE'] = "ncwms";
         OpenLayers.Layer.WMS.prototype.initialize.apply(this, [name, url, params, options]);
 
         this._setExtraLayerInfoFromNcwms();
@@ -273,7 +274,7 @@ OpenLayers.Layer.NcWms = OpenLayers.Class(OpenLayers.Layer.WMS, {
     },
 
     _getTimeParameter: function(dateTime) {
-        return dateTime.clone().utc().format('YYYY-MM-DDTHH:mm:ss.SSS');
+        return dateTime.clone().utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]');
     },
 
     _getExtraLayerInfoFromNcwms: function() {


### PR DESCRIPTION
 * Add Z when requesting time to denote UTC (thredds need that)
 * Pass service=ncwms, so Geoserver uses ncwms plugin instead of
   the default wms plugin. Doesn't affect regular ncwms
   interaction