### PR TITLE
Download estimator output inside downloadConfirmationPanel.

### DIFF
--- a/grails-app/services/au/org/emii/portal/NetcdfSubsetDownloadCalculatorService.groovy
+++ b/grails-app/services/au/org/emii/portal/NetcdfSubsetDownloadCalculatorService.groovy
@@ -1,0 +1,55 @@
+package au.org.emii.portal
+
+import grails.converters.JSON
+
+class NetcdfSubsetDownloadCalculatorService extends AsyncDownloadService {
+
+    def grailsApplication
+
+    def getConnection(params) {
+        return _gogoduckConnection()
+    }
+
+    // todo remove this stub
+    def stub(params) {
+        return "// todo"
+    }
+
+    def _gogoduckConnection() {
+        //def conn = new HTTPBuilder("${grailsApplication.config.gogoduck.url}/job/")
+        //conn.contentType = groovyx.net.http.ContentType.JSON
+
+        return conn
+    }
+
+    def getBody(params) {
+        String.valueOf(_getJobParameters(params) as JSON)
+    }
+
+    def onResponseSuccess = { resp, json ->
+        return json //as JSON
+    }
+
+    def _getJobParameters(params) {
+        if (!params.jobParameters) {
+            throw new Exception("No parameters passed to ${this.class.simpleName}")
+        }
+
+        return _roundUpEndTime(JSON.parse(params.jobParameters))
+    }
+
+    // This is to compensate for a lack of precision in the timestamps that NcWMS publishes
+    // (millisecond, whereas the NetCDF files can contain more precise timestamps).
+    def _roundUpEndTime(jobParams) {
+        if (jobParams?.subsetDescriptor?.temporalExtent?.end) {
+            def endTime =
+                jobParams.subsetDescriptor.temporalExtent.end.replace('Z', '999Z')
+            jobParams.subsetDescriptor.temporalExtent.end = endTime
+        }
+
+        return jobParams
+    }
+}
+
+
+

--- a/grails-app/views/_js_includes.gsp
+++ b/grails-app/views/_js_includes.gsp
@@ -172,6 +172,7 @@
     <script type="text/javascript" src="${resource(dir: 'js/portal/cart', file: 'DownloadEmailPanel.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/cart', file: 'DownloadChallengePanel.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/cart', file: 'DownloadConfirmationWindow.js')}"></script>
+    <script type="text/javascript" src="${resource(dir: 'js/portal/cart', file: 'DownloadCalculatorPanel.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/cart', file: 'InsertionService.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/cart', file: 'BaseInjector.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/cart', file: 'NoDataInjector.js')}"></script>

--- a/src/test/javascript/portal/cart/DownloadChallengePanelSpec.js
+++ b/src/test/javascript/portal/cart/DownloadChallengePanelSpec.js
@@ -17,7 +17,7 @@ describe("Portal.cart.DownloadChallengePanel", function() {
 
         it('hides challenge', function() {
             spyOn(panel, '_hideChallenge');
-            resp = { responseText: "" }
+            resp = { responseText: "" };
             panel._configureChallengeHtmlElements(resp);
             expect(panel._hideChallenge).toHaveBeenCalled();
         });

--- a/src/test/javascript/portal/cart/DownloadConfirmationWindowSpec.js
+++ b/src/test/javascript/portal/cart/DownloadConfirmationWindowSpec.js
@@ -39,18 +39,12 @@ describe("Portal.cart.DownloadConfirmationWindow", function() {
             beforeEach(function() {
                 spyOn(confirmationWindow.downloadEmailPanel, 'show');
                 spyOn(confirmationWindow.downloadEmailPanel, 'hide');
-
-                spyOn(confirmationWindow.downloadChallengePanel, 'show');
-                spyOn(confirmationWindow.downloadChallengePanel, 'hide');
             });
 
             it('shows when required', function() {
                 confirmationWindow.show({ collectEmailAddress: true, collection: mockCollection });
                 expect(confirmationWindow.downloadEmailPanel.show).toHaveBeenCalled();
                 expect(confirmationWindow.downloadEmailPanel.hide).not.toHaveBeenCalled();
-
-                expect(confirmationWindow.downloadChallengePanel.show).toHaveBeenCalled();
-                expect(confirmationWindow.downloadChallengePanel.hide).not.toHaveBeenCalled();
             });
 
             it('hides when required', function() {
@@ -58,8 +52,6 @@ describe("Portal.cart.DownloadConfirmationWindow", function() {
                 expect(confirmationWindow.downloadEmailPanel.show).not.toHaveBeenCalled();
                 expect(confirmationWindow.downloadEmailPanel.hide).toHaveBeenCalled();
 
-                expect(confirmationWindow.downloadChallengePanel.show).not.toHaveBeenCalled();
-                expect(confirmationWindow.downloadChallengePanel.hide).toHaveBeenCalled();
             });
 
             describe('download button', function() {

--- a/src/test/javascript/portal/cart/DownloadEmailPanelSpec.js
+++ b/src/test/javascript/portal/cart/DownloadEmailPanelSpec.js
@@ -15,6 +15,11 @@ describe("Portal.cart.DownloadEmailPanel", function() {
         });
     });
 
+    var mockCollection = {
+        getMetadataRecord: returns({ data: '' })
+    };
+
+
     it('gets email address from email field', function() {
         spyOn(panel.emailField, 'getValue');
         panel.getEmailValue();
@@ -55,6 +60,17 @@ describe("Portal.cart.DownloadEmailPanel", function() {
                 var returnVal = panel._validateEmailAddress('user@domain.com');
                 expect(returnVal).toBe(true);
             });
+        });
+
+    });
+
+    describe('resets challenge address panel', function() {
+
+        it('resets when required', function() {
+            spyOn(panel.downloadChallengePanel, '_doReset');
+            panel.show({collectEmailAddress: true, collection: mockCollection});
+
+            expect(panel.downloadChallengePanel._doReset).toHaveBeenCalled();
         });
 
     });

--- a/src/test/javascript/portal/cart/DownloadPanelSpec.js
+++ b/src/test/javascript/portal/cart/DownloadPanelSpec.js
@@ -210,43 +210,48 @@ describe("Portal.cart.DownloadPanel", function() {
     describe('confirmDownload', function() {
 
         it('calls trackUsage when the user accepts download', function() {
-            var testParams = {
-                filenameFormat: "{0}.csv",
-                downloadLabel: 'List of URLs'
-            };
+
             var testCollection = makeTestCollection();
             testCollection.getFilters = returns();
             var callbackScope = downloadPanel;
-            var callback = noOp;
+            var testKey = "downloadAsCsvLabel";
+            var downloadOptions = {};
+            downloadOptions.handlerParams = {
+                filenameFormat: "{0}.csv",
+                downloadLabel: 'List of URLs'
+            };
+            downloadOptions.handler = noOp;
             $.fileDownload = noOp;
 
             spyOn(downloadPanel.confirmationWindow, 'show');
             spyOn(window, 'trackUsage');
             spyOn(window, 'trackUserUsage');
 
-            downloadPanel.confirmDownload(testCollection, callbackScope, callback, testParams);
-            testParams.onAccept(testParams);
-            expect(window.trackUsage).toHaveBeenCalledWith(OpenLayers.i18n('downloadTrackingCategory'), OpenLayers.i18n('downloadTrackingActionPrefix') + testParams.downloadLabel, testCollection.getTitle(), null);
+            downloadPanel.confirmDownload(testCollection, callbackScope, downloadOptions);
+            downloadOptions.handlerParams.onAccept(downloadOptions.handlerParams);
+            expect(window.trackUsage).toHaveBeenCalledWith(OpenLayers.i18n('downloadTrackingCategory'), OpenLayers.i18n('downloadTrackingActionPrefix') + downloadOptions.handlerParams.downloadLabel, testCollection.getTitle(), null);
             expect(window.trackUserUsage).not.toHaveBeenCalled();
         });
 
         it('calls track User Usage when the user accepts download', function() {
-            var testParams = {
+
+            var testCollection = makeTestCollection();
+            testCollection.getFilters = returns();
+            var callbackScope = downloadPanel;
+            var downloadOptions = {};
+            downloadOptions.handlerParams = {
                 filenameFormat: "{0}.csv",
                 downloadLabel: 'List of URLs',
                 emailAddress: "me@here.com"
             };
-            var testCollection = makeTestCollection();
-            testCollection.getFilters = returns();
-            var callbackScope = downloadPanel;
-            var callback = noOp;
+            downloadOptions.handler = noOp;
             $.fileDownload = noOp;
 
             spyOn(downloadPanel.confirmationWindow, 'show');
             spyOn(window, 'trackUserUsage');
 
-            downloadPanel.confirmDownload(testCollection, callbackScope, callback, testParams);
-            testParams.onAccept(testParams);
+            downloadPanel.confirmDownload(testCollection, callbackScope, downloadOptions);
+            downloadOptions.handlerParams.onAccept(downloadOptions.handlerParams);
             expect(window.trackUserUsage).toHaveBeenCalled();
 
         });

--- a/src/test/javascript/portal/cart/InsertionServiceSpec.js
+++ b/src/test/javascript/portal/cart/InsertionServiceSpec.js
@@ -53,25 +53,6 @@ describe('Portal.cart.InsertionService', function() {
         });
     });
 
-    describe('download confirmation', function() {
-        it('delegates to the download panel for confirmation', function() {
-            mockInsertionService.downloadPanel = {
-                confirmDownload: noOp
-            };
-            spyOn(mockInsertionService.downloadPanel, 'confirmDownload');
-
-            var collection = {};
-            var callback = noOp;
-            var params = {};
-
-            mockInsertionService.downloadWithConfirmation(collection, this, callback, params);
-
-            expect(mockInsertionService.downloadPanel.confirmDownload).toHaveBeenCalledWith(
-                collection, this, callback, params
-            );
-        });
-    });
-
     function expectGetInjectorToHaveBeenCalled(injectorConstructor) {
 
         var injectorConstructors = [

--- a/test/unit/au/org/emii/portal/AsyncDownloadControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/AsyncDownloadControllerTests.groovy
@@ -40,7 +40,7 @@ class AsyncDownloadControllerTests extends ControllerUnitTestCase {
 
         controller.index()
 
-        assertEquals HTTP_500_INTERNAL_SERVER_ERROR, controller.renderArgs.status
+        assertEquals HTTP_401_UNAUTHORISED, controller.renderArgs.status
     }
 
     void testParametersPassedToAggregatorService() {

--- a/web-app/css/AODNTheme.css
+++ b/web-app/css/AODNTheme.css
@@ -337,7 +337,7 @@ ul.x-tab-strip-top li:hover * {
 .ext-webkit .x-form-invalid,
 .x-form-invalid
 {
-    background-color: inherit;
+    background-color: whitesmoke;
 }
 
 input[type=text]:read-only {

--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -384,6 +384,10 @@ a:hover.mainlinks {
     font-weight: bold;
 }
 
+.alert-attention {
+    background-color: #eeeeee;
+}
+
 .alert-warning, .alert-warning * {
     color: #8a6d3b;
 }
@@ -391,7 +395,6 @@ a:hover.mainlinks {
 .alert {
     border: 1px solid transparent;
     border-radius: 4px;
-    margin-bottom: 20px;
     padding: 15px;
 }
 
@@ -996,10 +999,6 @@ div.allwhite {
 
 .resultsHeaderBackground .x-panel-header {
     padding: 0 5px;
-}
-
-.downloadEmailPanel {
-    background-color: #eeeeee;
 }
 
 .facetedSearchBtn {

--- a/web-app/js/portal/cart/BaseInjector.js
+++ b/web-app/js/portal/cart/BaseInjector.js
@@ -35,18 +35,5 @@ Portal.cart.BaseInjector = Ext.extend(Object, {
         if (Ext.get(elementId)) {
             Ext.fly(elementId).update("");
         }
-    },
-
-    downloadWithConfirmation: function(dataCollection, generateUrlCallback, params) {
-
-        return function() {
-            this.downloadConfirmation.call(
-                this.downloadConfirmationScope,
-                dataCollection,
-                this,
-                generateUrlCallback,
-                params
-            );
-        };
     }
 });

--- a/web-app/js/portal/cart/DownloadCalculatorPanel.js
+++ b/web-app/js/portal/cart/DownloadCalculatorPanel.js
@@ -1,0 +1,43 @@
+Ext.namespace('Portal.cart');
+
+Portal.cart.DownloadCalculatorPanel = Ext.extend(Ext.Panel, {
+
+
+    initComponent: function() {
+
+        Ext.apply(this, {
+            html: this.getFormattedContent(OpenLayers.i18n('downloadCalculatorLoadingContent')),
+            cls: "alert alert-warning"
+        });
+
+        Portal.cart.DownloadCalculatorPanel.superclass.initComponent.apply(this, arguments);
+    },
+
+    getContent: function(downloadUrl) {
+        log.debug('downloading estimator asynchronously', downloadUrl);
+
+        Ext.Ajax.request({
+            url: downloadUrl,
+            scope: this,
+            success: function(response) {
+                this._onSuccess(response);
+            },
+            failure: function(response) {
+                this._onFailure(response);
+            }
+        });
+    },
+
+    _onSuccess: function(response) {
+        this.update(this.getFormattedContent(response.responseText));
+    },
+
+    _onFailure: function(response) {
+        var msg = String.format("Unable to estimate file size: '{0}'", response.statusText);
+        this.update(msg);
+    },
+
+    getFormattedContent: function(msg) {
+        return String.format("<h3>{0}</h3>",msg);
+    }
+});

--- a/web-app/js/portal/cart/DownloadChallengePanel.js
+++ b/web-app/js/portal/cart/DownloadChallengePanel.js
@@ -13,10 +13,9 @@ Portal.cart.DownloadChallengePanel = Ext.extend(Ext.Panel, {
         });
 
         var config = {
-            padding: 10,
             cls: 'downloadChallengePanel',
             items: [
-                {xtype: 'spacer', height: 5},
+                {xtype: 'spacer', height: 10},
                 {
                     html: "<div id='challenge'></div>"
                 },
@@ -25,13 +24,13 @@ Portal.cart.DownloadChallengePanel = Ext.extend(Ext.Panel, {
                     text: OpenLayers.i18n('challengeInstructions')
                 },
                 {xtype: 'spacer', height: 5},
-                this.challengeResponseField
+                this.challengeResponseField,
+                {xtype: 'spacer', height: 10}
             ],
             listeners: {
                 scope: this,
                 show: function() {
-                    this._getChallenge();
-                    this.challengeResponseField.reset();
+                    this._doReset();
                 }
             }
         };
@@ -41,6 +40,11 @@ Portal.cart.DownloadChallengePanel = Ext.extend(Ext.Panel, {
         Portal.cart.DownloadChallengePanel.superclass.initComponent.call(this, arguments);
 
         this._hideChallenge();
+    },
+
+    _doReset: function() {
+        this._getChallenge();
+        this.challengeResponseField.reset();
     },
 
     _getChallenge: function() {

--- a/web-app/js/portal/cart/DownloadConfirmationWindow.js
+++ b/web-app/js/portal/cart/DownloadConfirmationWindow.js
@@ -3,7 +3,7 @@ Ext.namespace('Portal.cart');
 Portal.cart.DownloadConfirmationWindow = Ext.extend(Ext.Window, {
 
     WINDOW_WIDTH: 780,
-    WINDOW_HEIGHT: 360,
+    WINDOW_HEIGHT: 570,
 
     initComponent: function() {
 
@@ -35,18 +35,19 @@ Portal.cart.DownloadConfirmationWindow = Ext.extend(Ext.Window, {
                 scope: this,
                 'valid': function() {
                     if (this.downloadEmailPanel.isVisible()) {
-                        this.downloadButton.enable()
+                        this.downloadButton.enable();
                     }
                 },
                 'invalid': function() {
                     if (this.downloadEmailPanel.isVisible()) {
-                        this.downloadButton.disable()
+                        this.downloadButton.disable();
                     }
                 }
+
             }
         });
 
-        this.downloadChallengePanel = new Portal.cart.DownloadChallengePanel({});
+        this.downloadCalculatorPanel = new Portal.cart.DownloadCalculatorPanel();
 
         Ext.apply(this, {
             title:OpenLayers.i18n('downloadConfirmationWindowTitle'),
@@ -56,12 +57,11 @@ Portal.cart.DownloadConfirmationWindow = Ext.extend(Ext.Window, {
             height: this.WINDOW_HEIGHT,
             width: this.WINDOW_WIDTH,
             items: {
-                padding: 5,
-                xtype: 'form',
                 items: [
                     this.downloadEmailPanel,
-                    this.downloadChallengePanel,
-                    {xtype: 'spacer', height: 20},
+                    {xtype: 'spacer', height: 5},
+                    this.downloadCalculatorPanel,
+                    {xtype: 'spacer', height: 15},
                     this.contentPanel
                 ],
                 buttons: [this.downloadButton, cancelButton],
@@ -104,6 +104,8 @@ Portal.cart.DownloadConfirmationWindow = Ext.extend(Ext.Window, {
         this.params = params;
         this.onAcceptCallback = params.onAccept;
 
+        this._showDownloadCalculatorPanelIfNeeded();
+
         Portal.cart.DownloadConfirmationWindow.superclass.show.call(this);
 
         var metadataRecord = params.collection.getMetadataRecord();
@@ -120,13 +122,23 @@ Portal.cart.DownloadConfirmationWindow = Ext.extend(Ext.Window, {
 
         if (params.collectEmailAddress) {
             this.downloadEmailPanel.show();
-            this.downloadChallengePanel.show();
             this.downloadButton.disable();
         }
         else {
             this.downloadEmailPanel.hide();
-            this.downloadChallengePanel.hide();
             this.downloadButton.enable();
+        }
+    },
+
+    _showDownloadCalculatorPanelIfNeeded: function() {
+
+        if (this.params.onLoadConfirmationWindow) {
+
+            this.params.onLoadConfirmationWindow(this.params);
+            this.downloadCalculatorPanel.show();
+        }
+        else {
+            this.downloadCalculatorPanel.hide();
         }
     },
 
@@ -135,8 +147,8 @@ Portal.cart.DownloadConfirmationWindow = Ext.extend(Ext.Window, {
 
         if (this.onAcceptCallback) {
             this.params.emailAddress = this.downloadEmailPanel.getEmailValue();
-            if (this.downloadChallengePanel.isChallenged()) {
-                this.params.challengeResponse = this.downloadChallengePanel.getChallengeResponseValue();
+            if (this.downloadEmailPanel.downloadChallengePanel.isChallenged()) {
+                this.params.challengeResponse = this.downloadEmailPanel.downloadChallengePanel.getChallengeResponseValue();
             }
             this.onAcceptCallback(this.params);
         }

--- a/web-app/js/portal/cart/DownloadEmailPanel.js
+++ b/web-app/js/portal/cart/DownloadEmailPanel.js
@@ -11,6 +11,8 @@ Portal.cart.DownloadEmailPanel = Ext.extend(Ext.Panel, {
             emailVal = Ext.util.Cookies.get('emailField');
         }
 
+        this.downloadChallengePanel = new Portal.cart.DownloadChallengePanel();
+
         this.emailField = new Ext.form.TextField({
             name: "emailField",
             value: emailVal,
@@ -22,20 +24,21 @@ Portal.cart.DownloadEmailPanel = Ext.extend(Ext.Panel, {
         });
 
         var config = {
-            padding: 10,
-            cls: 'downloadEmailPanel',
+            cls: 'alert alert-attention',
             items: [
                 {xtype: 'spacer', height: 5},
                 this.emailField,
                 {xtype: 'spacer', height: 5},
                 {
                     html: OpenLayers.i18n('notificationBlurbMessage')
-                }
+                },
+                this.downloadChallengePanel
             ],
             listeners: {
                 scope: this,
                 'show': function() {
                     this.emailField.focus();
+                    this.downloadChallengePanel._doReset();
                     var the = this;
                     setTimeout(function() { the.emailField.validate(); }, 200 );
                 }
@@ -52,7 +55,6 @@ Portal.cart.DownloadEmailPanel = Ext.extend(Ext.Panel, {
         Ext.util.Cookies.set('emailField', emailValue, new Date().add(Date.DAY, 90));
         return emailValue;
     },
-
 
     _validateEmailAddress: function(address) {
         if (!address) {

--- a/web-app/js/portal/cart/DownloadPanel.js
+++ b/web-app/js/portal/cart/DownloadPanel.js
@@ -218,12 +218,13 @@ Portal.cart.DownloadPanel = Ext.extend(Ext.Panel, {
     },
 
     _getMenuItem: function(handler, downloadOption, collection) {
+
         return {
             name: handler.onlineResource.name,
             title: handler.onlineResource.title,
             text: OpenLayers.i18n(downloadOption.textKey),
             handler: function() {
-                this.confirmDownload(collection, this, downloadOption.handler, downloadOption.handlerParams);
+                this.confirmDownload(collection, this, downloadOption);
             },
             scope: this
         }
@@ -285,16 +286,15 @@ Portal.cart.DownloadPanel = Ext.extend(Ext.Panel, {
         return (regexRes && regexRes[1].length > 0) ? regexRes[1].toTitleCase() : false;
     },
 
-    confirmDownload: function(collection, generateUrlCallbackScope, generateUrlCallback, params) {
+    confirmDownload: function(collection, generateUrlCallbackScope, downloadOption) {
 
         var self = this;
-
-        params = params || {};
+        params = downloadOption.handlerParams || {};
         params.collection = collection;
 
         params.onAccept = function(callbackParams) {
 
-            self.downloader.download(collection, generateUrlCallbackScope, generateUrlCallback, callbackParams);
+            self.downloader.download(collection, generateUrlCallbackScope, downloadOption.handler, downloadOption.handlerParams);
             var trackingAction = OpenLayers.i18n('downloadTrackingActionPrefix') + callbackParams.downloadLabel;
 
             trackDownloadUsage(
@@ -316,6 +316,12 @@ Portal.cart.DownloadPanel = Ext.extend(Ext.Panel, {
                 );
             }
         };
+
+        if (downloadOption.downloadSizeHandler) {
+            params.onLoadConfirmationWindow = function(callbackParams) {
+                self.confirmationWindow.downloadCalculatorPanel.getContent(downloadOption.downloadSizeHandler(collection, callbackParams));
+            };
+        }
         this.confirmationWindow.show(params);
     },
 

--- a/web-app/js/portal/cart/DownloadPanelItemTemplate.js
+++ b/web-app/js/portal/cart/DownloadPanelItemTemplate.js
@@ -153,7 +153,7 @@ Portal.cart.DownloadPanelItemTemplate = Ext.extend(Ext.XTemplate, {
         Ext.fly(elementId).update("");
 
         new Ext.Button({
-            text: "<span class=\"fa fa-spin fa-spinner \"></span> " + OpenLayers.i18n('downloadStatusRequested'),
+            text: "<span class=\"fa fa-fw fa-spin fa-spinner \"></span> " + OpenLayers.i18n('downloadStatusRequested'),
             cls: 'navigationButton navigationButtonActive',
             scope: this,
             disabled: true,

--- a/web-app/js/portal/cart/Downloader.js
+++ b/web-app/js/portal/cart/Downloader.js
@@ -134,7 +134,7 @@ Portal.cart.Downloader = Ext.extend(Ext.util.Observable, {
 
     _onAsyncDownloadRequestFailure: function(response) {
 
-        var msg = String.format("Error! The server response was: '{0}'<BR>{1}", response.statusText, OpenLayers.i18n('asyncDownloadErrorMsg'));
+        var msg = String.format("<h2 class='alert alert-danger'>Error! {0}</h2>{1}", response.responseText, OpenLayers.i18n('asyncDownloadErrorMsg'));
 
         this.messageBox.show({
             title: OpenLayers.i18n('asyncDownloadPanelTitle'),
@@ -142,6 +142,7 @@ Portal.cart.Downloader = Ext.extend(Ext.util.Observable, {
             width: this.ALERTWIDTH
         });
     },
+
 
     _sanitiseFilename: function(str) {
         return str.replace(/:/g, "#").replace(/[/\\ ]/g, "_");

--- a/web-app/js/portal/cart/InsertionService.js
+++ b/web-app/js/portal/cart/InsertionService.js
@@ -9,23 +9,18 @@ Portal.cart.InsertionService = Ext.extend(Object, {
 
     insertionValues: function(collection) {
 
-        var config = {
-            downloadConfirmation: this.downloadWithConfirmation,
-            downloadConfirmationScope: this
-        };
-
         var htmlInjection;
 
         if (this._isCollectionDownloadable(collection)) {
             if (collection.isNcwms()) {
-                htmlInjection = new Portal.cart.NcWmsInjector(config);
+                htmlInjection = new Portal.cart.NcWmsInjector();
             }
             else {
-                htmlInjection = new Portal.cart.WmsInjector(config);
+                htmlInjection = new Portal.cart.WmsInjector();
             }
         }
         else {
-            htmlInjection = new Portal.cart.NoDataInjector(config);
+            htmlInjection = new Portal.cart.NoDataInjector();
         }
 
         return htmlInjection.getInjectionJson(collection);
@@ -34,9 +29,5 @@ Portal.cart.InsertionService = Ext.extend(Object, {
     _isCollectionDownloadable: function(collection) {
         var downloadHandlers = Portal.cart.DownloadHandler.handlersForDataCollection(collection);
         return downloadHandlers.length > 0;
-    },
-
-    downloadWithConfirmation: function(collection, generateUrlCallbackScope, generateUrlCallback, params) {
-        this.downloadPanel.confirmDownload(collection, generateUrlCallbackScope, generateUrlCallback, params);
     }
 });

--- a/web-app/js/portal/cart/NetcdfSubsetServiceDownloadHandler.js
+++ b/web-app/js/portal/cart/NetcdfSubsetServiceDownloadHandler.js
@@ -28,6 +28,58 @@ Portal.cart.NetcdfSubsetServiceDownloadHandler = Ext.extend(Portal.cart.AsyncDow
         );
     },
 
+    _buildCalculatorUrl: function(filters, layerName, serverUrl, notificationEmailAddress) {
+
+        var cqlFilter = this._getSubset(filters);
+
+        return String.format(
+            "{0}{1}",
+            this.getAsyncDownloadUrl('calculator'),
+            Ext.urlEncode({
+                server: serverUrl,
+                jobType: 'NetcdfOutput',
+                mimeType: 'application/zip',
+                'jobParameters.typeName': layerName,
+                'jobParameters.cqlFilter': cqlFilter
+            })
+        );
+    },
+
+    getDownloadOptions: function(filters) {
+
+        var downloadOptions = [];
+
+        if (this._showDownloadOptions(filters)) {
+
+            downloadOptions.push({
+                textKey: this._getDownloadOptionTextKey(),
+                handler: this._getUrlGeneratorFunction(),
+                downloadSizeHandler: this._getEstimatorUrlGeneratorFunction(),
+                handlerParams: {
+                    asyncDownload: true,
+                    collectEmailAddress: true,
+                    serviceResponseHandler: this.serviceResponseHandler
+                }
+            });
+        }
+        return downloadOptions;
+    },
+
+    _getEstimatorUrlGeneratorFunction: function() {
+
+        var _this = this;
+
+        return function(collection, handlerParams) {
+            var url = _this._buildCalculatorUrl(
+                collection.getFilters(),
+                _this._resourceName(),
+                _this._resourceHref()
+            );
+            return url;
+        };
+    },
+
+
     _getSubset: function(filters) {
         var builder = new Portal.filter.combiner.DataDownloadCqlBuilder({
             filters: filters

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -119,7 +119,7 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
     // Download View
     downloadConfirmationWindowTitle: 'Data Download',
     downloadConfirmationWindowContent: " \
-  <h3>Licence and use limitations</h3> \
+  <h2>Licence and use limitations</h2> \
     <p> \
       <tpl if=\"jurisdictionLink\"><a target=\"_blank\" href=\"{jurisdictionLink}\">Jurisdiction</a></tpl> \
       <tpl if=\"imageLink\"><img src=\"{imageLink}\" /></tpl> \
@@ -146,6 +146,7 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
     downloadConfirmationCancelText: 'Cancel',
     challengeInstructions: 'Type the characters you see in the image above',
     downloadErrorText: 'There is a problem with the availability of your selected data download.',
+    downloadCalculatorLoadingContent: '<span class="fa fa-fw fa-spinner fa-spin "></span> Estimating download size....',
 
     // mainMapPanel
     layerExistsTitle: 'Add data collection',

--- a/web-app/js/portal/search/SearchFiltersPanel.js
+++ b/web-app/js/portal/search/SearchFiltersPanel.js
@@ -109,7 +109,7 @@ Portal.search.SearchFiltersPanel = Ext.extend(Ext.Panel, {
     },
 
     _makeSpinnerText: function(text) {
-        return '<span class=\"fa fa-spin fa-spinner \"></span> ' + text;
+        return '<span class=\"fa fa-fw fa-spin fa-spinner \"></span> ' + text;
     },
 
     _hideSpinnerText: function() {


### PR DESCRIPTION
***DONT MERGE YET***
Requires new NetcdfSubsetDownload Geoserver service (JavaDuck), replacing GoGoDuck
Requires completion of NetcdfSubsetDownloadCalculatorService to call the download calculator in JavaDuck

### Features:
- Uniform bootsrap spinners
- Styling of calculator results similar to Step 3 messages
- Captcha inside the grey border of the email form in download dialog box
- Custom message from Auth Controller when captcha not correct
- Stub output from the new NetcdfSubsetDownloadCalculatorService

## Setting up dev env to test
Load a ncWms layer in dev environment with config.groovy modified with:
```

    // Download handler config (online resource protocol -> DownloadHandler class)
    downloadHandlersForProtocol = [
        [ 'handler': 'WfsDownloadHandler',                 'protocol': 'OGC:WFS-1.0.0-http-get-capabilities' ],
        //[ 'handler': 'GogoduckDownloadHandler',            'protocol': 'OGC:WPS--gogoduck'                   ],
        //[ 'handler': 'PointCSVDownloadHandler',            'protocol': 'OGC:WPS--gogoduck'                   ],
        [ 'handler': 'NetcdfSubsetServiceDownloadHandler', 'protocol': 'OGC:WPS--gogoduck'      ],
```

To test that Capcha works in dev environment, change config.groovy:
```
downloadAuth {
    // Never show a captcha to those IP addresses
    whitelistClients = [
        
    ]

    // Treat those as usual even if they're whitelisted
    blacklistClients = []

    // Allow users to have to 2 aggregated downloads every 10 minutes without
    // displaying a challenge (captcha)
    maxAggregatedDownloadsInPeriod = 0  ....
```
