### PR TITLE
Allow bypassing HostVerifier

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -138,6 +138,10 @@ environments {
         grails.serverURL = "http://${localhostAddress}:8080/$appName"
         gogoduck.url = "http://${localhostAddress}:8300/go-go-duck"
         geonetwork.url = "https://catalogue-123.aodn.org.au/geonetwork"
+
+        // Set to true if you want to test interaction with new servers. This turns
+        // your portal instance into an open proxy and can be dangerous.
+        allowAnyHost = true
     }
 
     test {

--- a/src/groovy/au/org/emii/portal/HostVerifier.groovy
+++ b/src/groovy/au/org/emii/portal/HostVerifier.groovy
@@ -12,6 +12,9 @@ class HostVerifier {
     def allowedHosts = null
 
     def allowedHost(address) {
+        if (grailsApplication.config.allowAnyHost) {
+            return true
+        }
 
         initializeAllowedHostsIfNeeded()
 


### PR DESCRIPTION
If `config.allowAnyHost` is set to true, bypass HostVerifier and allow
interaction with any backend host.