### PR TITLE
Fixes #2107

### DIFF
--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -36,7 +36,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
             '            {[this.getParametersAsHtml(values)]}',
             '        </div>',
             '        <div class="floatLeft resultsIconContainer">',
-            '            <img class="floatRight" src="{[this.getIconUrl(values)]}" max-height="50" alt="Icon of metadata record holder" />',
+            '            <img class="floatRight" src="{[this.getIconUrl(values)]}" height="50" max-height="50" alt="Icon of metadata record holder" />',
             '        </div>',
             '    </div>',
             '</div>',


### PR DESCRIPTION
`max-height` is a bit too new for most browsers, but will override, when present, the old school `height` attribute now added by this pull request