### PR TITLE
Controller improvements

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/WpsController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/WpsController.groovy
@@ -18,7 +18,7 @@ class WpsController extends HostVerifyingController {
 
             if (execResponse != null) {
                 if (_error(execResponse)) {
-                    _renderExecutionFailed(execResponse)
+                    _renderExecutionFailed()
                 }
                 else {
                     params.status = "Preparing download"
@@ -92,7 +92,7 @@ class WpsController extends HostVerifyingController {
         it.'**'.find{node -> node.name() == 'Reference'}?.@href
     }
 
-    def _renderExecutionFailed(execResponse) {
+    def _renderExecutionFailed() {
         render(
             view: 'show',
             model: [

--- a/src/groovy/au/org/emii/portal/proxying/HostVerifyingController.groovy
+++ b/src/groovy/au/org/emii/portal/proxying/HostVerifyingController.groovy
@@ -1,0 +1,22 @@
+package au.org.emii.portal.proxying
+
+import static au.org.emii.portal.HttpUtils.Status.HTTP_400_BAD_REQUEST
+import static au.org.emii.portal.HttpUtils.Status.HTTP_403_FORBIDDEN
+
+abstract class HostVerifyingController {
+    def hostVerifier
+
+    def ifAllowed = { url, closure ->
+
+        if (!url) {
+            render text: "No URL supplied", contentType: "text/html", encoding: "UTF-8", status: HTTP_400_BAD_REQUEST
+        }
+        else if (!hostVerifier.allowedHost(url)) {
+            log.info "Requests to the url '$url' are not allowed"
+            render text: "Host for address '$url' not allowed", contentType: "text/html", encoding: "UTF-8", status: HTTP_403_FORBIDDEN
+        }
+        else {
+            closure()
+        }
+    }
+}

--- a/src/groovy/au/org/emii/portal/proxying/RequestProxyingController.groovy
+++ b/src/groovy/au/org/emii/portal/proxying/RequestProxyingController.groovy
@@ -7,9 +7,7 @@ import javax.servlet.http.Cookie
 import static au.org.emii.portal.HttpUtils.Status.*
 import static au.org.emii.portal.HttpUtils.buildAttachmentHeaderValueWithFilename
 
-abstract class RequestProxyingController {
-
-    def hostVerifier
+abstract class RequestProxyingController extends HostVerifyingController {
 
     def index = {
 
@@ -22,14 +20,7 @@ abstract class RequestProxyingController {
 
         def url = params.url
 
-        if (!url) {
-            render text: "No URL supplied", contentType: "text/html", encoding: "UTF-8", status: HTTP_400_BAD_REQUEST
-        }
-        else if (!hostVerifier.allowedHost(url)) {
-            log.info "Proxy: The url $url was not allowed"
-            render text: "Host for address '$url' not allowed", contentType: "text/html", encoding: "UTF-8", status: HTTP_403_FORBIDDEN
-        }
-        else {
+        ifAllowed(url) {
             _performProxying(paramProcessor, streamProcessor, fieldName, url)
         }
     }

--- a/test/unit/au/org/emii/portal/WpsControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/WpsControllerTests.groovy
@@ -6,6 +6,15 @@ import org.joda.time.DateTime
 
 class WpsControllerTests extends ControllerUnitTestCase {
 
+    @Override
+    void setUp() {
+        super.setUp()
+
+        controller.hostVerifier = [
+            allowedHost: { it =~ '.*allowedhost.*' }
+        ]
+    }
+
     void testRenderExecutionStatus() {
         controller.params.uuid = '1234'
         controller.params.status = 'great'
@@ -53,26 +62,20 @@ class WpsControllerTests extends ControllerUnitTestCase {
 
     void testJobComplete() {
 
-        controller.metaClass._performProxyingIfAllowed = { -> [name: {-> "notAnException" }]}
+        controller.metaClass._getExecutionStatusResponse = { [name: {-> "notAnException" }]}
 
         def notifyViaEmailCalled = false
-        def notifyViaEmailParams
         def url = "http://allowedhost.com/aproxyurl"
 
         controller.wpsService = [
-            _notifyDownloadViaEmail: { params ->
+            _notifyDownloadViaEmail: {
                 notifyViaEmailCalled = true
-                notifyViaEmailParams = params
             },
-            _getExecutionStatusUrl: {return url},
+            _getExecutionStatusUrl: {return url}
         ]
 
         controller.jobComplete(mockParams)
 
         assertTrue notifyViaEmailCalled
-        assertEquals(
-            url,
-            notifyViaEmailParams.url
-        )
     }
 }

--- a/test/unit/au/org/emii/portal/proxying/HostVerifyingControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/proxying/HostVerifyingControllerTests.groovy
@@ -1,0 +1,45 @@
+package au.org.emii.portal.proxying
+
+import grails.test.GrailsUnitTestCase
+
+import static au.org.emii.portal.HttpUtils.Status.*
+
+class HostVerifyingControllerTests extends GrailsUnitTestCase {
+
+    def controller
+
+    @Override
+    void setUp() {
+        super.setUp()
+
+        mockController(HostVerifyingController)
+
+        controller = new HostVerifyingController() {}
+        controller.hostVerifier = [
+            allowedHost: { it == 'http://known_site/' }
+        ]
+    }
+
+    void testUrlWithKnownServerAllowed() {
+
+        def called = false
+
+        controller.ifAllowed('http://known_site/') {
+            called = true
+        }
+
+        assertTrue called
+    }
+
+    void testUrlWithUnknownServerPrevented() {
+
+        def called = false
+
+        controller.ifAllowed('http://random_site/') {
+            called = true
+        }
+
+        assertFalse called
+        assertEquals HTTP_403_FORBIDDEN, controller.renderArgs.status
+    }
+}


### PR DESCRIPTION
The WPS controller previously extended from RequestProxyingController to get the known servers URL verification for free. However, it was a bit messy because we were overwriting internal logic because it isn't really proxying requests for the Portal client. So I extracted the host-validation logic into a new controller so that controllers can just subclass that for the behaviour.

So instead of (mis)using `_performProxyingIfAllowed()` we can just use the new method `_ifAllowed(url)`.