### PR TITLE
Send x forwarded for http header

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/AsyncDownloadController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/AsyncDownloadController.groovy
@@ -41,9 +41,13 @@ class AsyncDownloadController extends HostVerifyingController {
             try {
                 def ipAddress = request.getRemoteAddr()
 
+                log.info("AsyncDownloadController remoteAddr: " + ipAddress)
                 verifyChallengeResponse(params, ipAddress)
 
                 AsyncDownloadService aggregatorService = getAggregatorService(aggregatorServiceString, params)
+
+                //  Pass client IP address to download controller
+                params.put("X-Forwarded-For", ipAddress)
 
                 def renderText = aggregatorService.registerJob(params)
 

--- a/grails-app/services/au/org/emii/portal/GogoduckService.groovy
+++ b/grails-app/services/au/org/emii/portal/GogoduckService.groovy
@@ -2,7 +2,6 @@ package au.org.emii.portal
 
 import grails.converters.JSON
 import groovyx.net.http.HTTPBuilder
-import org.apache.http.util.EntityUtils
 
 class GogoduckService extends AsyncDownloadService {
 

--- a/grails-app/services/au/org/emii/portal/WpsAwsService.groovy
+++ b/grails-app/services/au/org/emii/portal/WpsAwsService.groovy
@@ -24,6 +24,13 @@ class WpsAwsService extends AsyncDownloadService {
 
     def getConnection(params) {
         def conn = new HTTPBuilder(params.server)
+
+        //  If an X-Forwarded-For param was passed - set it as a HTTP parameter
+        if(params["X-Forwarded-For"] != null) {
+            conn.headers["X-Forwarded-For"] = params["X-Forwarded-For"]
+            log.info("X-Forwarded-For param set : " + params["X-Forwarded-For"])
+        }
+
         conn.contentType = XML
 
         return conn

--- a/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
+++ b/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
@@ -47,12 +47,14 @@ class ProxiedRequest extends ExternalRequest {
     def getClientIpAddress = {
 
         def clientip = request.getHeader("Client-IP")
-        if (!clientip)
+        if (!clientip) {
             clientip = request.getHeader("X-Forwarded-For")
+        }
         if (!clientip) {
             clientip = request.remoteAddr
         }
-        log.debug clientip
+
+        log.info "PORTAL Client IP Address : ${clientip}"
         return clientip
     }
 
@@ -61,7 +63,11 @@ class ProxiedRequest extends ExternalRequest {
             def contentDisposition = conn.getHeaderField("Content-disposition")
             log.debug "Setting content disposition to '${contentDisposition}'"
             response.setHeader("Content-disposition", contentDisposition)
-            response.setHeader("X-Forwarded-For", getClientIpAddress())
+        }
+
+        // Forward the originating client IP address
+        if(getClientIpAddress) {
+            conn.setRequestProperty("X-Forwarded-For", getClientIpAddress())
         }
 
         _determineResponseContentType(conn)

--- a/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
+++ b/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
@@ -95,6 +95,7 @@ class ProxiedRequest extends ExternalRequest {
 
         // Forward the originating client IP address
         if(getClientIpAddress) {
+            log.info "Setting X-Forwarded-For HTTP header : ${getClientIpAddress}"
             conn.setRequestProperty("X-Forwarded-For", getClientIpAddress())
         }
 

--- a/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
+++ b/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
@@ -45,22 +45,6 @@ class ProxiedRequest extends ExternalRequest {
         }
     }
 
-    def getClientIpAddress = {
-
-        log.info "X-Forwarded-For : ${request.getHeader("X-Forwarded-For")}"
-        log.info "request.remoteAddr : ${request.remoteAddr}"
-
-        //  Pass X-Forwarded-For header on if present
-        def clientip = request.getHeader("X-Forwarded-For")
-
-        if (!clientip) {
-            clientip = request.remoteAddr
-        }
-
-        log.info "PORTAL Client IP Address : ${clientip}"
-        return clientip
-    }
-
     def onConnectionOpened = { conn ->
         if (!response.containsHeader("Content-disposition")) {
             def contentDisposition = conn.getHeaderField("Content-disposition")
@@ -90,12 +74,6 @@ class ProxiedRequest extends ExternalRequest {
 
         if (connectTimeout) {
             conn.setConnectTimeout(connectTimeout);
-        }
-
-        // Forward the originating client IP address
-        if(getClientIpAddress) {
-            log.info "Setting X-Forwarded-For HTTP header : ${getClientIpAddress}"
-            conn.setRequestProperty("X-Forwarded-For", getClientIpAddress())
         }
 
         onConnectionOpened conn

--- a/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
+++ b/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
@@ -64,40 +64,6 @@ class ProxiedRequest extends ExternalRequest {
     }
 
 
-    def executeRequest = { streamProcessor = null ->
-
-        def processStream = streamProcessor ?: straightThrough
-
-        log.debug "Opening connection to target URL: $targetUrl"
-
-        URLConnection conn = targetUrl.openConnection()
-
-        if (connectTimeout) {
-            conn.setConnectTimeout(connectTimeout);
-        }
-
-        onConnectionOpened conn
-
-        try {
-            InputStream inputStream = conn.getInputStream()
-        }
-        catch (IOException e) {
-            throw e
-            return
-        }
-
-        try {
-            if (response) {
-                outputStream = response.outputStream
-            }
-            processStream conn.inputStream, outputStream
-            outputStream.flush()
-        }
-        finally {
-            IOUtils.closeQuietly(outputStream)
-        }
-    }
-
     static def _getTargetUrl(params, proxyRedirectService) {
 
         String url = params.remove('url')

--- a/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
+++ b/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
@@ -47,14 +47,12 @@ class ProxiedRequest extends ExternalRequest {
 
     def getClientIpAddress = {
 
-        log.info "request.remoteAddr : ${request.getHeader("Client-IP")}"
-        log.info "request.remoteAddr : ${request.getHeader("X-Forwarded-For")}"
+        log.info "X-Forwarded-For : ${request.getHeader("X-Forwarded-For")}"
         log.info "request.remoteAddr : ${request.remoteAddr}"
 
-        def clientip = request.getHeader("Client-IP")
-        if (!clientip) {
-            clientip = request.getHeader("X-Forwarded-For")
-        }
+        //  Pass X-Forwarded-For header on if present
+        def clientip = request.getHeader("X-Forwarded-For")
+
         if (!clientip) {
             clientip = request.remoteAddr
         }
@@ -80,6 +78,7 @@ class ProxiedRequest extends ExternalRequest {
             response.contentType = params.remove('format') ?: request.contentType
         }
     }
+
 
     def executeRequest = { streamProcessor = null ->
 

--- a/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
+++ b/src/groovy/au/org/emii/portal/proxying/ProxiedRequest.groovy
@@ -46,6 +46,10 @@ class ProxiedRequest extends ExternalRequest {
 
     def getClientIpAddress = {
 
+        log.info "request.remoteAddr : ${request.getHeader("Client-IP")}"
+        log.info "request.remoteAddr : ${request.getHeader("X-Forwarded-For")}"
+        log.info "request.remoteAddr : ${request.remoteAddr}"
+
         def clientip = request.getHeader("Client-IP")
         if (!clientip) {
             clientip = request.getHeader("X-Forwarded-For")

--- a/test/unit/au/org/emii/portal/AsyncDownloadControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/AsyncDownloadControllerTests.groovy
@@ -57,9 +57,10 @@ class AsyncDownloadControllerTests extends ControllerUnitTestCase {
         controller.params.aggregatorService ='gogoduck'
         controller.params.a = "b"
         controller.params.c = "d"
+        controller.params.put("X-Forwarded-For", "127.0.0.1")
 
         // Note that the 'aggregatorService' will be stripped off
-        def mockParams = [server: 'allowed', a: 'b', c: 'd']
+        def mockParams = [server: 'allowed', a: 'b', c: 'd', "X-Forwarded-For" : '127.0.0.1']
 
         controller.gogoduckService.metaClass.registerJob {
             params ->


### PR DESCRIPTION
Will send X-Forwarded-For HTTP header containing the remote client IP address as the first entry (that header contains a list of IP Addresses) to the AWS WPS endpoint.  This can then be used to filter requests as being internal or external in SumoLogic.