### PR TITLE
Fix #2574 absolute image path GFI popup pointers

### DIFF
--- a/web-app/css/general.css
+++ b/web-app/css/general.css
@@ -534,7 +534,7 @@ div.olMap.x-item-disabled * {
 }
 
 .gx-popup-anc{
-    background:transparent url(/images/popupPointer.png) no-repeat 0 0;
+    background:transparent url(../images/popupPointer.png) no-repeat 0 0;
     position:absolute;
     left:45px;
     z-index:2;
@@ -543,7 +543,7 @@ div.olMap.x-item-disabled * {
     pointer-events:none;
 }
 .gx-popup-anc.top{
-    background:transparent url(/images/popupPointer-top.png) no-repeat 0 0;
+    background:transparent url(../images/popupPointer-top.png) no-repeat 0 0;
     top: -20px;
     height:20px;
     left:40px;


### PR DESCRIPTION
This was affecting Deakin who have their portal with the context set as `/portal`
The problem can be seen on http://po.aodn.org.au/imos123/search
This fix works with contextless setups like production or through intellij