### PR TITLE
Get rid of unneeded spaces in EPSG parameters of getfeatureinfo requests

### DIFF
--- a/web-app/js/portal/prototypes/OpenLayers.js
+++ b/web-app/js/portal/prototypes/OpenLayers.js
@@ -68,8 +68,8 @@ OpenLayers.Layer.WMS.prototype.getFeatureInfoRequestString = function(clickPoint
         INFO_FORMAT: this.getFeatureInfoFormat(),
         QUERY_LAYERS: this.params.LAYERS,
         FEATURE_COUNT: this.isNcwms() ? 1 : 100,
-        SRS: 'EPSG: 4326',
-        CRS: 'EPSG: 4326',
+        SRS: 'EPSG:4326',
+        CRS: 'EPSG:4326',
         WIDTH: this.map.size.w,
         HEIGHT: this.map.size.h
     };


### PR DESCRIPTION
(required change for geowebcache comparability)