### PR TITLE
Citation Feature: populate download confirmation from metadata record

### DIFF
--- a/src/test/javascript/portal/cart/DownloadConfirmationWindowSpec.js
+++ b/src/test/javascript/portal/cart/DownloadConfirmationWindowSpec.js
@@ -11,10 +11,18 @@ describe("Portal.cart.DownloadConfirmationWindow", function() {
     var downloadFilename = "imos:argo profiles";
     var superclass;
 
+    var mockCollection = {
+        getMetadataRecord: returns({ data: '' })
+    };
+
     beforeEach(function() {
 
         confirmationWindow = new Portal.cart.DownloadConfirmationWindow();
         superclass = Portal.cart.DownloadConfirmationWindow.superclass;
+
+        // Mock UI-related methods invoked in show()
+        confirmationWindow.contentPanel.update = function() {};
+        confirmationWindow.syncShadow = undefined;
 
         spyOn(superclass, "show");
         spyOn(superclass, "hide");
@@ -24,7 +32,7 @@ describe("Portal.cart.DownloadConfirmationWindow", function() {
 
         beforeEach(function() {
 
-            confirmationWindow.show(downloadUrl, downloadFilename);
+            confirmationWindow.show({ collection: mockCollection });
         });
 
         it('shows window', function() {
@@ -43,7 +51,7 @@ describe("Portal.cart.DownloadConfirmationWindow", function() {
             });
 
             it('shows when required', function() {
-                confirmationWindow.show({ collectEmailAddress: true });
+                confirmationWindow.show({ collectEmailAddress: true, collection: mockCollection });
                 expect(confirmationWindow.downloadEmailPanel.show).toHaveBeenCalled();
                 expect(confirmationWindow.downloadEmailPanel.hide).not.toHaveBeenCalled();
 
@@ -52,7 +60,7 @@ describe("Portal.cart.DownloadConfirmationWindow", function() {
             });
 
             it('hides when required', function() {
-                confirmationWindow.show({ collectEmailAddress: false });
+                confirmationWindow.show({ collectEmailAddress: false, collection: mockCollection });
                 expect(confirmationWindow.downloadEmailPanel.show).not.toHaveBeenCalled();
                 expect(confirmationWindow.downloadEmailPanel.hide).toHaveBeenCalled();
 

--- a/web-app/js/portal/cart/DownloadConfirmationWindow.js
+++ b/web-app/js/portal/cart/DownloadConfirmationWindow.js
@@ -12,13 +12,8 @@ Portal.cart.DownloadConfirmationWindow = Ext.extend(Ext.Window, {
     initComponent: function() {
 
         // Content
-        var contentPanel = new Ext.Panel({
-            html: OpenLayers.i18n(
-                'downloadConfirmationWindowContent', {
-                    downloadDatasetHelpUrl: Portal.app.appConfig.help.downloadDatasetUrl,
-                    helpUrl: Portal.app.appConfig.help.url
-                }
-            ),
+        this.contentPanel = new Ext.Panel({
+            tpl: OpenLayers.i18n('downloadConfirmationWindowContent'),
             width: 450,
             resizable: false
         });
@@ -72,7 +67,7 @@ Portal.cart.DownloadConfirmationWindow = Ext.extend(Ext.Window, {
                     this.downloadEmailPanel,
                     this.downloadChallengePanel,
                     {xtype: 'spacer', height: 20},
-                    contentPanel
+                    this.contentPanel
                 ],
                 buttons: [this.downloadButton, cancelButton],
                 keys: [
@@ -115,6 +110,15 @@ Portal.cart.DownloadConfirmationWindow = Ext.extend(Ext.Window, {
         this.onAcceptCallback = params.onAccept;
 
         Portal.cart.DownloadConfirmationWindow.superclass.show.call(this);
+
+        var metadataRecord = params.collection.getMetadataRecord();
+        this.contentPanel.update(metadataRecord.data);
+
+        // Undocumented, but works around a Ext bug where the shadow
+        // doesn't resize when the content does:
+        if (typeof(this.syncShadow) === 'function') {
+            this.syncShadow();
+        }
     },
 
     _showEmailPanelIfNeeded: function(params) {

--- a/web-app/js/portal/cart/DownloadPanel.js
+++ b/web-app/js/portal/cart/DownloadPanel.js
@@ -186,6 +186,9 @@ Portal.cart.DownloadPanel = Ext.extend(Ext.Panel, {
 
         var self = this;
 
+        params = params || {};
+        params.collection = collection;
+
         params.onAccept = function(callbackParams) {
             self.downloader.download(collection, generateUrlCallbackScope, generateUrlCallback, callbackParams);
             trackDownloadUsage(

--- a/web-app/js/portal/data/MetadataRecord.js
+++ b/web-app/js/portal/data/MetadataRecord.js
@@ -92,6 +92,27 @@ Portal.data.MetadataRecord = function() {
         name: 'organisation'
     });
 
+    var resourceConstraintsField = new Portal.data.ChildElementsField({
+        name: 'resourceConstraints'// ,
+        // convert: function(v, record) {
+        //     // Do we want to extract these individually and ignore
+        //     // resourceConstraints (which groups jurisdictionlink,
+        //     // licenseLink, etc), or just treat everything separately?
+        // }
+    });
+
+    var attrConstrField = new Portal.data.ChildElementsField({
+        name: 'attrConstr'
+    });
+
+    var otherConstrField = new Portal.data.ChildElementsField({
+        name: 'otherConstr'
+    });
+
+    var useLimitationField = new Portal.data.ChildElementsField({
+        name: 'useLimitation'
+    });
+
     function convertXmlToLinks(v, record) {
         var linkElems = Ext.DomQuery.jsSelect('link', record);
         var links = [];
@@ -140,6 +161,15 @@ Portal.data.MetadataRecord = function() {
         parameterField,
         'platform',
         organisationField,
+        resourceConstraintsField,
+        'jurisdictionLink',
+        'licenseLink',
+        'licenseName',
+        'imageLink',
+        attrConstrField,
+        otherConstrField,
+        'otherCitation',
+        useLimitationField,
         { name: 'temporalExtentBegin', mapping: 'tempExtentBegin' },
         { name: 'temporalExtentEnd', mapping: 'tempExtentEnd' },
         linksField,

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -125,15 +125,24 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
     downloadConfirmationWindowTitle: 'Data Download',
     downloadConfirmationWindowContent: " \
   <h3>Licence and use limitations</h3> \
-    <p>Data downloaded in a cart may include licence information or use limitations. \
-       If an agreement is included with data in the cart then by using those data you are accepting the terms of that \
-       agreement.</p> \
-    <h3>Any questions?</h3> \
-    <p>Please visit the <a class='external' target='_blank' href=\"${downloadDatasetHelpUrl}\">Download a Dataset</a> \
-       page of the <a class='external' target='_blank' href=\"${helpUrl}\">Portal Help</a> forum where you can find \
-       more information.</p> \
-    <br /> \
-    <p class=\"small\"><i>You accept all risks and responsibility for losses, damages, costs and other consequences \
+    <p> \
+      <tpl if=\"jurisdictionLink\"><a href=\"{jurisdictionLink}\">Jurisdiction</a></tpl> \
+      <tpl if=\"imageLink\"><img src=\"{imageLink}\" /></tpl> \
+      <tpl if=\"licenseLink != undefined\"><a href=\"{licenseLink}\">{licenseName}</a></tpl> \
+      <tpl if=\"licenseLink == undefined\">{licenseName}</tpl> \
+    </p> \
+    <tpl if=\"attrConstr && attrConstr.length &gt; 0\"> \
+      <h4><legend>Attribution Constraints</h4> \
+      <tpl if=\"otherCitation\"><p>{otherCitation}</p></tpl> \
+      <tpl for=\"attrConstr\"><p>{.}</p></tpl> \
+      <tpl for=\"otherConstr\"><p>{.}</p></tpl> \
+    </tpl> \
+    <tpl if=\"useLimitation && useLimitation.length\"> \
+      <h4>Usage Constraints</h4> \
+      <tpl for=\"useLimitation\"><p>{.}</p></tpl> \
+    </tpl> \
+    <p><b>B​y using this data you are accepting the license agreement and terms specified above.</b><br /> \
+    <i class=\"small\">You accept all risks and responsibility for losses, damages, costs and other consequences \
       resulting directly or indirectly from using this site and any information or material available from it.</i></p> \
 ",
     downloadConfirmationDownloadText: 'I understand, download',


### PR DESCRIPTION
There's a few dependencies involved before this can be usefully deployed:

* A bugfix on the otherConstraints indexing (aodn/schema-plugins#30)
* Inclusion of the licence image link in indexing (aodn/schema-plugins#31)
* dump both the otherConstraints and image link fields in geonetwork (aodn/core-geonetwork#58)

Otherwise though, it's essentially just a matter of formatting.  Since there are repeated and optional fields, I've switched to using a Extjs template instead of OL templates.