### PR TITLE
Allows ncWMS downloading of datasets that have no Temporal information

### DIFF
--- a/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
+++ b/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
@@ -38,13 +38,20 @@ describe('Portal.cart.NcWmsInjector', function() {
             expect(injector._getDataFilterEntry(dataCollection)).not.toEqual(String.format("<i>{0}<i>", OpenLayers.i18n("noFilterLabel")));
         });
 
-        it('returns an empty message when no defined date', function() {
+        it('returns a message when no valid date', function() {
+            dataCollection.getFilters = returns([{
+                isNcwmsParams: true
+            }]);
+            expect(injector._getDataFilterEntry(dataCollection)).toEqual(OpenLayers.i18n('unavailableTemporalExtent'));
+        });
+
+        it('returns a message when no temporal subset is possible', function() {
             dataCollection.getFilters = returns([{
                 isNcwmsParams: true,
-                dateRangeStart: null
+                name: "time"
             }]);
-
             expect(injector._getDataFilterEntry(dataCollection)).toEqual(OpenLayers.i18n('temporalExtentNotLoaded'));
+
         });
 
         it('indicates bounds properly created', function() {
@@ -92,7 +99,6 @@ describe('Portal.cart.NcWmsInjector', function() {
             })]);
 
             var entry = injector._getDataFilterEntry(dataCollection);
-            console.log(dataCollection.getFilters());
             expect(entry).toEqual(
                 String.format('{0}:&nbsp;-23.654, 114.567<br>{1}:&nbsp;{2} to {3}<br>',
                     OpenLayers.i18n("timeSeriesAtHeading"),

--- a/src/test/javascript/portal/details/NcWmsPanelSpec.js
+++ b/src/test/javascript/portal/details/NcWmsPanelSpec.js
@@ -42,7 +42,7 @@ describe('Portal.details.NcWmsPanel', function() {
         });
 
         ncwmsPanel._setBounds = noOp;
-        ncwmsPanel._removeLoadingInfo = noOp;
+        ncwmsPanel._hideStatusInfo = noOp;
         ncwmsPanel.selectedLayer = layer;
         ncwmsPanel.pointTimeSeriesPanel = {
             _resetPanel: returns()
@@ -56,7 +56,7 @@ describe('Portal.details.NcWmsPanel', function() {
 
         it('assigns a DataCollection instance from a layer', function() {
             _applyCommonSpies();
-            spyOn(ncwmsPanel, '_removeLoadingInfo');
+            spyOn(ncwmsPanel, '_hideStatusInfo');
 
             ncwmsPanel._initWithLayer();
             expect(ncwmsPanel.dataCollection).toBeTruthy();
@@ -135,18 +135,18 @@ describe('Portal.details.NcWmsPanel', function() {
 
     describe('layer temporal extent load', function() {
         it('enables the start date picker', function() {
-            ncwmsPanel._layerTemporalExtentLoad();
+            ncwmsPanel._layerTemporalExtentLoad(layer);
             expect(ncwmsPanel.startDateTimePicker.disabled).toBeFalsy();
         });
 
         it('enables the end date picker', function() {
-            ncwmsPanel._layerTemporalExtentLoad();
+            ncwmsPanel._layerTemporalExtentLoad(layer);
             expect(ncwmsPanel.endDateTimePicker.disabled).toBeFalsy();
         });
 
         it('updates the time range label', function() {
             spyOn(ncwmsPanel, '_updateTimeRangeLabel');
-            ncwmsPanel._layerTemporalExtentLoad();
+            ncwmsPanel._layerTemporalExtentLoad(layer);
             expect(ncwmsPanel._updateTimeRangeLabel).toHaveBeenCalled();
         });
     });

--- a/src/test/javascript/portal/ui/openlayers/layer/NcWmsSpec.js
+++ b/src/test/javascript/portal/ui/openlayers/layer/NcWmsSpec.js
@@ -183,7 +183,6 @@ describe("OpenLayers.Layer.NcWms", function() {
 
     it('async parses dates from NcWMS GetMetadata JSON', function() {
         var ncwmsFiltersJson = '[{"label":"Time","type":"TimeSeries","name":"timesteps","possibleValues":["2010-02-23T00:00:00Z","2010-03-10T00:00:00Z","2010-03-11T00:00:00Z","2010-03-12T00:00:00Z","2010-03-13T00:00:00Z"]}]';
-        var ncwmsFilters = Ext.util.JSON.decode(ncwmsFiltersJson);
 
         var datesWithData = null;
 
@@ -192,8 +191,9 @@ describe("OpenLayers.Layer.NcWms", function() {
                 datesWithData = cachedLayer.temporalExtent.getDays();
             }
         );
-
-        cachedLayer._parseDatesWithDataAsync(ncwmsFilters);
+        var ncwmsFilters = Ext.util.JSON.decode(ncwmsFiltersJson)[0];
+        var datesToProcess = ncwmsFilters['possibleValues'];
+        cachedLayer._parseDatesWithDataAsync(datesToProcess);
 
         // Wait for function to return
         waitsFor(function() {

--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -395,6 +395,7 @@ a:hover.mainlinks {
     padding: 15px;
 }
 
+
 /*
 Geoserver default tables in external GFI
 */

--- a/web-app/js/portal/cart/GogoduckDownloadHandler.js
+++ b/web-app/js/portal/cart/GogoduckDownloadHandler.js
@@ -3,6 +3,7 @@ Ext.namespace('Portal.cart');
 Portal.cart.GogoduckDownloadHandler = Ext.extend(Portal.cart.AsyncDownloadHandler, {
 
     SUBSET_FORMAT: 'TIME,{0},{1};LATITUDE,{2},{3};LONGITUDE,{4},{5}',
+    SUBSET_FORMAT_WITHOUT_TIME: 'LATITUDE,{2},{3};LONGITUDE,{4},{5}',
 
     _getDownloadOptionTextKey: function() {
         return 'downloadAsSubsettedNetCdfLabel';
@@ -39,14 +40,19 @@ Portal.cart.GogoduckDownloadHandler = Ext.extend(Portal.cart.AsyncDownloadHandle
             return filter.isNcwmsParams;
         })[0];
 
+        var dateRangeStart = (aggregationParams) ?  this._formatDate(aggregationParams.dateRangeStart || this.DEFAULT_DATE_START) : undefined;
+        var dateRangeEnd = (aggregationParams) ?  this._formatDate(aggregationParams.dateRangeEnd || this.DEFAULT_DATE_END) : undefined;
+
+        var returnStringFormat = (dateRangeStart != undefined || dateRangeEnd != undefined) ? this.SUBSET_FORMAT : this.SUBSET_FORMAT_WITHOUT_TIME;
+
         return String.format(
-            this.SUBSET_FORMAT,
-            this._formatDate(aggregationParams.dateRangeStart || this.DEFAULT_DATE_START),
-            this._formatDate(aggregationParams.dateRangeEnd || this.DEFAULT_DATE_END),
-            (aggregationParams.latitudeRangeStart || this.DEFAULT_LAT_START).toDecimalString(),
-            (aggregationParams.latitudeRangeEnd || this.DEFAULT_LAT_END).toDecimalString(),
-            (aggregationParams.longitudeRangeStart || this.DEFAULT_LON_START).toDecimalString(),
-            (aggregationParams.longitudeRangeEnd || this.DEFAULT_LON_END).toDecimalString()
+            returnStringFormat,
+            dateRangeStart,
+            dateRangeEnd,
+            (aggregationParams && aggregationParams.latitudeRangeStart || this.DEFAULT_LAT_START).toDecimalString(),
+            (aggregationParams && aggregationParams.latitudeRangeEnd || this.DEFAULT_LAT_END).toDecimalString(),
+            (aggregationParams && aggregationParams.longitudeRangeStart || this.DEFAULT_LON_START).toDecimalString(),
+            (aggregationParams && aggregationParams.longitudeRangeEnd || this.DEFAULT_LON_END).toDecimalString()
         );
     }
 });

--- a/web-app/js/portal/cart/NcWmsInjector.js
+++ b/web-app/js/portal/cart/NcWmsInjector.js
@@ -4,7 +4,13 @@ Ext.namespace('Portal.cart');
 Portal.cart.NcWmsInjector = Ext.extend(Portal.cart.BaseInjector, {
 
     _getDataFilterEntry: function(collection) {
+
         var filters = collection.getFilters();
+
+        var time = filters.filter(function(filter) {
+            return filter.name == "time";
+        })[0];
+
         var params = filters.filter(function(filter) {
             return filter.isNcwmsParams;
         })[0];
@@ -42,6 +48,9 @@ Portal.cart.NcWmsInjector = Ext.extend(Portal.cart.BaseInjector, {
             var startDateString = this._formatDate(params.dateRangeStart);
             var endDateString = this._formatDate(params.dateRangeEnd);
             dateString = this._formatHumanDateInfo('temporalExtentHeading', startDateString, endDateString);
+        }
+        else if (!time) {
+            dateString = OpenLayers.i18n('unavailableTemporalExtent');
         }
         else {
             dateString = OpenLayers.i18n('temporalExtentNotLoaded');

--- a/web-app/js/portal/cart/NcWmsInjector.js
+++ b/web-app/js/portal/cart/NcWmsInjector.js
@@ -7,7 +7,7 @@ Portal.cart.NcWmsInjector = Ext.extend(Portal.cart.BaseInjector, {
 
         var filters = collection.getFilters();
 
-        var time = filters.filter(function(filter) {
+        var timeFilter = filters.filter(function(filter) {
             return filter.name == "time";
         })[0];
 
@@ -44,15 +44,23 @@ Portal.cart.NcWmsInjector = Ext.extend(Portal.cart.BaseInjector, {
             );
         }
 
+
+        console.log(timeFilter);
+
+
+
         if (params && params.dateRangeStart) {
             var startDateString = this._formatDate(params.dateRangeStart);
             var endDateString = this._formatDate(params.dateRangeEnd);
             dateString = this._formatHumanDateInfo('temporalExtentHeading', startDateString, endDateString);
         }
-        else if (!time) {
+        else if (timeFilter != undefined && !timeFilter.hasValue()) {
+// todo
+            console.log("temporal Extent not available");
             dateString = OpenLayers.i18n('unavailableTemporalExtent');
         }
         else {
+            console.log("temporal Extent not yet Loaded");
             dateString = OpenLayers.i18n('temporalExtentNotLoaded');
         }
         return areaString + timeSeriesAtString + dateString;
@@ -64,6 +72,9 @@ Portal.cart.NcWmsInjector = Ext.extend(Portal.cart.BaseInjector, {
         injectionJson.dataFilters = this._getDataFilterEntry(collection);
         if (injectionJson.dataFilters.contains(OpenLayers.i18n('temporalExtentNotLoaded'))) {
             injectionJson.errorMessage = OpenLayers.i18n('temporalExtentNotLoaded');
+        }
+        else if (injectionJson.dataFilters.contains(OpenLayers.i18n('unavailableTemporalExtent'))) {
+            injectionJson.errorMessage = OpenLayers.i18n('unavailableTemporalExtent');
         }
         injectionJson.isTemporalExtentSubsetted = collection.isTemporalExtentSubsetted;
 

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -67,7 +67,7 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
     // Animation Panel
     selectTimePeriod: 'Select ${direction} Time Period',
     selectMapTimePeriod: 'Move Time on Map',
-    errorSelectMapTimePeriod: "End of the Collections available dates",
+    unavailableTemporalExtent: "The dataset has no temporal information",
 
     // tab titles
     subsetPanelTitle: 'Subset',

--- a/web-app/js/portal/ui/openlayers/layer/NcWms.js
+++ b/web-app/js/portal/ui/openlayers/layer/NcWms.js
@@ -67,10 +67,12 @@ OpenLayers.Layer.NcWms = OpenLayers.Class(OpenLayers.Layer.WMS, {
                     }
                     catch (e) {
                         log.error("Could not parse dates for NcWMS layer '" + this.params.LAYERS + "'");
+                        this.events.triggerEvent('temporalextentloaded', this);
                     }
                 }
-
-                this.events.triggerEvent('temporalextentloaded', this);
+                else {
+                    this.events.triggerEvent('temporalextentloaded', this);
+                }
             },
             failure: function() {
                 log.error("Could not get filters for NcWMS layer '" + this.params.LAYERS + "'");

--- a/web-app/js/portal/ui/openlayers/layer/NcWms.js
+++ b/web-app/js/portal/ui/openlayers/layer/NcWms.js
@@ -56,12 +56,21 @@ OpenLayers.Layer.NcWms = OpenLayers.Class(OpenLayers.Layer.WMS, {
             scope: this,
             url: url,
             success: function(resp, options) {
-                try {
-                    this._parseDatesWithDataAsync(Ext.util.JSON.decode(resp.responseText));
+
+                // Assume only one filter which is the one we're after
+                var dateFilter = Ext.util.JSON.decode(resp.responseText)[0];
+                var datesToProcess = dateFilter['possibleValues'];
+
+                if (datesToProcess.length > 0) {
+                    try {
+                        this._parseDatesWithDataAsync(datesToProcess);
+                    }
+                    catch (e) {
+                        log.error("Could not parse dates for NcWMS layer '" + this.params.LAYERS + "'");
+                    }
                 }
-                catch (e) {
-                    log.error("Could not parse filters for NcWMS layer '" + this.params.LAYERS + "'");
-                }
+
+                this.events.triggerEvent('temporalextentloaded', this);
             },
             failure: function() {
                 log.error("Could not get filters for NcWMS layer '" + this.params.LAYERS + "'");
@@ -246,10 +255,7 @@ OpenLayers.Layer.NcWms = OpenLayers.Class(OpenLayers.Layer.WMS, {
         return OpenLayers.Layer.WMS.prototype.getURL.apply(this, [bounds]);
     },
 
-    _parseDatesWithDataAsync: function(response) {
-        // Assume only one filter which is the one we're after
-        var dateFilter = response[0];
-        var datesToProcess = dateFilter['possibleValues'];
+    _parseDatesWithDataAsync: function(datesToProcess) {
 
         // Interleave processing into chunks, browser will be more responsive
         var chunkSize = 256;


### PR DESCRIPTION
This pull request allow ncWMS datasets to be downloaded that have no Temporal information within the file. 
It can be merged now, although the ncWMS download request through Geoserver (JavaDuck) will still fail as Geoserver expects temporal parameters which wont be sent.

See https://github.com/aodn/backlog/issues/594