### PR TITLE
Add type filter to _getServer to avoid returning ncWMS servers if kno…

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/DownloadController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/DownloadController.groovy
@@ -249,7 +249,7 @@ class DownloadController extends RequestProxyingController {
     }
 
     def _getServer(host) {
-        return grailsApplication.config.knownServers.find { it.uri.toURL().host == host }
+        return grailsApplication.config.knownServers.find { it.uri.toURL().host == host && it.type == 'GeoServer' }
     }
 
     def _loadCommonFields(params) {


### PR DESCRIPTION
…wnServers list order changes

Follow up from https://github.com/aodn/aodn-portal/issues/2341

The summary of the issue is that the knownServers list is derived from the user configured Portal.groovy file, but the code itself assumes a certain order (i.e. that the server with 'type: ''GeoServer"' for a given hostname is always first, before other servers with the same hostname).

This snippet below caused the issue because when searching for '**geoserver-systest.aodn.org.au**', the ncWMS server was found first and no urlSubstitutions took place. If the GeoServer server was first, as the code assumes it will be, it would work.

The code extracts the host from:
```groovy
"url" -> "http://geoserver-systest.aodn.org.au/geoserver/ows?typeName=argo_profile_map&SERVICE=WFS&outputFormat=csv&REQUEST=GetFeature&VERSION=1.0.0&CQL_FILTER=INTERSECTS(position%2CPOLYGON((109.5556640625%20-19.9521484375%2C109.5556640625%20-13.0966796875%2C119.4873046875%20-13.0966796875%2C119.4873046875%20-19.9521484375%2C109.5556640625%20-19.9521484375)))"
```
And searches for a knownServer with the same hostname in:

```groovy
    [
        id: "aodn_geoserver_ncwms_systest",
        uri: "http://geoserver-systest.aodn.org.au/geoserver/ncwms",
        wmsVersion: "1.3.0",
        type: "ncWMS"
    ],
    [
        id: "aodn_geoserver_systest",
        uri: "http://geoserver-systest.aodn.org.au/geoserver/wms",
        wmsVersion: "1.1.1",
        type: "GeoServer",
        csvDownloadFormat: "csv-with-metadata-header",
        supportsCsvMetadataHeaderOutputFormat: true,
        urlListDownloadSubstitutions: [
            '^': "http://data.aodn.org.au/"
        ]
    ],
```

This is up for discussion, as there may be a cleaner more specific way to manage it, but there seem to be some constraints. 

The assumptions seem to be:

1. the urlSubstitutions are associated with the server of type 'GeoServer'
1. the 'host' attribute is the only thing available to match on
1. there is *typically* only one Geoserver on a given host name