### PR TITLE
Don't test loading indicator on firefox…

### DIFF
--- a/selenium/src/test/java/au/org/emii/portal/tests/step1/LoadingIndicatorTest.java
+++ b/selenium/src/test/java/au/org/emii/portal/tests/step1/LoadingIndicatorTest.java
@@ -15,7 +15,7 @@ public class LoadingIndicatorTest extends BaseTest {
 
     private static Logger log = Logger.getLogger(LoadingIndicatorTest.class.getName());
 
-    @Test
+    @Test(groups = { "SkipFirefox"})
     public void loadingIndicatorTest() throws InterruptedException {
         WebDriver driver = getDriver();
 

--- a/selenium/src/test/resources/testng.xml
+++ b/selenium/src/test/resources/testng.xml
@@ -20,6 +20,7 @@
         <groups>
             <run>
                 <exclude name="SkipTest"/>
+                <exclude name="SkipFirefox"/>
             </run>
         </groups>
         <packages>
@@ -41,6 +42,7 @@
         <groups>
             <run>
                 <exclude name="SkipTest"/>
+                <exclude name="SkipFirefox"/>
             </run>
         </groups>
         <packages>


### PR DESCRIPTION
… since the firefox testing driver is usually too slow to catch the indicator in time.

The loading indicator only appears for about a second. The firefox driver takes longer than a second to check it. Therefore it only passes about 15% of the time, even though the indicator is working.