### PR TITLE
Fix #2481. For some reason the height of the body was being returned …

### DIFF
--- a/web-app/js/portal/jquery.js
+++ b/web-app/js/portal/jquery.js
@@ -4,7 +4,7 @@ jQuery( document ).ready(function() {
         function() {
             var resBody = jQuery(this).children('.facetedSearchResultBody');
             var fullHeight = resBody[0].scrollHeight;
-            var originalHeight = resBody.height();
+            var originalHeight = Math.round(resBody.height());
 
             if (fullHeight > 0  && fullHeight != originalHeight) {
                 resBody.data("originalHeight", originalHeight );


### PR DESCRIPTION
…as a double rather than a rounded integer on non-local machines.

(if you want to test this, go to portal edge and change the code manually in your browser tools)