### PR TITLE
updated labels

### DIFF
--- a/src/test/javascript/portal/filter/GeometryFilterSpec.js
+++ b/src/test/javascript/portal/filter/GeometryFilterSpec.js
@@ -31,7 +31,7 @@ describe("Portal.filter.GeometryFilter", function() {
 
                 expect(humanReadableForm).toContain(OpenLayers.i18n("spatialExtentHeading"));
                 expect(humanReadableForm).toContain(OpenLayers.i18n("spatialExtentPolygonNote"));
-                expect(humanReadableForm).toBe('Spatial Subset: Polygon with max extent 1W 2S 3E 4N');
+                expect(humanReadableForm).toBe(OpenLayers.i18n("spatialExtentHeading") + ': Polygon with max extent 1W 2S 3E 4N');
             });
         });
     });
@@ -64,7 +64,7 @@ describe("Portal.filter.GeometryFilter", function() {
                 var humanReadableForm = filter.getHumanReadableForm();
 
                 expect(humanReadableForm).toContain(OpenLayers.i18n("spatialExtentHeading"));
-                expect(humanReadableForm).toBe('Spatial Subset: 1W 2S 3E 4N');
+                expect(humanReadableForm).toBe(OpenLayers.i18n("spatialExtentHeading") + ': 1W 2S 3E 4N');
             });
         });
     });

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -212,10 +212,10 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
     asyncDownloadErrorMsg: 'Unable to create subsetting job. Please re-check the parameters you provided and try again.',
     asyncServiceMsg: "<a class='external' target='_blank' href='${url}'>Follow the progress of your job</a><br /><br />",
 
-    spatialExtentHeading: 'Spatial Subset',
+    spatialExtentHeading: 'Spatial',
     timeSeriesAtHeading: 'Timeseries at Lat/Lon',
-    temporalExtentHeading: 'Temporal Extent',
-    generalFilterHeading: 'Filters',
+    temporalExtentHeading: 'Temporal',
+    generalFilterHeading: 'Others',
     currentDateTimeLabel: 'Displaying',
     spatialExtentPolygonNote: 'Polygon with max extent ',
     pointTimeSeriesLabel: 'Point timeseries',


### PR DESCRIPTION
Minor UI changes as part of [backlog issue #762](https://github.com/aodn/backlog/issues/762)

Peter and Phil had a discussion and decided that some facet labels on Step 2 would change so:
- 'Spatial Subset' -> 'Spatial'
- 'Temporal Extent' -> 'Temporal'
- 'Filters' -> 'Others'

I investigated whether changing the size of these labels was feasible but there aren't any good css selectors to make use of to target these (without risking the style change leaking out into other parts of the page/site)
