### PR TITLE
Fix selenium pom.xml for utf-8...

### DIFF
--- a/selenium/pom.xml
+++ b/selenium/pom.xml
@@ -113,6 +113,7 @@
     <properties>
         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
         <build>local</build>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <browserstack.video>true</browserstack.video>
         <browserstack.debug>true</browserstack.debug>
         <browserstack.local>false</browserstack.local>


### PR DESCRIPTION
... so maven handles utf-8 characters by default. The jenkins build was failing because of a utf-8 character in ShapeFileTest.

NB. the selenium build will continue to fail because of a problem in another test (which I'm in process of fixing), but this can be put through in the meantime