### PR TITLE
Send correct click point values to GFI requests

### DIFF
--- a/src/test/javascript/portal/ui/FeatureInfoPopupSpec.js
+++ b/src/test/javascript/portal/ui/FeatureInfoPopupSpec.js
@@ -87,17 +87,17 @@ describe("Portal.ui.FeatureInfoPopup", function()
    });
 
     describe("_clickPoint", function(){
-        it("returns integer x and y values", function()
+        it("returns original integer x and y values", function()
         {
-            featureInfoPopup.map.getViewPortPxFromLonLat = function() {
-                var position = {};
-                position.x = 30.1;
-                position.y = 30.1;
-                return position;
-            };
+            featureInfoPopup._display = noOp;
+            featureInfoPopup._setLocationString = noOp;
+            featureInfoPopup._handleDepthService = noOp;
+            featureInfoPopup._handleLayers = noOp;
 
-            expect(featureInfoPopup._clickPoint().x).toEqual(30);
-            expect(featureInfoPopup._clickPoint().y).toEqual(30);
+            featureInfoPopup.findFeatures({xy: {x: 1298, y: 241}});
+
+            expect(featureInfoPopup._clickPoint().x).toEqual(1298);
+            expect(featureInfoPopup._clickPoint().y).toEqual(241);
         });
     });
 

--- a/web-app/js/portal/ui/FeatureInfoPopup.js
+++ b/web-app/js/portal/ui/FeatureInfoPopup.js
@@ -71,7 +71,9 @@ Portal.ui.FeatureInfoPopup = Ext.extend(GeoExt.Popup, {
     },
 
     findFeatures: function(event) {
+
         this.location = this.map.getLonLatFromViewPortPx(event.xy);
+        this.locationXy = event.xy;
 
         this._setLocationString();
         this._display();
@@ -165,8 +167,7 @@ Portal.ui.FeatureInfoPopup = Ext.extend(GeoExt.Popup, {
     },
 
     _clickPoint: function() {
-        var pixel = this.map.getViewPortPxFromLonLat(this.location);
-        return { x: Math.round(pixel.x), y: Math.round(pixel.y)}
+        return this.locationXy;
     },
 
     _collectUniqueLayers: function() {
@@ -235,7 +236,7 @@ Portal.ui.FeatureInfoPopup = Ext.extend(GeoExt.Popup, {
         return result;
     },
 
-    _display: function(clickLocation) {
+    _display: function() {
         this.doLayout();
         this.show();
     },


### PR DESCRIPTION
By itself this does not solve the issue that the GFI requests dont seem to return hits often enough. It does solve the issue where requests returned server errors as the value for the 'X' click point became a negative number and this always failed. Possibly upgrades to Geoserver and or Openlayers produced this outcome?
#### To Test
The error can be seen by adding the code below to the `findFeatures` function in `FeatureInfoPopup.js`. Whenever x is negative there will have been a 500 error returned. _Click on the right of the map_
```
console.log(event.xy);
this.loc = this.map.getLonLatFromViewPortPx(event.xy);
var pix = this.map.getViewPortPxFromLonLat(this.loc);
console.log(this.loc);
console.log("x: " + pix.x );
```

#### Note
This bug also comes from styling issues where lines are styled too small for the feature to be considered in GFI responses. Reported at https://github.com/aodn/content/issues/154