### PR TITLE
Add simple controller to trigger reload of external config files

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/ExternalConfigReloadController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/ExternalConfigReloadController.groovy
@@ -14,9 +14,15 @@ class ExternalConfigReloadController {
         def locations = config.grails.config.locations
 
         locations.each { location ->
-            String configFileName = location.split("file:")[1]
-            log.info "Reloading config from file '${configFileName}'..."
-            config.merge(new ConfigSlurper().parse(new File(configFileName).text))
+            String configFileName = location.replaceFirst(~/^file:/, '')
+            File configFile = new File(configFileName)
+
+            if (configFile.exists()) {
+                log.info "Reloading config from file '${configFileName}'..."
+                config.merge(new ConfigSlurper().parse(configFile.text))
+            } else {
+                log.debug "File for config location '${location}' doesn't exist."
+            }
         }
         render(status: 200, text: 'OK')
     }

--- a/grails-app/controllers/au/org/emii/portal/ExternalConfigReloadController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/ExternalConfigReloadController.groovy
@@ -1,0 +1,30 @@
+package au.org.emii.portal
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class ExternalConfigReloadController {
+
+    static final Logger log = LoggerFactory.getLogger(this)
+
+    def grailsApplication
+
+    def index() {
+        def config = grailsApplication.config
+        def locations = config.grails.config.locations
+
+        locations.each { location ->
+            String configFileName = location.split("file:")[1]
+            log.info "Reloading config from file '${configFileName}'..."
+            config.merge(new ConfigSlurper().parse(new File(configFileName).text))
+        }
+        render(status: 200, text: 'OK')
+    }
+
+    def beforeInterceptor = {
+        if (!["127.0.0.1", "0:0:0:0:0:0:0:1"].contains(request.remoteAddr)) {
+            render(status: 401, text: 'Unauthorized')
+            return false
+        }
+    }
+}


### PR DESCRIPTION
This enables the external groovy config file(s) to be reloaded without restarting Tomcat.
Currently if Portal.groovy (or any other hypothetical external config file) is updated but the WAR contents are not, the new configuration will not be effective until Tomcat is restarted.

Example usage: (from localhost *only*): 

```bash
[/var/log/tomcat8]# wget -q http://localhost:8080/ExternalConfigReload -O/dev/null

[/var/log/tomcat8]# tail catalina.out 
13-Sep-2016 05:54:00.447 INFO [main] org.apache.coyote.AbstractProtocol.start Starting ProtocolHandler ["http-nio-8080"]
13-Sep-2016 05:54:00.463 INFO [main] org.apache.coyote.AbstractProtocol.start Starting ProtocolHandler ["ajp-nio-8009"]
13-Sep-2016 05:54:00.467 INFO [main] org.apache.catalina.startup.Catalina.start Server startup in 18839 ms
2016-09-13 05:54:48,871 INFO  [http-nio-8080-exec-2] [] au.org.emii.portal.ExternalConfigReloadController  - Reloading config from file '/etc/aodn-config/Portal.groovy'...
```