### PR TITLE
added test for step1 FreeTextSearch

### DIFF
--- a/selenium/pom.xml
+++ b/selenium/pom.xml
@@ -27,6 +27,7 @@
                         <browserstack.local>${browserstack.local}</browserstack.local>
                         <aodnPortal>${aodnPortal}</aodnPortal>
                         <aodnPortalSearch>${aodnPortalSearch}</aodnPortalSearch>
+                        <aodnPortalProxy>${aodnPortalProxy}</aodnPortalProxy>
                     </systemPropertyVariables>
                     <includes>
                         <include>**/Test*.java</include>
@@ -119,5 +120,6 @@
         <browserstack.local>false</browserstack.local>
         <aodnPortal>https://portal-edge.aodn.org.au/</aodnPortal>
         <aodnPortalSearch>search</aodnPortalSearch>
+        <aodnPortalProxy>proxy</aodnPortalProxy>
     </properties>
 </project>

--- a/selenium/src/test/java/au/org/emii/portal/tests/BaseTest.java
+++ b/selenium/src/test/java/au/org/emii/portal/tests/BaseTest.java
@@ -35,6 +35,7 @@ public class BaseTest {
     public static String BROWSER_STACK_BUILD;
     public static String AODN_PORTAL_HOME_PAGE;
     public static String AODN_PORTAL_SEARCH_PAGE;
+    public static String AODN_PORTAL_PROXY_URL;
 
     public String browserStackSessionUrl;
 
@@ -85,6 +86,7 @@ public class BaseTest {
 
         AODN_PORTAL_HOME_PAGE = System.getProperty("aodnPortal");
         AODN_PORTAL_SEARCH_PAGE = AODN_PORTAL_HOME_PAGE + System.getProperty("aodnPortalSearch");
+        AODN_PORTAL_PROXY_URL = AODN_PORTAL_HOME_PAGE + System.getProperty("aodnPortalProxy");
 
         this.capabilities = getDesiredCapability(browser, browser_version, os, os_version, device, platform, resolution);
 

--- a/selenium/src/test/java/au/org/emii/portal/tests/step1/FreeTextSearchTest.java
+++ b/selenium/src/test/java/au/org/emii/portal/tests/step1/FreeTextSearchTest.java
@@ -1,0 +1,84 @@
+package au.org.emii.portal.tests.step1;
+
+import au.org.emii.portal.tests.BaseTest;
+import org.apache.log4j.Logger;
+import org.openqa.selenium.*;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+
+public class FreeTextSearchTest extends BaseTest {
+
+    private static Logger log = Logger.getLogger(FreeTextSearchTest.class.getName());
+
+    public static Map<String, String> getQueryMap(String query)
+    {
+        String[] params = query.split("&");
+        Map<String, String> map = new HashMap<String, String>();
+        for (String param : params)
+        {
+            String name = param.split("=")[0];
+            String value = param.split("=")[1];
+            map.put(name, value);
+        }
+        return map;
+    }
+
+
+    @Test(groups = { "SkipFirefox"})
+    public void freeTextSearchTest() {
+        String searchTerm = "CARS";
+
+        log.info("Loading search page - Step 1");
+        WebDriver driver = getDriver();
+        driver.get(AODN_PORTAL_SEARCH_PAGE);
+
+        //scroll to bottom of panel so video shows text being entered in input
+        webElementUtil.findElement(By.xpath("//*[@id=\"ext-gen59\"]")).click();
+        ((JavascriptExecutor)driver).executeScript("window.scrollTo(0, document.body.scrollHeight)");
+
+        //enter the search term
+        WebElement searchInput = webElementUtil.findElement(By.xpath("//*[@id=\"ext-comp-1024\"]"));
+        searchInput.sendKeys(searchTerm);
+        searchInput.sendKeys(Keys.RETURN);
+
+        //wait and get filtered results
+        driver.manage().timeouts().implicitlyWait(5, TimeUnit.SECONDS);
+        List<WebElement> panels = webElementUtil.findElements(By.className("resultsTextBody"));
+
+        List<String> metadataUrls = new ArrayList<String>();
+
+        //open new tabs for each metadata record
+        for (WebElement panel: panels) {
+
+            try {
+                String query = new URL(panel.findElement(By.linkText("more")).getAttribute("href")).getQuery();
+                Map<String, String> queryMap = getQueryMap(query);
+
+                queryMap.get("uuid");
+                String proxyUrl = URLEncoder.encode("http://catalogue-systest-internal.aodn.org.au/geonetwork/srv/eng/xml.metadata.get?uuid=" + queryMap.get("uuid"), "UTF-8");
+                metadataUrls.add(AODN_PORTAL_PROXY_URL + "?url=" + proxyUrl);
+
+            } catch (java.net.MalformedURLException | java.io.UnsupportedEncodingException e) {
+                log.error(e.getMessage(), e);
+            }
+        }
+
+        //open each metadata page in turn to check for search term
+        for (String url : metadataUrls) {
+            driver.get(url);
+
+            Assert.assertTrue(driver.getPageSource().contains(searchTerm));
+        }
+
+        log.info("Validation Complete");
+    }
+}

--- a/selenium/src/test/java/au/org/emii/portal/tests/step1/FreeTextSearchTest.java
+++ b/selenium/src/test/java/au/org/emii/portal/tests/step1/FreeTextSearchTest.java
@@ -2,7 +2,12 @@ package au.org.emii.portal.tests.step1;
 
 import au.org.emii.portal.tests.BaseTest;
 import org.apache.log4j.Logger;
-import org.openqa.selenium.*;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -12,7 +17,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 
 public class FreeTextSearchTest extends BaseTest {
@@ -41,26 +45,35 @@ public class FreeTextSearchTest extends BaseTest {
         WebDriver driver = getDriver();
         driver.get(AODN_PORTAL_SEARCH_PAGE);
 
-        //scroll to bottom of panel so video shows text being entered in input
-        webElementUtil.findElement(By.xpath("//*[@id=\"ext-gen59\"]")).click();
-        ((JavascriptExecutor)driver).executeScript("window.scrollTo(0, document.body.scrollHeight)");
+        WebElement stalenessCheck = driver.findElements(By.className("resultsHeaderBackground")).get(0);
+
+        List<WebElement> filterPanels = webElementUtil.findElements(By.className("search-filter-panel"));
+        WebElement panel = null;
+
+        for(WebElement p : filterPanels) {
+            if(p.getText().contains("Keyword")) {
+                panel=p;
+            }
+        }
+
+        WebElement searchInput = panel.findElement(By.tagName("input"));
 
         //enter the search term
-        WebElement searchInput = webElementUtil.findElement(By.xpath("//*[@id=\"ext-comp-1024\"]"));
         searchInput.sendKeys(searchTerm);
         searchInput.sendKeys(Keys.RETURN);
 
         //wait and get filtered results
-        driver.manage().timeouts().implicitlyWait(5, TimeUnit.SECONDS);
+        WebDriverWait wait = new WebDriverWait(driver, 30);
+        wait.until(ExpectedConditions.stalenessOf(stalenessCheck));
         List<WebElement> panels = webElementUtil.findElements(By.className("resultsTextBody"));
 
         List<String> metadataUrls = new ArrayList<String>();
 
         //open new tabs for each metadata record
-        for (WebElement panel: panels) {
+        for (WebElement resultPanel: panels) {
 
             try {
-                String query = new URL(panel.findElement(By.linkText("more")).getAttribute("href")).getQuery();
+                String query = new URL(resultPanel.findElement(By.linkText("more")).getAttribute("href")).getQuery();
                 Map<String, String> queryMap = getQueryMap(query);
 
                 queryMap.get("uuid");


### PR DESCRIPTION
This test enters a search term in the Keyword search box. 

To confirm that the results are valid, the test gets the 'more' link (external link to the metadata record) and massages it into a proxied request to geonetwork using the xml search endpoint. The resulting xml document is scanned for the search term (i.e. to make sure that the record really should appear in the results).

There is an issue that selenium does not like to work with xml pages and as a result it can read the page content okay for Chrome but not for firefox. So... I've used a 'SkipFirefox' directive for this test as I don't think there's a fix for this.