### PR TITLE
Encode ncwms layer name

### DIFF
--- a/src/groovy/au/org/emii/portal/wms/NcwmsServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/NcwmsServer.groovy
@@ -34,7 +34,11 @@ class NcwmsServer extends WmsServer {
         // Assume for NcWMS only date can be the filter request
         def date = filter
 
-        def urlFilterValues = String.format('%1$s?layerName=%2$s&REQUEST=GetMetadata&item=timesteps&day=%3$s', server, layer, date)
+        def urlFilterValues = String.format('%1$s?layerName=%2$s&REQUEST=GetMetadata&item=timesteps&day=%3$s',
+            server,
+            URLEncoder.encode(layer, "UTF-8"),
+            date
+        )
         def json = JSON.parse(getUrlContent(urlFilterValues))
 
         def filterValues = parseTimeSteps(date, json.timesteps)
@@ -74,6 +78,9 @@ class NcwmsServer extends WmsServer {
     }
 
     private String getMetadataUrl(server, layer) {
-        return String.format('%1$s?layerName=%2$s&REQUEST=GetMetadata&item=layerDetails', server, layer)
+        return String.format('%1$s?layerName=%2$s&REQUEST=GetMetadata&item=layerDetails',
+            server,
+            URLEncoder.encode(layer, "UTF-8")
+        )
     }
 }

--- a/web-app/js/portal/ui/openlayers/layer/NcWms.js
+++ b/web-app/js/portal/ui/openlayers/layer/NcWms.js
@@ -282,7 +282,7 @@ OpenLayers.Layer.NcWms = OpenLayers.Class(OpenLayers.Layer.WMS, {
         return String.format(
             "{0}?layerName={1}&REQUEST=GetMetadata&item=layerDetails",
             this.url,
-            this.params.LAYERS
+            encodeURIComponent(this.params.LAYERS)
         );
     },
 
@@ -290,7 +290,7 @@ OpenLayers.Layer.NcWms = OpenLayers.Class(OpenLayers.Layer.WMS, {
         return String.format(
             "layer/getFilters?serverType=ncwms&server={0}&layer={1}",
             encodeURIComponent(this.url),
-            this.params.LAYERS
+            encodeURIComponent(this.params.LAYERS)
         );
     },
 
@@ -298,7 +298,7 @@ OpenLayers.Layer.NcWms = OpenLayers.Class(OpenLayers.Layer.WMS, {
         return String.format(
             "layer/getStyles?serverType=ncwms&server={0}&layer={1}",
             encodeURIComponent(this.url),
-            this.params.LAYERS
+            encodeURIComponent(this.params.LAYERS)
         );
     },
 
@@ -306,7 +306,7 @@ OpenLayers.Layer.NcWms = OpenLayers.Class(OpenLayers.Layer.WMS, {
         return String.format(
             "layer/getFilterValues?serverType=ncwms&server={0}&layer={1}&filter={2}",
             encodeURIComponent(this.url),
-            this.params.LAYERS,
+            encodeURIComponent(this.params.LAYERS),
             date.clone().startOf('day').toISOString()
         );
     },


### PR DESCRIPTION
Ncwms layer name will look like `workspace:layer#time,file_url/variable`.

This introduces the `#`, which will allow users to control from
metadata which `time` and `file_url` columns names they would
like to use when using the abomination ncwms controller.

After introducing the `#`, it means we need to encode the layer
name properly in JS land. The server side changes ensure that
when accessing geoserver backends (ncwms abomination controller),
the layer name will be encoded.

This does not affect regular ncwms layers where the layer does not
need to be encoded.