### PR TITLE
Partial fix for #2134

### DIFF
--- a/src/test/javascript/portal/cart/NetcdfSubsetServiceDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/cart/NetcdfSubsetServiceDownloadHandlerSpec.js
@@ -64,7 +64,8 @@ describe('Portal.cart.NetcdfSubsetServiceDownloadHandler', function () {
                     },
                     {
                         isVisualised: returns(false), // Not visualised
-                        hasValue: returns(true)
+                        hasValue: returns(true),
+                        getCql: returns("Depth Cql")
                     },
                     {
                         visualised: true,
@@ -88,7 +89,7 @@ describe('Portal.cart.NetcdfSubsetServiceDownloadHandler', function () {
             expect(url).toHaveParameterWithValue('jobType', 'NetcdfOutput');
             expect(url).toHaveParameterWithValue('email.to', 'bob@example.com');
             expect(url).toHaveParameterWithValue('jobParameters.typeName', 'layer_name');
-            expect(url).toHaveParameterWithValue('jobParameters.cqlFilter', 'Geometry Cql AND Salinity Cql');
+            expect(url).toHaveParameterWithValue('jobParameters.cqlFilter', 'Geometry Cql AND Depth Cql AND Salinity Cql');
         });
     });
 });

--- a/web-app/js/portal/cart/NetcdfSubsetServiceDownloadHandler.js
+++ b/web-app/js/portal/cart/NetcdfSubsetServiceDownloadHandler.js
@@ -26,7 +26,7 @@ Portal.cart.NetcdfSubsetServiceDownloadHandler = Ext.extend(Portal.cart.AsyncDow
     },
 
     _getSubset: function(filters) {
-        var builder = new Portal.filter.combiner.BodaacCqlBuilder({
+        var builder = new Portal.filter.combiner.DataDownloadCqlBuilder({
             filters: filters
         });
 


### PR DESCRIPTION
The nominated measurement timestamp property should be used for temporal filtering not the temporal coverage start and end timestamps used for filtering the WMS layer.

There is also an issue with the conversion of the date selected in the temporal filters to UTC which will be addressed separately (converted from a local date/time to UTC which is unexpected)