### PR TITLE
Validate from and to date fields on value change after updating minmax

### DIFF
--- a/src/test/javascript/portal/filter/ui/DateFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/DateFilterPanelSpec.js
@@ -31,7 +31,7 @@ describe("Portal.filter.ui.DateFilterPanel", function() {
     describe('handleRemoveFilter', function() {
         beforeEach(function() {
             filterPanel.toDate.reset = jasmine.createSpy('toDate reset');
-            filterPanel.toDate.setMinValue = jasmine.createSpy('toDate setMinValue');
+            filterPanel.toDate.setMinimumValue = jasmine.createSpy('toDate setMinValue');
 
             filterPanel.fromDate.reset = jasmine.createSpy('fromDate reset');
         });
@@ -43,7 +43,7 @@ describe("Portal.filter.ui.DateFilterPanel", function() {
 
         it('sets min value of toDate', function() {
             filterPanel.handleRemoveFilter();
-            expect(filterPanel.toDate.setMinValue).toHaveBeenCalled();
+            expect(filterPanel.toDate.setMinimumValue).toHaveBeenCalled();
         });
 
         it('resets fromDate', function() {
@@ -64,7 +64,8 @@ describe("Portal.filter.ui.DateFilterPanel", function() {
             };
             filterPanel.toDate = {
                 getValue: returns(moment('1999-11-31T00:00:00.000Z')), 
-                setMinValue: noOp
+                setMinimumValue: noOp,
+                isDateValid: noOp
             };
 
             filterPanel._applyDateFilter(component);
@@ -79,9 +80,10 @@ describe("Portal.filter.ui.DateFilterPanel", function() {
         Ext.each(['fromDate', 'toDate'], function(property) {
             this[property] = {
                 getValue: noOp,
-                setMinValue: noOp,
-                setMaxValue: noOp,
-                applyDefaultValueLimits: noOp
+                setMinimumValue: noOp,
+                setMaximumValue: noOp,
+                applyDefaultValueLimits: noOp,
+                isDateValid: noOp
             };
         }, filterPanel);
     }

--- a/web-app/js/portal/filter/ui/DateFilterPanel.js
+++ b/web-app/js/portal/filter/ui/DateFilterPanel.js
@@ -38,7 +38,7 @@ Portal.filter.ui.DateFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel, 
     handleRemoveFilter: function() {
         this.fromDate.reset();
         this.toDate.reset();
-        this.toDate.setMinValue(Portal.utils.Date.getEarliestPortalDate());
+        this.toDate.setMinimumValue(Portal.utils.Date.getEarliestPortalDate());
 
         this.filter.clearValue();
     },
@@ -74,10 +74,10 @@ Portal.filter.ui.DateFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel, 
     },
 
     _setMinMax: function(resettableDate, vals) {
-        resettableDate.setMinValue(moment(vals[0]).toDate());
+        resettableDate.setMinimumValue(moment(vals[0]).toDate());
 
         if (vals.length == 2) {
-            resettableDate.setMaxValue(moment(vals[1]).toDate());
+            resettableDate.setMaximumValue(moment(vals[1]).toDate());
         }
     },
 
@@ -85,8 +85,11 @@ Portal.filter.ui.DateFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterPanel, 
 
         var changedField = component._dateField;
 
-        this.toDate.setMinValue(this.fromDate.getValue());
-        this.fromDate.setMaxValue(this.toDate.getValue());
+        this.toDate.setMinimumValue(this.fromDate.getValue());
+        this.fromDate.setMaximumValue(this.toDate.getValue());
+
+        this.fromDate.isDateValid();
+        this.toDate.isDateValid();
 
         var usageLabelKey = changedField.getValue() ? 'trackingUserSet' : 'trackingDefaultValueReset';
         var val = changedField.name + " " + OpenLayers.i18n(usageLabelKey) + " " + changedField.getValue();

--- a/web-app/js/portal/filter/ui/ResettableDate.js
+++ b/web-app/js/portal/filter/ui/ResettableDate.js
@@ -53,17 +53,21 @@ Portal.filter.ui.ResettableDate = Ext.extend(Ext.Container, {
         return result;
     },
 
-    setMinValue: function(value) {
+    setMinimumValue: function(value) {
         this._dateField.setMinUtcValue(value ? value : Portal.utils.Date.getEarliestPortalDate());
     },
 
-    setMaxValue: function(value) {
+    setMaximumValue: function(value) {
         this._dateField.setMaxUtcValue(value ? value : Portal.utils.Date.getLatestPortalDate());
     },
 
+    isDateValid: function() {
+        return this._dateField.validate();
+    },
+
     applyDefaultValueLimits: function() {
-        this.setMinValue();
-        this.setMaxValue();
+        this.setMinimumValue();
+        this.setMaximumValue();
     },
 
     _createDateField: function(cfg) {
@@ -73,7 +77,7 @@ Portal.filter.ui.ResettableDate = Ext.extend(Ext.Container, {
             altFormats: OpenLayers.i18n('dateAltFormats'),
             emptyText: cfg.emptyText,
             blankText: OpenLayers.i18n('emptyDateFieldMessage'),
-            allowBlank: false,
+            allowBlank: true,
             height: this.ELEMENT_HEIGHT,
             width: this.ELEMENT_WIDTH,
             listeners: {


### PR DESCRIPTION
Fixes issue #2317.
I've renamed a few functions to avoid confusion.
Allow blank fields as this defaults to min and max of the spatial extent for collection.