### PR TITLE
Fix for MOTD on home page without ExtJS

### DIFF
--- a/grails-app/taglib/au/org/emii/portal/MessageOfTheDayTagLib.groovy
+++ b/grails-app/taglib/au/org/emii/portal/MessageOfTheDayTagLib.groovy
@@ -15,21 +15,18 @@ class MessageOfTheDayTagLib {
 
         if (motd) {
             out << """// MOTD
-            Ext.onReady(function() {
-                Ext.Msg.show({
-                    title: "<h2>${motd.title.encodeAsJavaScript()}</h2>",
-                    msg: "${motd.msg.encodeAsJavaScript()}",
-                    buttons: Ext.Msg.OK,
-                    cls: 'motd',
-                    width: 600
-                });
+            \$(document).ready(function() {
+                \$('#motd #motdTitle').html("${motd.title.encodeAsJavaScript()}");
+                \$('#motd #motdBody').html("${motd.msg.encodeAsJavaScript()}");
+                \$('#motd').modal();
             });"""
         }
     }
 
     def toMotdMap(motd) {
-        if (motd && motd.size() > 0) {
-            def motdLines = motd.split(lineSeparator)
+
+        if (motd && motd.trim().size() > 0) {
+            def motdLines = motd.trim().split(lineSeparator)
 
             def motdMap = [:]
             if (motdLines.size() > 1) {
@@ -38,7 +35,7 @@ class MessageOfTheDayTagLib {
                 motdMap.msg = motdLines[1..-1].join(lineSeparator)
             }
             else {
-                motdMap.title = motd
+                motdMap.title = "Notice"
                 motdMap.msg = motd
             }
             return motdMap

--- a/grails-app/views/_motd.gsp
+++ b/grails-app/views/_motd.gsp
@@ -1,0 +1,14 @@
+<div class="modal fade" id="motd" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+            </button>
+                <h3 class="modal-title" id="motdTitle">Modal title</h3>
+
+            </div>
+            <div class="modal-body" id="motdBody"></div>
+        </div>
+    </div>
+</div>

--- a/grails-app/views/landing/index.gsp
+++ b/grails-app/views/landing/index.gsp
@@ -12,7 +12,6 @@
     <g:render template="/public_theme_includes"></g:render>
     <g:render template="/landing_theme_includes"></g:render>
 
-
     <script type="text/javascript">
         <portal:motdPopup />
 
@@ -113,5 +112,6 @@
 
 <g:render template="/google_analytics"></g:render>
 <g:render template="/hotjar"></g:render>
+<g:render template="/motd"></g:render>
 </body>
 </html>

--- a/src/groovy/au/org/emii/portal/PortalBranding.groovy
+++ b/src/groovy/au/org/emii/portal/PortalBranding.groovy
@@ -82,7 +82,7 @@ class PortalBranding {
         if (grailsApplication.config.portal.brandingBase) {
             return "${grailsApplication.config.portal.brandingBase}/motd"
         }
-        else {
+        else if (grailsApplication.config.portal.motdUrl) {
             return grailsApplication.config.portal.motdUrl
         }
     }

--- a/test/unit/au/org/emii/portal/MessageOfTheDayTagLibTests.groovy
+++ b/test/unit/au/org/emii/portal/MessageOfTheDayTagLibTests.groovy
@@ -31,15 +31,8 @@ class MessageOfTheDayTagLibTests extends GrailsUnitTestCase {
     }
 
     void testMotdMapOneLiner() {
-        def motdRaw = "title is also a message\n"
+        def motdRaw = "this is the message\n"
         def motd = messageOfTheDayTagLib.toMotdMap(motdRaw)
-        assertEquals "title is also a message\n", motd.title
-        assertEquals "title is also a message\n", motd.msg
-
-        // And with no new line
-        motdRaw = "title is also a message"
-        motd = messageOfTheDayTagLib.toMotdMap(motdRaw)
-        assertEquals "title is also a message", motd.title
-        assertEquals "title is also a message", motd.msg
+        assertEquals motdRaw, motd.msg
     }
 }


### PR DESCRIPTION
### To test 
Add an accessible url to portal's config.groovy `motdUrl` Eg: https://s3-ap-southeast-2.amazonaws.com/static.emii.org.au/portalMotd/index.txt

The plain text file should contain two plain text lines. The portal will show a modal popup on the front page.
See https://github.com/aodn/static.emii.org.au_site/pull/13