### PR TITLE
Titles are now trimmed when excessively long. Hover shows full title with default cursor

### DIFF
--- a/src/test/javascript/portal/cart/DownloadPanelItemTemplateSpec.js
+++ b/src/test/javascript/portal/cart/DownloadPanelItemTemplateSpec.js
@@ -2,7 +2,7 @@ describe('Portal.cart.DownloadPanelItemTemplate', function () {
 
     var html;
     var tpl;
-    var mockDataInjection;
+    var  mockDataInjection;
     var dataCollectionStore;
 
     beforeEach(function() {
@@ -16,7 +16,7 @@ describe('Portal.cart.DownloadPanelItemTemplate', function () {
 
         mockDataInjection = {
             getUuid: returns(42),
-            title: 'the title',
+            title: 'AODN Contributors idea of a concise title to best describe a dataset: This is the title that is simply too long to fit into the available space even when we allow contributors to use 2 lines to fit this super long title in',
             pointOfTruthLink: [
                 {
                     href: 'point of truth url'
@@ -46,7 +46,7 @@ describe('Portal.cart.DownloadPanelItemTemplate', function () {
 
         beforeEach(function() {
 
-            spyOn(tpl, '_getRecordTitle');
+            spyOn(tpl, '_getHtmlTitle');
             spyOn(tpl, '_createDownloadButtonAfterPageLoad');
             spyOn(tpl, '_createRemoveButtonAfterPageLoad');
             spyOn(tpl, '_getDataFilterEntry');
@@ -58,7 +58,7 @@ describe('Portal.cart.DownloadPanelItemTemplate', function () {
         });
 
         it('creates a title for the record', function() {
-            expect(tpl._getRecordTitle).toHaveBeenCalled();
+            expect(tpl._getHtmlTitle).toHaveBeenCalled();
         });
 
         it('creates a download button', function() {
@@ -94,8 +94,8 @@ describe('Portal.cart.DownloadPanelItemTemplate', function () {
 
         it('returns the correct record title', function() {
 
-            html = tpl._getRecordTitle(mockDataInjection);
-            expect(html).toBe('the title');
+            html = tpl._getHtmlTitle(mockDataInjection);
+            expect(html).toBe('<h3 title=\"AODN Contributors idea of a concise title to best describe a dataset: This is the title that is simply too long to fit into the available space even when we allow contributors to use 2 lines to fit this super long title in\">AODN Contributors idea of a concise title to best describe a dataset: This is the title that is simply too long to fit into the available space even when we allow contributors...</h3>');
         });
     });
 

--- a/web-app/css/AODNTheme.css
+++ b/web-app/css/AODNTheme.css
@@ -37,6 +37,7 @@ h1, h2, h3, h4,
 .x-window-header-text,
 .search-filter-panel .filter-selection-panel-header-selected {
     color: #4D5B63;
+    cursor: default;
 }
 
 #header {

--- a/web-app/js/portal/cart/DownloadPanelItemTemplate.js
+++ b/web-app/js/portal/cart/DownloadPanelItemTemplate.js
@@ -18,7 +18,7 @@ Portal.cart.DownloadPanelItemTemplate = Ext.extend(Ext.XTemplate, {
             '    <div class="downloads resultsRowHeaderTitle">',
             '      <div class="x-tool-awesome" title="{[this.getTooltip(\'removeDataCollectionTooltip\')]}" class="removeButton" id="{[this._getLinkId(values,\'removeButtonId\')]}">{[this._createRemoveButtonAfterPageLoad(values)]}</div>',
             '      <div class="x-tool-awesome" title="{[this.getTooltip(\'shareButtonTooltip\')]}" id="{[this._getLinkId(values,\'shareButtonId\')]}">{[this._createShareButtonAfterPageLoad(values)]}</div>',
-            '    <span class="x-panel-header-text"><h3>{[this._getRecordTitle(values)]}</h3></span>',
+            '    <span class="x-panel-header-text">{[this._getHtmlTitle(values)]}</span>',
             '    </div>',
             '    <div class="floatRight listButtonWrapper" id="{[this._getLinkId(values,\'downloadButtonId\')]}">{[this._createDownloadButtonAfterPageLoad(values)]}</div>',
             '  </div>',
@@ -48,8 +48,9 @@ Portal.cart.DownloadPanelItemTemplate = Ext.extend(Ext.XTemplate, {
         return OpenLayers.i18n(i18nId);
     },
 
-    _getRecordTitle: function(values) {
-        return values.title;
+    _getHtmlTitle: function(values) {
+        var title = values.title;
+        return String.format("<h3 title=\"{0}\">{1}</h3>", title, Ext.util.Format.ellipsis(title, 180, true));
     },
 
     _createShareButtonAfterPageLoad: function(collection) {

--- a/web-app/js/portal/details/DataCollectionDetailsPanel.js
+++ b/web-app/js/portal/details/DataCollectionDetailsPanel.js
@@ -13,7 +13,7 @@ Portal.details.DataCollectionDetailsPanel = Ext.extend(Ext.Panel, {
 
         var config = Ext.apply({
             cls: 'dataCollectionDetailsPanel',
-            title: '<h4>' + cfg.dataCollection.getTitle() + '</h4>',
+            title: this._getHtmlTitle(cfg.dataCollection.getTitle()),
             autoHeight: true,
             defaults: {
                 style: {padding: '10px'},
@@ -44,6 +44,10 @@ Portal.details.DataCollectionDetailsPanel = Ext.extend(Ext.Panel, {
         layerAdapter.un('loadstart', this._onLayerLoadStart, this);
         layerAdapter.un('loadend', this._onLayerLoadEnd, this);
         layerAdapter.un('tileerror', this._onLayerLoadError, this);
+    },
+
+    _getHtmlTitle: function(title) {
+        return String.format("<h4 title=\"{0}\">{1}</h4>", title, Ext.util.Format.ellipsis(title, 100, true));
     },
 
     _onExpand: function() {

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -20,7 +20,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
             '<div class="resultsHeaderBackground">',
             '    <div class="x-panel-header">',
             '        <div class="resultsRowHeaderTitle">',
-            '            <h3>{[values.title]}</h3>',
+            '            {[this.getHtmlTitle(values)]}',
             '        </div>',
             '        <div class="facetedSearchBtn" id="{[this.buttonElementId(values.uuid)]}">',
             '            {[this.getButton(values)]}',
@@ -57,6 +57,10 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
                 },
                 getIconUrl: function(values) {
                     return Ext.ux.Ajax.constructProxyUrl(this.getGeonetworkImageUrl(values.iconSourceUuid));
+                },
+                getHtmlTitle: function(values) {
+                    var title = values.title;
+                    return String.format("<h3 title=\"{0}\">{1}</h3>", title, Ext.util.Format.ellipsis(title, 180, true));
                 }
             }
         );


### PR DESCRIPTION
part fixes https://github.com/aodn/backlog/issues/361