### PR TITLE
Update slf4j version to be later than used by other dependences

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.5.8</version>
+            <version>1.7.25</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -182,7 +182,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.5.8</version>
+            <version>1.7.25</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
Currently the slf4j api version was 1.7.5 but slf4j-log4j12 impl was 1.5.8
which causes errors.