### PR TITLE
allowAnyHost now works in dev environments.

### DIFF
--- a/web-app/js/portal/data/Server.js
+++ b/web-app/js/portal/data/Server.js
@@ -22,6 +22,10 @@ Portal.data.Server = {
                 return false;
             }
             else {
+                if (Portal.app.appConfig.allowAnyHost) {
+                    serverInfo = server;
+                    return false;
+                }
                 return true;
             }
         });


### PR DESCRIPTION
Sick of having to add to `knownServers` in `Config.groovy`
Fear no more! Filters in step 2 will magically populate in dev environments