### PR TITLE
Minimaps use zoomToExtent function now

### DIFF
--- a/src/test/javascript/portal/search/FacetedSearchResultsMiniMapSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsMiniMapSpec.js
@@ -73,16 +73,15 @@ describe("Portal.search.FacetedSearchResultsMiniMap", function() {
             expect(miniMap.render).toHaveBeenCalledWith(mapContainerId);
         });
 
-        it('calls setCenter if bounds are set', function() {
+        it('calls zoomToExtent if bounds are set', function() {
             spyOn(miniMap.metadataExtent, 'getBounds').andReturn(new OpenLayers.Bounds(40, -40, 80, 40));
             miniMap._renderAndPosition();
-            expect(miniMap.setCenter).toHaveBeenCalled();
+            expect(miniMap.zoomToExtent).toHaveBeenCalled();
         });
 
         it('calls zoomToExtent if bounds are not set', function() {
             spyOn(miniMap.metadataExtent, 'getBounds').andReturn(false);
             miniMap._renderAndPosition();
-            expect(miniMap.zoomToExtent).toHaveBeenCalled();
         });
     });
 

--- a/web-app/js/portal/search/FacetedSearchResultsMiniMap.js
+++ b/web-app/js/portal/search/FacetedSearchResultsMiniMap.js
@@ -32,15 +32,12 @@ Portal.search.FacetedSearchResultsMiniMap = Ext.extend(OpenLayers.Map, {
         if (Ext.get(this.mapContainerId)) {
 
             this.render(this.mapContainerId);
-            if (this.metadataExtent.getBounds()) {
-                this.setCenter(
-                    this._getCenterLonLat(),
-                    this._calculateZoomLevel(this.metadataExtent.getBounds())
-                );
+
+            var extent = this.metadataExtent.getBounds();
+            if (!extent) {
+                extent = new OpenLayers.Bounds.fromString(Portal.app.appConfig.portal.defaultDatelineZoomBbox);
             }
-            else {
-                this.zoomToExtent(new OpenLayers.Bounds.fromString(Portal.app.appConfig.portal.defaultDatelineZoomBbox));
-            }
+            this.zoomToExtent(extent);
         }
     },
 
@@ -63,17 +60,5 @@ Portal.search.FacetedSearchResultsMiniMap = Ext.extend(OpenLayers.Map, {
             zoomLevel = 4;
         }
         return zoomLevel;
-    },
-
-    _getCenterLonLat: function() {
-        var LONGITUDE_OF_AUSTRALIA = 90;
-        var bounds = this.metadataExtent.getBounds();
-        var centerLonLat = bounds.getCenterLonLat();
-
-        if (this.getZoomForExtent(bounds) == 0) {
-            centerLonLat.lon = LONGITUDE_OF_AUSTRALIA;
-        }
-
-        return centerLonLat;
     }
 });


### PR DESCRIPTION
Essentially the the bug is that the whole extent of the collection should now show for all collections. Still reliant on Openlayers to do the best fit

Fixes #2048 