### PR TITLE
Status urls from Batch/Geoserver GoGoDuck in popup

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,6 +1,6 @@
 #Grails Metadata file
-#Thu Mar 23 14:35:19 AEDT 2017
-app.build.date=23/03/2017 14\:35
+#Tue Nov 14 15:05:31 AEDT 2017
+app.build.date=14/11/2017 15\:05
 app.build.number=UNKNOWN
 app.build.scmRevision=UNKNOWN
 app.grails.version=2.4.4

--- a/grails-app/controllers/au/org/emii/portal/AsyncDownloadController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/AsyncDownloadController.groovy
@@ -6,13 +6,17 @@ class AsyncDownloadController {
 
     def gogoduckService
     def wpsService
+    def wpsAwsService
     def downloadAuthService
 
-    AsyncDownloadService getAggregatorService(aggregatorService) {
+    AsyncDownloadService getAggregatorService(aggregatorService, params) {
         switch (aggregatorService) {
             case 'gogoduck':
                 return gogoduckService
             case 'wps':
+                if (!(params.server.contains("geoserver"))) {
+                    return wpsAwsService
+                }
                 return wpsService
             default:
                 throw new Exception("Cannot find aggregatorService for '$aggregatorService'")
@@ -37,7 +41,7 @@ class AsyncDownloadController {
 
             verifyChallengeResponse(params, ipAddress)
 
-            AsyncDownloadService aggregatorService = getAggregatorService(aggregatorServiceString)
+            AsyncDownloadService aggregatorService = getAggregatorService(aggregatorServiceString, params)
 
             def renderText = aggregatorService.registerJob(params)
 

--- a/grails-app/services/au/org/emii/portal/WpsAwsService.groovy
+++ b/grails-app/services/au/org/emii/portal/WpsAwsService.groovy
@@ -46,6 +46,6 @@ class WpsAwsService extends AsyncDownloadService {
     def _getExecutionStatusUrl(registerResponse) {
         def xmlLink =  new XmlSlurper().parseText(registerResponse).@statusLocation[0].toString()
 
-        return xmlLink.replace(/format=xml/,"format=html")
+        return xmlLink.replace(/format=XML/,"format=HTML")
     }
 }

--- a/grails-app/services/au/org/emii/portal/WpsAwsService.groovy
+++ b/grails-app/services/au/org/emii/portal/WpsAwsService.groovy
@@ -1,0 +1,51 @@
+package au.org.emii.portal
+
+import grails.converters.JSON
+import groovy.xml.StreamingMarkupBuilder
+import groovyx.net.http.HTTPBuilder
+import groovyx.net.http.HttpResponseException
+
+import static groovyx.net.http.ContentType.XML
+import static groovyx.net.http.Method.POST
+
+class WpsAwsService extends AsyncDownloadService {
+
+    def groovyPageRenderer
+    def grailsApplication
+
+    String registerJob(params) throws HttpResponseException {
+
+        def response = getConnection(params).request(POST) {req ->
+            body = getBody(params)
+            response.success = onResponseSuccess
+        }
+        return [url: _getExecutionStatusUrl(response) ] as JSON
+    }
+
+    def getConnection(params) {
+        def conn = new HTTPBuilder(params.server)
+        conn.contentType = XML
+
+        return conn
+    }
+
+    def getBody(params) {
+        // grails puts all permutations of dotted parameters in here, we only want one lot.
+        params.jobParameters = params.jobParameters.findAll { it.value instanceof String }
+
+        def body = groovyPageRenderer.render(template: '/wps/asyncRequest.xml', model: params)
+        log.debug("Request body:\n\n${body}")
+
+        return body
+    }
+
+    def onResponseSuccess = { resp, xmlReader ->
+        return new StreamingMarkupBuilder().bindNode(xmlReader).toString()
+    }
+
+    def _getExecutionStatusUrl(registerResponse) {
+        def xmlLink =  new XmlSlurper().parseText(registerResponse).@statusLocation[0].toString()
+
+        return xmlLink.replace(/format=xml/,"format=html")
+    }
+}

--- a/test/unit/au/org/emii/portal/WpsAwsServiceTests.groovy
+++ b/test/unit/au/org/emii/portal/WpsAwsServiceTests.groovy
@@ -1,0 +1,41 @@
+package au.org.emii.portal
+
+import grails.test.*
+
+class WpsAwsServiceTests extends GrailsUnitTestCase {
+    WpsAwsService service
+
+    @Override
+    void setUp() {
+        super.setUp()
+
+        service = new WpsAwsService()
+
+    }
+
+    void testGetConnection() {
+
+        def connection = service.getConnection([ server: 'myserver' ])
+
+        assertNotNull connection
+        assertEquals 'myserver', String.valueOf(connection.uri)
+        assertEquals groovyx.net.http.ContentType.XML, connection.contentType
+    }
+
+    void testGetBody() {
+        def params = [ jobParameters: [ typeName: 'an awesome layer', cqlFilter: 'some cql' ] ]
+        def called = false
+
+        service.groovyPageRenderer = [
+            render: { args ->
+                called = true
+
+                assertEquals '/wps/asyncRequest.xml', args.template
+                assertEquals params, args.model
+            }
+        ]
+
+        service.getBody(params)
+        assertTrue called
+    }
+}


### PR DESCRIPTION
Required for the new AWS batch GoGoDuck. Will break status urls returned from Geoserver GoGoDuck