### PR TITLE
Fix ImosLinkCheckTest so it actually catches broken links

### DIFF
--- a/selenium/src/test/java/au/org/emii/portal/tests/ImosLinkCheckTest.java
+++ b/selenium/src/test/java/au/org/emii/portal/tests/ImosLinkCheckTest.java
@@ -19,16 +19,19 @@ public class ImosLinkCheckTest extends BaseTest {
 
         // Go to search page - Step 1
         getDriver().get(AODN_PORTAL_SEARCH_PAGE);
+        portalUtil.waitUntilLoadingComplete();
         int invalidLinksCountSearchPageStep1 = seleniumUtil.validateUrlLinks();
         Assert.assertEquals(invalidLinksCountSearchPageStep1, 0);
 
         // Go to search page - Step 2
         webElementUtil.clickButtonWithTitle("Add this collection");
+        portalUtil.waitUntilLoadingComplete();
         int invalidLinksCountSearchPageStep2 = seleniumUtil.validateUrlLinks();
         Assert.assertEquals(invalidLinksCountSearchPageStep2, 0);
 
         // Go to search page - Step 3
         webElementUtil.clickButtonWithText("Next");
+        portalUtil.waitUntilLoadingComplete();
         int invalidLinksCountSearchPageStep3 = seleniumUtil.validateUrlLinks();
         Assert.assertEquals(invalidLinksCountSearchPageStep3, 0);
     }

--- a/selenium/src/test/java/au/org/emii/portal/tests/step1/ExpandCollapseLargeRecordTest.java
+++ b/selenium/src/test/java/au/org/emii/portal/tests/step1/ExpandCollapseLargeRecordTest.java
@@ -22,7 +22,6 @@ public class ExpandCollapseLargeRecordTest extends BaseTest {
         log.info("Loading search page - Step 1");
         WebDriver driver = getDriver();
         driver.get(AODN_PORTAL_SEARCH_PAGE);
-        WebDriverWait wait = new WebDriverWait(driver, 30);
 
         // Search for phytoplankton records
         WebElement keyword = webElementUtil.findElement(By.xpath("//*[contains(@class, 'free-text-search')]/div[2]/div/div[2]/div/input"));
@@ -32,8 +31,7 @@ public class ExpandCollapseLargeRecordTest extends BaseTest {
         keyword.sendKeys(Keys.ENTER);
 
         // Wait until the search completes
-        List<WebElement> spinners = webElementUtil.findElements(By.className("fa-spinner"));
-        wait.until(ExpectedConditions.invisibilityOfAllElements(spinners));
+        portalUtil.waitUntilLoadingComplete();
 
         List<WebElement> resultsHeaderBackgrounds = webElementUtil.findElements(By.className("resultsHeaderBackground"));
 

--- a/selenium/src/test/java/au/org/emii/portal/tests/step3/DownloadOptionsTest.java
+++ b/selenium/src/test/java/au/org/emii/portal/tests/step3/DownloadOptionsTest.java
@@ -32,8 +32,7 @@ public class DownloadOptionsTest extends BaseTest {
         WebDriverWait wait = new WebDriverWait(driver, 30);
 
         //wait until layer has finished loading, so we can be sure the step 3 button will be clickable
-        List<WebElement> spinners = webElementUtil.findElements(By.className("fa-spinner"));
-        wait.until(ExpectedConditions.invisibilityOfAllElements(spinners));
+        portalUtil.waitUntilLoadingComplete();
 
         // Step 3
         webElementUtil.clickButtonWithText("Next");

--- a/selenium/src/test/java/au/org/emii/portal/utils/PortalUtil.java
+++ b/selenium/src/test/java/au/org/emii/portal/utils/PortalUtil.java
@@ -69,4 +69,9 @@ public class PortalUtil {
             attempts++;
         }
     }
+    public void waitUntilLoadingComplete() {
+        WebDriverWait wait = new WebDriverWait(webElementUtil.driver, webElementUtil.TIMEOUT);
+        List<WebElement> spinners = webElementUtil.findElements(By.className("fa-spinner"));
+        wait.until(ExpectedConditions.invisibilityOfAllElements(spinners));
+    }
 }

--- a/selenium/src/test/java/au/org/emii/portal/utils/SeleniumUtil.java
+++ b/selenium/src/test/java/au/org/emii/portal/utils/SeleniumUtil.java
@@ -19,6 +19,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -59,21 +60,22 @@ public class SeleniumUtil {
 
         int invalidLinksCount = 0;
         List<WebElement> anchorTagsList = driver.findElements(By
-                .tagName("a"));
+                .xpath("//a[string(@href)]"));
         log.info("Total no. of links are "
                 + anchorTagsList.size());
 
-        for (int i = 0; i < anchorTagsList.size(); i++) {
-            WebElement anchorTag = anchorTagsList.get(i);
-            if (anchorTag != null && anchorTag.getAttribute("href") != null) {
-                String url = anchorTag.getAttribute("href");
-                if (validLinks.contains(url)) {
-                    break; // Do Nothing
-                } else if (invalidLinks.contains(url)) {
-                    invalidLinksCount ++;
-                } else {
-                    invalidLinksCount = verifyURLStatus(url, invalidLinksCount);
-                }
+        List<String> urlsToCheck = new LinkedList<>();
+        for(WebElement anchorTag: anchorTagsList) {
+            urlsToCheck.add(anchorTag.getAttribute("href"));
+        }
+
+        for(String url: urlsToCheck) {
+            if (validLinks.contains(url)) {
+                continue; // Do Nothing
+            } else if (invalidLinks.contains(url)) {
+                invalidLinksCount ++;
+            } else {
+                invalidLinksCount = verifyURLStatus(url, invalidLinksCount);
             }
         }
 


### PR DESCRIPTION
See my explanation of the issue at https://github.com/aodn/aodn-portal/issues/2548#issuecomment-352963115

This should make the test _pass_ when we run it on our local machines and _fail_ when it's run on jenkins, because of catalogue-systest only being available from our locals.