### PR TITLE
Fixes sitemap for non-development environments

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -139,7 +139,7 @@ environments {
 
         // URLs
         def localhostAddress = java.net.InetAddress.getLocalHost().getHostAddress()
-        grails.serverURL = "http://${localhostAddress}:9090/"
+        grails.serverURL = "http://${localhostAddress}:8090"
         gogoduck.url = "http://${localhostAddress}:8300/go-go-duck"
         geonetwork.url = "https://catalogue-portal.aodn.org.au/geonetwork"
 

--- a/grails-app/controllers/au/org/emii/portal/SearchController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/SearchController.groovy
@@ -17,7 +17,7 @@ class SearchController {
     }
 
     def uuid = {
-        redirect(url: "search?uuid=" +  params.id + "&info=true")
+        redirect(uri: "/search?uuid=" +  params.id + "&info=true")
     }
 
     def config = {


### PR DESCRIPTION
Related to #2423 which was working on localhost but not on edge and systest because of a  difference between serverurls having or not having a backslash at the end