### PR TITLE
Send workspace and layername together rather than as separate parameters

### DIFF
--- a/src/groovy/au/org/emii/portal/wms/GeoserverServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/GeoserverServer.groovy
@@ -75,9 +75,8 @@ class GeoserverServer extends WmsServer {
     }
 
     def _loadFile(layer, filename) {
-        def workspaceName = getLayerWorkspace(layer)
-        def layerName = getLayerName(layer)
-        def inputFile = new File("$filePath/${workspaceName}/${layerName}/${filename}")
+        layer = layer.replace(':','/')
+        def inputFile = new File("$filePath/${layer}/${filename}")
         return inputFile.text
     }
 
@@ -89,32 +88,12 @@ class GeoserverServer extends WmsServer {
         return outputStream.toString("utf-8")
     }
 
-    static String getLayerWorkspace(fullLayerName) {
-        if (fullLayerName.contains(":")) {
-            return fullLayerName.split(":")[0]
-        }
-        else {
-            return ""
-        }
-    }
-
-    static String getLayerName(fullLayerName) {
-        if (fullLayerName.contains(":")) {
-            return fullLayerName.split(":")[1]
-        }
-        else {
-            return fullLayerName
-        }
-    }
-
     static String _getFiltersUrlBase(server, layer, request, extraOpts) {
-        def workspaceName = getLayerWorkspace(layer)
-        def layerName = getLayerName(layer)
 
         def final service = "layerFilters"
         def final version = "1.0.0"
 
-        return server + "?request=${request}&service=${service}&version=${version}&workspace=${workspaceName}&layer=${layerName}${extraOpts}"
+        return server + "?request=${request}&service=${service}&version=${version}&layer=${layer}${extraOpts}"
     }
 
     static String getFiltersUrl(server, layer) {

--- a/test/unit/au/org/emii/portal/wms/GeoserverServerTests.groovy
+++ b/test/unit/au/org/emii/portal/wms/GeoserverServerTests.groovy
@@ -136,7 +136,7 @@ class GeoserverServerTests extends GrailsUnitTestCase {
         def server = "http://geoserver-123.aodn.org.au/geoserver/wms"
         def layer = "aodn:aodn_dsto_glider_trajectory_map"
         assertEquals(
-            "http://geoserver-123.aodn.org.au/geoserver/wms?request=enabledFilters&service=layerFilters&version=1.0.0&workspace=aodn&layer=aodn_dsto_glider_trajectory_map",
+            "http://geoserver-123.aodn.org.au/geoserver/wms?request=enabledFilters&service=layerFilters&version=1.0.0&layer=aodn:aodn_dsto_glider_trajectory_map",
             geoserverServer.getFiltersUrl(server, layer)
         )
     }
@@ -146,26 +146,8 @@ class GeoserverServerTests extends GrailsUnitTestCase {
         def layer = "aodn:aodn_dsto_glider_trajectory_map"
         def filter = "driftnum"
         assertEquals(
-            "http://geoserver-123.aodn.org.au/geoserver/wms?request=uniqueValues&service=layerFilters&version=1.0.0&workspace=aodn&layer=aodn_dsto_glider_trajectory_map&propertyName=driftnum",
+            "http://geoserver-123.aodn.org.au/geoserver/wms?request=uniqueValues&service=layerFilters&version=1.0.0&layer=aodn:aodn_dsto_glider_trajectory_map&propertyName=driftnum",
             geoserverServer.getFilterValuesUrl(server, layer, filter)
         )
-    }
-
-    void testGetWorkspace() {
-        def fullLayerName = "aodn:aodn_dsto_glider_trajectory_map"
-        def layerName = geoserverServer.getLayerName(fullLayerName)
-        def workspace = geoserverServer.getLayerWorkspace(fullLayerName)
-
-        assertEquals("aodn", workspace)
-        assertEquals("aodn_dsto_glider_trajectory_map", layerName)
-    }
-
-    void testGetWorkspaceWhenNoWorkspaceSpecified() {
-        def fullLayerName = "aodn_dsto_glider_trajectory_map"
-        def layerName = geoserverServer.getLayerName(fullLayerName)
-        def workspace = geoserverServer.getLayerWorkspace(fullLayerName)
-
-        assertEquals("", workspace)
-        assertEquals(fullLayerName, layerName)
     }
 }


### PR DESCRIPTION
for enabledFilters and uniqueValues requests