### PR TITLE
Fixes #2121

### DIFF
--- a/web-app/js/portal/search/GeoSelectionPanel.js
+++ b/web-app/js/portal/search/GeoSelectionPanel.js
@@ -45,6 +45,8 @@ Portal.search.GeoSelectionPanel = Ext.extend(Ext.Panel, {
                 new Ext.Container({
                     layout: 'hbox',
                     cls: "geoSelectionPanelbuttons",
+                    autoWidth: true,
+                    autoHeight: true,
                     items: [
                         this.goButton = new Ext.Button({
                             text:OpenLayers.i18n("goButton")


### PR DESCRIPTION
Let the browser not EXT position the controls, complementing the CSS rules which are overlaying the controls over the map