### PR TITLE
Reworking of the test.

### DIFF
--- a/selenium/src/test/java/au/org/emii/portal/tests/step1/ExpandCollapseLargeRecordTest.java
+++ b/selenium/src/test/java/au/org/emii/portal/tests/step1/ExpandCollapseLargeRecordTest.java
@@ -35,36 +35,36 @@ public class ExpandCollapseLargeRecordTest extends BaseTest {
         List<WebElement> spinners = webElementUtil.findElements(By.className("fa-spinner"));
         wait.until(ExpectedConditions.invisibilityOfAllElements(spinners));
 
-        int numberOfRecords = webElementUtil.findElements(By.className("resultsHeaderBackground")).size();
+        List<WebElement> resultsHeaderBackgrounds = webElementUtil.findElements(By.className("resultsHeaderBackground"));
 
-        for (int i = 0; i < numberOfRecords; i++) {
-            List<WebElement> facetedSearchResults = webElementUtil.findElements(By.className("facetedSearchResultBody"));
-            WebElement record = facetedSearchResults.get(i);
+        for (int i = 0; i < resultsHeaderBackgrounds.size(); i++) {
 
-            List<WebElement> recordHeaders = webElementUtil.findElements(By.className("resultsHeaderBackground"));
-            WebElement recordHeader = recordHeaders.get(i);
+            WebElement parent = resultsHeaderBackgrounds.get(i);
+            WebElement facetedSearchResultBody = parent.findElement(By.className("facetedSearchResultBody"));
 
-            String originalHeight = record.getAttribute("style");
-            expandRecord(record, recordHeader, originalHeight);
-            collapseRecord(record, recordHeader, originalHeight);
+            String originalHeight = facetedSearchResultBody.getAttribute("style");
+            expandRecord(parent, facetedSearchResultBody, originalHeight);
+            collapseRecord(parent, facetedSearchResultBody, originalHeight);
         }
-
         log.info("Validation Complete");
     }
 
-    private void expandRecord(WebElement record, WebElement recordHeader, String originalHeight) {
-        String newHeight = clickRecordAndGetNewHeight(record, recordHeader);
+    private void expandRecord(WebElement parent, WebElement facetedSearchResultBody, String originalHeight) {
+
+        String newHeight = clickRecordAndGetNewHeight(parent, facetedSearchResultBody);
         Assert.assertFalse(newHeight.contains(originalHeight));
     }
 
-    private void collapseRecord(WebElement record, WebElement recordHeader, String originalHeight) {
-        String newHeight = clickRecordAndGetNewHeight(record, recordHeader);
+    private void collapseRecord(WebElement parent, WebElement facetedSearchResultBody, String originalHeight) {
+
+        String newHeight = clickRecordAndGetNewHeight(parent, facetedSearchResultBody);
         Assert.assertTrue(newHeight.contains(originalHeight));
     }
 
-    private String clickRecordAndGetNewHeight(WebElement record, WebElement recordHeader) {
-        recordHeader.click();
+    private String clickRecordAndGetNewHeight(WebElement parent, WebElement facetedSearchResultBody) {
+
+        parent.click();
         webElementUtil.waitUntilAnimationIsDone("facetedSearchResultBody");
-        return record.getAttribute("style");
+        return facetedSearchResultBody.getAttribute("style");
     }
 }

--- a/selenium/src/test/java/au/org/emii/portal/utils/WebElementUtil.java
+++ b/selenium/src/test/java/au/org/emii/portal/utils/WebElementUtil.java
@@ -448,12 +448,12 @@ public class WebElementUtil {
 
     public void waitUntilAnimationIsDone(final String cssLocator)
     {
-        WebDriverWait wdw = new WebDriverWait(driver, 20);
+        WebDriverWait wdw = new WebDriverWait(driver, 20, 300);
         ExpectedCondition<Boolean> expectation = new ExpectedCondition<Boolean>() {
             @Override
             public Boolean apply(WebDriver driver) {
                 String temp = ((JavascriptExecutor)driver)
-                        .executeScript("return jQuery('"+cssLocator+"').is(':animated')").toString();
+                        .executeScript("return jQuery('."+cssLocator+"').is(':animated')").toString();
                 return  temp.equalsIgnoreCase("false");
             }
         };

--- a/web-app/js/portal/jquery.js
+++ b/web-app/js/portal/jquery.js
@@ -12,7 +12,6 @@ jQuery( document ).ready(function() {
                 jQuery.data(resBody[0],"originalHeight", currentHeight );
             }
 
-            // animate height of parent facetedSearchResultBody
             if (fullHeight > 0  && currentHeight != fullHeight  ) {
                 resBody.animate({
                     height: fullHeight


### PR DESCRIPTION
The refactoring ensures we are definitely testing the correct elements should the order have been a problem.

I noticed the tests were always succeeding when i had lots of debug lines and queries within the test. This suggests that although we are waiting for animations to end, the style attributes were still not written into the page and we were testing them too early, hence the new wait.