### PR TITLE
Don't convert date filter from local time to UTC

### DIFF
--- a/src/test/javascript/portal/utils/TimeUtilSpec.js
+++ b/src/test/javascript/portal/utils/TimeUtilSpec.js
@@ -1,0 +1,10 @@
+describe("Portal.utils.TimeUtil", function() {
+    it('returns date formatted in iso8601 format at UTC', function() {
+        var tu = new Portal.utils.TimeUtil();
+        var testDate = new Date('2013/3/26');
+
+        var formattedDate = tu.toUtcIso8601DateString(testDate);
+
+        expect(formattedDate).toEqual('2013-03-26T00:00:00Z');
+    });
+});

--- a/web-app/js/portal/filter/DateFilter.js
+++ b/web-app/js/portal/filter/DateFilter.js
@@ -114,7 +114,7 @@ Portal.filter.DateFilter = Ext.extend(Portal.filter.Filter, {
     _getDateString: function(newDate) {
 
         if (newDate) {
-            return this.timeUtil._toUtcIso8601DateString(newDate);
+            return this.timeUtil.toUtcIso8601DateString(newDate);
         }
         return '';
     },

--- a/web-app/js/portal/utils/TimeUtil.js
+++ b/web-app/js/portal/utils/TimeUtil.js
@@ -1,46 +1,27 @@
 Ext.namespace('Portal.utils');
 
 Portal.utils.TimeUtil = Ext.extend(Object, {
-    constructor:function(config) {
-        this.DATE_FORMAT = 'Y-m-d';
-        this.TIME_FORMAT = 'H:i:s (P)';
-        this.DATE_TIME_FORMAT = this.DATE_FORMAT + ' ' + this.TIME_FORMAT;
-    },
-
     _parseIso8601Date : function(string) {
         return Date.parseDate(string, "c");
     },
 
-    _toDateString : function(date) {
-        return date.format(this.DATE_FORMAT);
+    _toIso8601DateString : function(date) {
+        return date.getFullYear() + "-"
+                + this._pad((date.getMonth() + 1)) + "-"
+                + this._pad(date.getDate());
     },
 
-    _toUtcDateString : function(date) {
-        return date.getUTCFullYear() + "-"
-                + this._pad((date.getUTCMonth() + 1)) + "-"
-                + this._pad(date.getUTCDate());
-    },
-
-    _toTimeString : function(date) {
-        return date.format(this.TIME_FORMAT);
-    },
-
-    _toUtcTimeString : function(date) {
-        return this._pad(date.getUTCHours()) + ":"
-                + this._pad(date.getUTCMinutes()) + ":"
-                + this._pad(date.getUTCSeconds()) + 'Z';
+    _toIso8601TimeString : function(date) {
+        return this._pad(date.getHours()) + ":"
+                + this._pad(date.getMinutes()) + ":"
+                + this._pad(date.getSeconds());
     },
 
     _pad : function(val) {
         return val < 10 ? '0' + val : val.toString();
     },
 
-    _toUtcIso8601DateString : function(date, timeString) {
-        if (timeString) {
-            return this._toUtcIso8601DateString(Date.parseDate(date
-                            .format(this.DATE_FORMAT)
-                            + ' ' + timeString, this.DATE_TIME_FORMAT));
-        }
-        return this._toUtcDateString(date) + 'T' + this._toUtcTimeString(date);
+    toUtcIso8601DateString : function(date) {
+        return this._toIso8601DateString(date) + 'T' + this._toIso8601TimeString(date) + 'Z';
     }
 });


### PR DESCRIPTION
When testing https://github.com/aodn/aodn-portal/pull/2141 for https://github.com/aodn/aodn-portal/issues/2134, I noticed that dates selected in the date filter for non-gridded data are treated as being in local time and converted to UTC before being sent geoserver for subsetting (WFS and WPS).

So 2013/3/26 would be converted to UTC and sent to Geoserver as 2013-03-25T13:00:00Z resulting in my Netcdf files (or CSV files) including data from this timestamp onwards.

Date/Times selected for gridded data are treated as being at UTC and so the treatment of date/times is inconsistent between gridded and non-gridded data.

This PR makes the treatment of the date selected for non-gridded data consistent with that of gridded data.  It also makes it work the way I was expecting - i.e. I selected data for 26/3/2013 so when I look at the file I don't expect to see data from the previous day.