### PR TITLE
Stop developers submitting requests to prod WPS

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -142,11 +142,14 @@ environments {
         def localhostAddress = java.net.InetAddress.getLocalHost().getHostAddress()
         grails.serverURL = "http://${localhostAddress}:9090"
         gogoduck.url = "http://${localhostAddress}:8300/go-go-duck"
-        geonetwork.url = "https://catalogue-portal.aodn.org.au/geonetwork"
+        geonetwork.url = "https://catalogue-imos.aodn.org.au/geonetwork"
 
         // Set to true if you want to test interaction with new servers. This turns
         // your portal instance into an open proxy and can be dangerous.
         allowAnyHost = true
+
+        // Hosts which shouldn't be allowed even if allowAnyHosts is set to true
+        excludedHosts = ['geoserver-wps.aodn.org.au', 'wps.aodn.org.au']
     }
 
     test {

--- a/src/groovy/au/org/emii/portal/HostVerifier.groovy
+++ b/src/groovy/au/org/emii/portal/HostVerifier.groovy
@@ -12,17 +12,22 @@ class HostVerifier {
     def allowedHosts = null
 
     def allowedHost(address) {
-        if (grailsApplication.config.allowAnyHost) {
-            return true
-        }
-
-        initializeAllowedHostsIfNeeded()
-
         if (!address) {
             return false
         }
 
         def host = extractHost(address)
+
+        if (excludedHost(host)) {
+            log.error "Not allowing request to address '${address}' (host blacklisted)"
+            return false
+        }
+
+        if (grailsApplication.config.allowAnyHost) {
+            return true
+        }
+
+        initializeAllowedHostsIfNeeded()
 
         if (allowedHosts[host]) {
             return true
@@ -35,6 +40,12 @@ class HostVerifier {
 
     def extractHost(url) {
         return url.toURL().host
+    }
+
+    def excludedHost(host) {
+        def appConfig = grailsApplication.config
+
+        return appConfig.excludedHosts && appConfig.excludedHosts.contains(host)
     }
 
     def initializeAllowedHostsIfNeeded() {

--- a/test/unit/au/org/emii/portal/HostVerifierTests.groovy
+++ b/test/unit/au/org/emii/portal/HostVerifierTests.groovy
@@ -4,13 +4,11 @@ import grails.test.GrailsUnitTestCase
 
 class HostVerifierTests extends GrailsUnitTestCase {
 
-    def request
     def verifier
     def mockConfig
 
     protected void setUp() {
         super.setUp()
-        request = new MockRequest()
         mockConfig = new ConfigObject()
         verifier = new HostVerifier()
 
@@ -54,6 +52,22 @@ class HostVerifierTests extends GrailsUnitTestCase {
         assertTrue(verifier.allowedHost('http://geonetwork.aodn.org.au'))
     }
 
+    void testExcludedHost() {
+        def devConfig = new ConfigObject()
+        def hostVerifier = new HostVerifier()
+
+        hostVerifier.grailsApplication = devConfig
+
+        _addConfig(devConfig, ["config", "geonetwork", "url"], 'http://geonetwork.aodn.org.au/geonetwork')
+        _addConfig(devConfig, ["config", "baselayerServer", "uri"], 'http://geoserverstatic.emii.org.au')
+
+        _addConfig(devConfig, ["config", "allowAnyHost"], true)
+        _addConfig(devConfig, ["config", "excludedHosts"], ["geoserver-wps.aodn.org.au"])
+
+        assertTrue(hostVerifier.allowedHost("http://geoserver-123.aodn.org.au/geoserver"))
+        assertFalse(hostVerifier.allowedHost("http://geoserver-wps.aodn.org.au/geoserver"))
+    }
+
     def _addConfig(configObject, keys, value) {
         keys.eachWithIndex{ key, i ->
             if (i == keys.size() - 1) {
@@ -68,20 +82,4 @@ class HostVerifierTests extends GrailsUnitTestCase {
         }
     }
 
-    class MockRequest {
-
-        def host
-
-        MockRequest() {
-            this('http://localhost')
-        }
-
-        MockRequest(host) {
-            this.host = host
-        }
-
-        def getHeader(header) {
-            return host
-        }
-    }
 }


### PR DESCRIPTION
Blacklist prod wps endpoints in development and verify WPS requests in any environment are to an allowed host before submitting them.