### PR TITLE
Fixes #2478 Update Geonetwork URL called to update popularity

### DIFF
--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -318,7 +318,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
 
         // Updating the popularity counter of the metadata record at GeoNetwork
         Ext.ux.Ajax.proxyRequestXML({
-            url: Portal.app.appConfig.geonetwork.url + '/srv/eng/xml_iso19139?uuid=' + uuid
+            url: Portal.app.appConfig.geonetwork.url + '/srv/eng/xml_iso19139.mcp?uuid=' + uuid + "&styleSheet=xml_iso19139.mcp.xsl"
         });
     },
 


### PR DESCRIPTION
Fixes the console red. Thanks for providing the fix @julian1 

@jonescc Is this still the best way to update the Geonetwork popularity?
This URL now returns about a thousand lines of unused response