### PR TITLE
Fixes 2188 - unit information comes from metadata only

### DIFF
--- a/web-app/js/portal/ui/FeatureInfoPopup.js
+++ b/web-app/js/portal/ui/FeatureInfoPopup.js
@@ -143,7 +143,7 @@ Portal.ui.FeatureInfoPopup = Ext.extend(GeoExt.Popup, {
                 layer: layer,
                 name: layer.name,
                 expectedFormat: layer.getFeatureInfoFormat(),
-                units: (extraLayerInfo.units != undefined) ? extraLayerInfo.units : layer.units,
+                units: extraLayerInfo.units,
                 copyright: extraLayerInfo.copyright
             },
             success: function(resp, options) {


### PR DESCRIPTION
Units will not be stated if the metadata does not contain units.

Related work to correctly return units comes from https://github.com/aodn/geoserver-build/pull/138