### PR TITLE
Fixes #2132 trackDownloadUsage is only done on accepting license dialog box.

### DIFF
--- a/src/test/javascript/portal/cart/DownloadPanelSpec.js
+++ b/src/test/javascript/portal/cart/DownloadPanelSpec.js
@@ -214,6 +214,7 @@ describe("Portal.cart.DownloadPanel", function() {
                 filenameFormat: "{0}.csv"
             };
             var testCollection = makeTestCollection();
+            testCollection.getFilters = returns();
             var callbackScope = downloadPanel;
             var callback = noOp;
             var testKey = "downloadAsCsvLabel";
@@ -224,7 +225,7 @@ describe("Portal.cart.DownloadPanel", function() {
 
             downloadPanel.confirmDownload(testCollection, callbackScope, callback, testParams, testKey);
             testParams.onAccept(testParams);
-            expect(window.trackUsage).toHaveBeenCalledWith(OpenLayers.i18n('downloadTrackingCategory'), OpenLayers.i18n('downloadTrackingActionPrefix') + OpenLayers.i18n(testKey), testCollection.getTitle(), undefined);
+            expect(window.trackUsage).toHaveBeenCalledWith(OpenLayers.i18n('downloadTrackingCategory'), OpenLayers.i18n('downloadTrackingActionPrefix') + OpenLayers.i18n(testKey), testCollection.getTitle(), null);
         });
     });
 

--- a/web-app/js/portal/cart/DownloadPanel.js
+++ b/web-app/js/portal/cart/DownloadPanel.js
@@ -245,10 +245,19 @@ Portal.cart.DownloadPanel = Ext.extend(Ext.Panel, {
             trackDownloadUsage(
                 OpenLayers.i18n('downloadTrackingActionPrefix') + OpenLayers.i18n(textKey),
                 collection.getTitle(),
-                undefined
+                self._getCollectionFiltersAsText(collection)
             );
         };
 
         this.confirmationWindow.show(params);
+    },
+
+    _getCollectionFiltersAsText: function(dataCollection){
+
+        var describer = new Portal.filter.combiner.HumanReadableFilterDescriber({
+            filters: dataCollection.getFilters()
+        });
+
+        return describer.buildDescription(' ');
     }
 });

--- a/web-app/js/portal/cart/GogoduckDownloadHandler.js
+++ b/web-app/js/portal/cart/GogoduckDownloadHandler.js
@@ -20,8 +20,6 @@ Portal.cart.GogoduckDownloadHandler = Ext.extend(Portal.cart.AsyncDownloadHandle
             'jobParameters.subset': subset
         };
 
-        this._trackUsage(layerName, subset);
-
         return String.format(
             "{0}{1}",
             this.getAsyncDownloadUrl('wps'),
@@ -42,14 +40,6 @@ Portal.cart.GogoduckDownloadHandler = Ext.extend(Portal.cart.AsyncDownloadHandle
             (aggregationParams.latitudeRangeEnd || this.DEFAULT_LAT_END).toDecimalString(),
             (aggregationParams.longitudeRangeStart || this.DEFAULT_LON_START).toDecimalString(),
             (aggregationParams.longitudeRangeEnd || this.DEFAULT_LON_END).toDecimalString()
-        );
-    },
-
-    _trackUsage: function(layerName, subset) {
-        trackDownloadUsage(
-            OpenLayers.i18n('gogoduckTrackingLabel'),
-            layerName,
-            subset
         );
     }
 });

--- a/web-app/js/portal/cart/GogoduckV1DownloadHandler.js
+++ b/web-app/js/portal/cart/GogoduckV1DownloadHandler.js
@@ -29,24 +29,8 @@ Portal.cart.GogoduckV1DownloadHandler = Ext.extend(Portal.cart.AsyncDownloadHand
             }
         };
 
-        this._trackUsage(layerName, args.subsetDescriptor);
-
         var paramsAsJson = Ext.util.JSON.encode(args);
 
         return String.format(this.getAsyncDownloadUrl('gogoduck') + 'jobParameters={0}', encodeURIComponent(paramsAsJson));
-    },
-
-    _trackUsage: function(layerName, subsetDescriptor) {
-        trackDownloadUsage(
-            OpenLayers.i18n('gogoduckTrackingLabel'),
-            layerName,
-            String.format("TIME:{0},{1} LAT:{2},{3} LON:{4},{5}",
-                subsetDescriptor.temporalExtent.start,
-                subsetDescriptor.temporalExtent.end,
-                subsetDescriptor.spatialExtent.south,
-                subsetDescriptor.spatialExtent.north,
-                subsetDescriptor.spatialExtent.west,
-                subsetDescriptor.spatialExtent.east)
-        );
     }
 });

--- a/web-app/js/portal/cart/NetcdfSubsetServiceDownloadHandler.js
+++ b/web-app/js/portal/cart/NetcdfSubsetServiceDownloadHandler.js
@@ -10,8 +10,6 @@ Portal.cart.NetcdfSubsetServiceDownloadHandler = Ext.extend(Portal.cart.AsyncDow
 
         var cqlFilter = this._getSubset(filters);
 
-        this._trackUsage(layerName, cqlFilter);
-
         return String.format(
             "{0}{1}",
             this.getAsyncDownloadUrl('wps'),
@@ -31,13 +29,5 @@ Portal.cart.NetcdfSubsetServiceDownloadHandler = Ext.extend(Portal.cart.AsyncDow
         });
 
         return builder.buildCql();
-    },
-
-    _trackUsage: function(layerName, cqlFilter) {
-        trackDownloadUsage(
-            OpenLayers.i18n('wpsTrackingLabel'),
-            layerName,
-            cqlFilter
-        );
     }
 });

--- a/web-app/js/portal/filter/DateFilter.js
+++ b/web-app/js/portal/filter/DateFilter.js
@@ -88,8 +88,7 @@ Portal.filter.DateFilter = Ext.extend(Portal.filter.Filter, {
 
         var label = OpenLayers.i18n('temporalExtentHeading');
 
-        if (!this.isPrimary()) {
-
+        if (!this.isPrimary() && this.getLabel()) {
             label += ' (' + this.getLabel() + ')';
         }
 


### PR DESCRIPTION
@jonescc Track download changes now in one place with the filters supplied as human readable text as the data