### PR TITLE
Set correct scope for timeout to redraw previous spatial extent on error

### DIFF
--- a/web-app/js/portal/ui/openlayers/control/SpatialConstraint.js
+++ b/web-app/js/portal/ui/openlayers/control/SpatialConstraint.js
@@ -201,18 +201,19 @@ Portal.ui.openlayers.control.SpatialConstraint = Ext.extend(OpenLayers.Control.D
     },
 
     _showSpatialExtentError: function(geometry) {
+        var that = this;
         this.vectorlayer.style = this.errorStyle;
-        setTimeout(
-            this._recallLastSpatialExtent,
-            this.SPATIAL_EXTENT_ERROR_TIMEOUT,
-            this
-        );
+        setTimeout((function() {
+            that._recallLastSpatialExtent(that);
+        }), that.SPATIAL_EXTENT_ERROR_TIMEOUT);
     },
 
     _recallLastSpatialExtent: function(that) {
         if (that.oldGeometry) {
             that.vectorlayer.style = OpenLayers.Feature.Vector.style['default'];
             that.redraw(that.oldGeometry);
+        } else {
+            this.clear();
         }
     },
 


### PR DESCRIPTION
Fixes issue #2324 