### PR TITLE
Issue 2395

### DIFF
--- a/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
+++ b/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
@@ -44,7 +44,7 @@ describe('Portal.cart.NcWmsInjector', function() {
                 dateRangeStart: null
             }]);
 
-            expect(injector._getDataFilterEntry(dataCollection)).toEqual("");
+            expect(injector._getDataFilterEntry(dataCollection)).toEqual(OpenLayers.i18n('temporalExtentNotLoaded'));
         });
 
         it('indicates bounds properly created', function() {

--- a/src/test/javascript/portal/details/NcWmsPanelSpec.js
+++ b/src/test/javascript/portal/details/NcWmsPanelSpec.js
@@ -21,6 +21,8 @@ describe('Portal.details.NcWmsPanel', function() {
         layer.events = { on: noOp };
         layer.processTemporalExtent = noOp;
         layer.map = map;
+        layer.getTemporalExtentMin = noOp;
+        layer.getTemporalExtentMax = noOp;
 
         layerSelectionModel = new Ext.util.Observable();
         layerSelectionModel.getSelectedLayer = returns(layer);

--- a/web-app/js/portal/PortalEvents.js
+++ b/web-app/js/portal/PortalEvents.js
@@ -2,6 +2,7 @@ var PORTAL_EVENTS = {
     BASE_LAYER_CHANGED:            "baseLayerChanged",
     BASE_LAYER_LOADED_FROM_SERVER: "baseLayersLoadedFromServer",
     DATA_COLLECTION_ADDED:         "dataCollectionAdded",
+    DATA_COLLECTION_MODIFIED:      "dataCollectionModified",
     DATA_COLLECTION_REMOVED:       "dataCollectionRemoved",
     DATA_COLLECTION_SELECTED:      "dataCollectionSelected",
     RESET:                         "reset"

--- a/web-app/js/portal/cart/DownloadPanel.js
+++ b/web-app/js/portal/cart/DownloadPanel.js
@@ -64,6 +64,7 @@ Portal.cart.DownloadPanel = Ext.extend(Ext.Panel, {
         this.on('beforeshow', function() { this.generateContent() }, this);
         Ext.MsgBus.subscribe(PORTAL_EVENTS.DATA_COLLECTION_ADDED, function() { this.generateContent() }, this);
         Ext.MsgBus.subscribe(PORTAL_EVENTS.DATA_COLLECTION_REMOVED, function() { this.generateContent() }, this);
+        Ext.MsgBus.subscribe(PORTAL_EVENTS.DATA_COLLECTION_MODIFIED, function() { this.generateContent() }, this);
     },
 
     onDownloadRequested: function(downloadUrl, collection) {

--- a/web-app/js/portal/cart/DownloadPanelItemTemplate.js
+++ b/web-app/js/portal/cart/DownloadPanelItemTemplate.js
@@ -57,10 +57,9 @@ Portal.cart.DownloadPanelItemTemplate = Ext.extend(Ext.XTemplate, {
         if (values.errorMessage && values.errorMessage != "") {
             msg = values.errorMessage;
         }
-        else if (values.dataFilters == "") {
-            msg = OpenLayers.i18n('emptyDownloadPlaceholder');
+        else if (values.isTemporalExtentSubsetted == false || values.dataFilters == "") {
+            msg = OpenLayers.i18n('emptyDownloadFilter');
         }
-
         if (msg == "" && values.intersect == false) {
             msg = OpenLayers.i18n('spatialSubsetOutOfBoundsMsg');
         }
@@ -79,7 +78,7 @@ Portal.cart.DownloadPanelItemTemplate = Ext.extend(Ext.XTemplate, {
     },
 
     _createShareButton: function(values) {
-        var url =  String.format(
+        var url = String.format(
             '{0}/search?uuid={1}',
             Portal.app.appConfig.grails.serverURL.replace(/\/+$/, ""),
             values.uuid
@@ -168,7 +167,7 @@ Portal.cart.DownloadPanelItemTemplate = Ext.extend(Ext.XTemplate, {
             new Ext.Button({
                 text: OpenLayers.i18n('downloadButtonLabel'),
                 cls: 'navigationButton',
-                disabled: values.intersect == false,
+                disabled: this.downloadButtonDisabled(values),
                 scope: this,
                 renderTo: elementId,
                 menu: new Ext.menu.Menu({
@@ -177,6 +176,10 @@ Portal.cart.DownloadPanelItemTemplate = Ext.extend(Ext.XTemplate, {
                 })
             });
         }
+    },
+
+    downloadButtonDisabled: function(values) {
+        return values.intersect == false || (values.errorMessage && values.errorMessage != "");
     },
 
     _createRemoveButtonAfterPageLoad: function(values) {

--- a/web-app/js/portal/cart/NcWmsInjector.js
+++ b/web-app/js/portal/cart/NcWmsInjector.js
@@ -43,8 +43,22 @@ Portal.cart.NcWmsInjector = Ext.extend(Portal.cart.BaseInjector, {
             var endDateString = this._formatDate(params.dateRangeEnd);
             dateString = this._formatHumanDateInfo('temporalExtentHeading', startDateString, endDateString);
         }
-
+        else {
+            dateString = OpenLayers.i18n('temporalExtentNotLoaded');
+        }
         return areaString + timeSeriesAtString + dateString;
+    },
+
+    getInjectionJson: function(collection) {
+        var injectionJson = Portal.cart.NcWmsInjector.superclass.getInjectionJson(collection);
+
+        injectionJson.dataFilters = this._getDataFilterEntry(collection);
+        if (injectionJson.dataFilters.contains(OpenLayers.i18n('temporalExtentNotLoaded'))) {
+            injectionJson.errorMessage = OpenLayers.i18n('temporalExtentNotLoaded');
+        }
+        injectionJson.isTemporalExtentSubsetted = collection.isTemporalExtentSubsetted;
+
+        return injectionJson;
     },
 
     _formatHumanDateInfo: function(labelKey, value1, value2) {

--- a/web-app/js/portal/details/NcWmsPanel.js
+++ b/web-app/js/portal/details/NcWmsPanel.js
@@ -437,8 +437,8 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Container, {
     },
 
     _applyFilterValuesToCollection: function() {
-        var dateRangeStart = this._getDateFromPicker(this.startDateTimePicker);
-        var dateRangeEnd = this._getDateFromPicker(this.endDateTimePicker);
+        var dateRangeStart = this._getUtcMomentFromPicker(this.startDateTimePicker);
+        var dateRangeEnd = this._getUtcMomentFromPicker(this.endDateTimePicker);
         var geometry = this._getGeometryFilter();
 
         if (this._timeSeriesOptionAvailable()){
@@ -451,6 +451,19 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Container, {
             }
         }
         this.dataCollection.filters = this._ncwmsParamsAsFilters(dateRangeStart, dateRangeEnd, geometry, pointFilterAvailable, pointFilterValue);
+
+        this.dataCollection.isTemporalExtentSubsetted = this.isTemporalExtentSubsetted(dateRangeStart, dateRangeEnd);
+    },
+
+    isTemporalExtentSubsetted: function(dateRangeStart, dateRangeEnd) {
+
+        var temporalExtentBegin = this.layer.getTemporalExtentMin();
+        var temporalExtentEnd = this.layer.getTemporalExtentMax();
+        if (dateRangeStart && temporalExtentBegin && temporalExtentEnd) {
+            return ! (dateRangeStart.isSame(temporalExtentBegin) && dateRangeEnd.isSame(temporalExtentEnd));
+        }
+        return undefined;
+
     },
 
     _isDateRangeValid: function(start, end) {
@@ -594,7 +607,7 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Container, {
         this.layer.setTime(momentDate);
     },
 
-    _getDateFromPicker: function(datePicker) {
+    _getUtcMomentFromPicker: function(datePicker) {
         if (moment(datePicker.getValue()).isValid()) {
             return moment.utc(datePicker.getValue());
         }

--- a/web-app/js/portal/details/NcWmsPanel.js
+++ b/web-app/js/portal/details/NcWmsPanel.js
@@ -554,6 +554,8 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Container, {
         else {
             this._resetExtent(this.layer.getSubsetExtentMin(), this.layer.getSubsetExtentMax());
             this._applyFilterValuesToCollection();
+
+            Ext.MsgBus.publish(PORTAL_EVENTS.DATA_COLLECTION_MODIFIED, this.dataCollection);
         }
 
         this._setFrameButtonsState();

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -238,7 +238,8 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
 
     numberFilterError: 'Start value must be less the end value',
 
-    emptyDownloadPlaceholder: "The full data collection will be downloaded. Consider filtering the collection.",
+    emptyDownloadFilter: "The full data collection will be downloaded. Please consider filtering the collection.",
+    temporalExtentNotLoaded: "Waiting for Temporal extent to load.. <br/>Please consider filtering the collection before downloading",
 
     // FeatureInfoPopup.js
     noDataCollectionTitle: 'No data collection selected',


### PR DESCRIPTION
When a user loads a ncWMS layer and goes quickly to step 3, the page indicate that the Temporal extent filters are loading, and the download options are disabled during this time. This happens even on fast internet connections such as UTAS.

- Now the download panel (step 3) will reload when temporal filters finish loading, in this way the temporal filter should be correct before the user can choose a download option if the download option button is enabled that is.
- The user will see a message when the temporal extent matches the full extent of the chosen layer of the collection. This message is advisory and the download button is enabled
