### PR TITLE
Fixed various issues introduced by JQuery upgrade.

### DIFF
--- a/web-app/js/portal/jquery.js
+++ b/web-app/js/portal/jquery.js
@@ -1,7 +1,7 @@
 jQuery( document ).ready(function() {
 
-    jQuery(".resultsHeaderBackground:not(.facetedSearchBtn *)").on("click",
-        function(){
+    jQuery(document).on("click", ".resultsHeaderBackground:not(.facetedSearchBtn *)",
+        function() {
             var resBody = jQuery(this).children('.facetedSearchResultBody');
             var fullHeight = resBody[0].scrollHeight;
             var originalHeight = resBody.height();
@@ -19,25 +19,18 @@ jQuery( document ).ready(function() {
             }
         });
 
-    jQuery(".resultsHeaderBackground:not(.facetedSearchBtn *)").on("mouseover",
-        function(){
+    jQuery(document).on("mouseover", ".resultsHeaderBackground:not(.facetedSearchBtn *)",
+        function() {
             var resBody = jQuery(this).children('.facetedSearchResultBody');
             var fullHeight = resBody[0].scrollHeight;
 
-            if (fullHeight > 0  && fullHeight != resBody.height()) {
+            if (fullHeight > 0 && fullHeight != resBody.height()) {
                 jQuery(this).addClass("expandable");
             }
         });
 
-    jQuery('.button input').on('hover',
-        function(){
-            jQuery(this).toggleClass("hover")
-                .next().stop(true, true).slideToggle();
-
-        });
-
     // getFeatureInfo popup links  .not('.jQueryLiveAnchor')
-    jQuery('.featureinfocontent a:not(.jQueryLiveAnchor)').on('hover',
+    jQuery(document).on("mouseover", '.featureinfocontent a:not(.jQueryLiveAnchor)',
         function() {
             var thisTag = jQuery(this);
             var trackChangesCommand = "trackGetFeatureInfoClickUsage('" + thisTag.attr('href') + "'); return true;";
@@ -48,27 +41,14 @@ jQuery( document ).ready(function() {
         });
 
     // activelayer/tree labels
-    jQuery('#activeLayerTreePanel .x-tree-node a span, .x-tree-node-leaf span').on('hover',
-        function(){
+    jQuery(document).on("mouseover", '#activeLayerTreePanel .x-tree-node a span, .x-tree-node-leaf span',
+        function() {
             jQuery(this).attr('title', jQuery(this).html());
-            jQuery(this).off('hover');
         });
 
     // helper tooltip for unpin (popup)
-    jQuery('.x-tool-unpin').on('hover',
-        function(){
+    jQuery(document).on('mouseover', '.x-tool-unpin',
+        function() {
             jQuery(this).attr('title', "Click to move and resize");
-            jQuery(this).off('hover');
         });
-
-
-    jQuery('.layersDiv, .olControlOverviewMapElement')
-        .on("mouseenter", function(){
-            jQuery(this).addClass("fullTransparency");
-        })
-        .on("mouseleave", function(){
-            jQuery(this).removeClass("fullTransparency");
-        });
-
 });
-


### PR DESCRIPTION
 Some events weren't being run due to JQuery3 handling events differently.

JQuery3 Upgrade (see #2458) predictably caused a bunch of issues:
- Mouse over title text on the last level facet menu items wasn't working
- Mouse over title text on "pin" icon of getfeatureinfo wasn't working
- FeatureInfo hyperlink clicks were not being tracked
- Search results which were too long to fit in regular size couldn't be expanded

There were two events being added in jquery.js (lines 32 and 65 of the unrefactored file) which I couldn't for the life of me work out what they were supposed to do. I therefore removed them as a I strongly suspect they're remnants of long deceased features. 