### PR TITLE
Issue #2556 - Increase height of the download confirmation window - to prevent scrollbars from being displayed (with current content).  Will improve usability.

### DIFF
--- a/web-app/js/portal/cart/DownloadConfirmationWindow.js
+++ b/web-app/js/portal/cart/DownloadConfirmationWindow.js
@@ -3,7 +3,7 @@ Ext.namespace('Portal.cart');
 Portal.cart.DownloadConfirmationWindow = Ext.extend(Ext.Window, {
 
     WINDOW_WIDTH: 780,
-    WINDOW_HEIGHT: 360,
+    WINDOW_HEIGHT: 445,
 
     initComponent: function() {
 


### PR DESCRIPTION
Increase height of download confirmation window - so that user doesn't have to scroll.