### PR TITLE
URL encode layer in GetLegendGraphic

### DIFF
--- a/web-app/js/portal/details/StylePanel.js
+++ b/web-app/js/portal/details/StylePanel.js
@@ -185,7 +185,7 @@ Portal.details.StylePanel = Ext.extend(Ext.Container, {
         }
 
         opts += "&REQUEST=GetLegendGraphic"
-             +  "&LAYER=" + layer.params.LAYERS
+             +  "&LAYER=" + encodeURIComponent(layer.params.LAYERS),
              +  "&FORMAT=" + layer.params.FORMAT;
 
         if (layer && layer.server && layer.server.wmsVersion) {


### PR DESCRIPTION
Amend 41b46c4, also GetLegendGraphic needs to encode the layer as
it will contain `#`s.