### PR TITLE
WPS downloads now have a popup as soon as job requested

### DIFF
--- a/src/test/javascript/portal/cart/DownloaderSpec.js
+++ b/src/test/javascript/portal/cart/DownloaderSpec.js
@@ -11,6 +11,7 @@ describe("Portal.cart.Downloader", function() {
 
     beforeEach(function() {
         downloader = new Portal.cart.Downloader();
+        downloader.messageBox = {show: noOp};
         wfsDownloadUrl = 'http://download';
         generateUrlCallback = jasmine.createSpy('generateUrl').andReturn(wfsDownloadUrl);
         downloadToken = 1234;
@@ -51,6 +52,7 @@ describe("Portal.cart.Downloader", function() {
             var wfsDownloadUrl = 'http://someurl';
             var params = {};
 
+            spyOn(Ext.Msg, 'show');
             spyOn(Ext.Ajax, 'request');
 
             downloader._downloadAsynchronously(collection, wfsDownloadUrl, params);
@@ -90,7 +92,7 @@ describe("Portal.cart.Downloader", function() {
 
         beforeEach(function() {
             downloadUrl = "http://downloadurl";
-
+            spyOn(Ext.Msg, 'show');
             spyOn(downloader, '_constructProxyUrl').andReturn(downloadUrl);
             spyOn($, 'fileDownload');
         });

--- a/web-app/css/imosTheme.css
+++ b/web-app/css/imosTheme.css
@@ -357,3 +357,6 @@ ul.x-tab-strip-top {
 dt {
     padding-top: 10px;
 }
+.x-window-plain .x-window-body {
+    background-color: #fefefe !important;
+}

--- a/web-app/js/portal/cart/Downloader.js
+++ b/web-app/js/portal/cart/Downloader.js
@@ -3,6 +3,9 @@ Ext.namespace('Portal.cart');
 Portal.cart.Downloader = Ext.extend(Ext.util.Observable, {
 
     constructor: function(config) {
+
+        this.ALERTWIDTH =  500;
+
         this.addEvents('downloadrequested', 'downloadstarted', 'downloadfailed');
 
         Ext.apply(this, config);
@@ -96,6 +99,12 @@ Portal.cart.Downloader = Ext.extend(Ext.util.Observable, {
     _downloadAsynchronously: function(collection, downloadUrl, params) {
         log.debug('downloading asynchronously', downloadUrl);
 
+        this.messageBox = Ext.Msg.show({
+            title: OpenLayers.i18n('asyncDownloadPanelTitleLoading'),
+            msg: OpenLayers.i18n('asyncDownloadSuccessPendingMsg'),
+            width: this.ALERTWIDTH
+        });
+
         Ext.Ajax.request({
             url: downloadUrl,
             scope: this,
@@ -107,13 +116,14 @@ Portal.cart.Downloader = Ext.extend(Ext.util.Observable, {
     },
 
     _onAsyncDownloadRequestSuccess: function(response, params) {
-        Ext.Msg.alert(
-            OpenLayers.i18n('asyncDownloadPanelTitle'),
-            OpenLayers.i18n('asyncDownloadSuccessMsg', {
+        this.messageBox.show({
+            title: OpenLayers.i18n('asyncDownloadPanelTitle'),
+            msg: OpenLayers.i18n('asyncDownloadSuccessMsg', {
                 email: params.emailAddress,
                 serviceMessage: this._getServiceMessage(params.serviceResponseHandler, response.responseText)
-            })
-        );
+            }),
+            width: this.ALERTWIDTH
+        });
     },
 
     _getServiceMessage: function(serviceResponseHandler, response) {
@@ -121,10 +131,11 @@ Portal.cart.Downloader = Ext.extend(Ext.util.Observable, {
     },
 
     _onAsyncDownloadRequestFailure: function() {
-        Ext.Msg.alert(
-            OpenLayers.i18n('asyncDownloadPanelTitle'),
-            OpenLayers.i18n('asyncDownloadErrorMsg')
-        );
+        this.messageBox.show({
+            title: OpenLayers.i18n('asyncDownloadPanelTitle'),
+            msg: OpenLayers.i18n('asyncDownloadErrorMsg'),
+            width: this.ALERTWIDTH
+        });
     },
 
     _sanitiseFilename: function(str) {

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -186,7 +186,9 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
     addAnother: 'Add another filter - where possible',
 
     // Async Downloads
-    asyncDownloadPanelTitle: 'Subset',
+    asyncDownloadPanelTitleLoading: 'Requesting subset ...',
+    asyncDownloadPanelTitle: 'Subset job status',
+    asyncDownloadSuccessPendingMsg: "Waiting for your job to register with our servers.....",
     asyncDownloadSuccessMsg: 'Your subsetting job has been created. Processing commenced.<br /><br />When the job is complete we will send an email to <i>${email}</i> with download instructions.<br /><br />${serviceMessage}NB. Subsetting jobs can vary considerably in how long they take, from minutes to hours. Both the number of source files and the selected area can affect how long a job takes to run.',
     asyncDownloadErrorMsg: 'Unable to create subsetting job. Please re-check the parameters you provided and try again.',
     asyncServiceMsg: "<a class='external' target='_blank' href='${url}'>Follow the progress of your job</a><br /><br />",


### PR DESCRIPTION
Opens an Ext popup as soon as the user clicks the button to request a WPS download. This informs the user s that something happened. When the job is successfully registered (or failed) the same popup will be used.
Although Ext does a nice job of closing old popups for us, it is probably fractionally speedier to reuse the same this.messageBox. It also keeps the same width.
