### PR TITLE
Use DescribeLayer to get linked wfs server

### DIFF
--- a/src/groovy/au/org/emii/portal/wms/CoreGeoserverServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/CoreGeoserverServer.groovy
@@ -3,7 +3,11 @@ package au.org.emii.portal.wms
 import au.org.emii.portal.proxying.ExternalRequest
 import groovy.json.JsonSlurper
 
+import java.util.concurrent.ConcurrentHashMap
+
 class CoreGeoserverServer extends WmsServer {
+
+    private static def linkedWfsFeatureTypeMap = new ConcurrentHashMap()
 
     def groovyPageRenderer
 
@@ -80,7 +84,8 @@ class CoreGeoserverServer extends WmsServer {
     }
 
     def _describeFeatureType(server, layer) {
-        def requestUrl = server + "?request=DescribeFeatureType&service=WFS&version=1.0.0&typeName=${layer}"
+        def (wfsServer, typeName) = _lookupWfs(server, layer)
+        def requestUrl = wfsServer + "request=DescribeFeatureType&service=WFS&version=1.0.0&typeName=${typeName}"
         def outputStream = new ByteArrayOutputStream()
         def request = new ExternalRequest(outputStream, requestUrl.toURL())
 
@@ -89,11 +94,12 @@ class CoreGeoserverServer extends WmsServer {
     }
 
     def _getPagedUniqueValues(server, layer, filter) {
-        def params = [typeName: layer, propertyName: filter]
+        def (wfsServer, typeName) = _lookupWfs(server, layer)
+        def params = [typeName: typeName, propertyName: filter]
         def body = groovyPageRenderer.render(template: '/filters/pagedUniqueRequest.xml', model: params)
         log.debug("Request body:\n\n${body}")
 
-        def connection = server.toURL().openConnection()
+        def connection = wfsServer.toURL().openConnection()
 
         connection.with {
             doOutput = true
@@ -104,6 +110,38 @@ class CoreGeoserverServer extends WmsServer {
             }
             content.text
         }
+    }
+
+
+    def _lookupWfs(server, layer) {
+        def wmsLayer = [server, layer]
+
+        if (linkedWfsFeatureTypeMap.containsKey(wmsLayer)) {
+            return linkedWfsFeatureTypeMap.get(wmsLayer)
+        }
+
+        String response = _describeLayer(server, layer)
+
+        def parser = new XmlSlurper()
+        parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+        parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        def xml = parser.parseText(response)
+
+        def wfsFeatureType = [xml.LayerDescription.@wfs.text(), xml.LayerDescription.Query.@typeName.text()]
+
+        linkedWfsFeatureTypeMap.put(wmsLayer, wfsFeatureType)
+
+        return wfsFeatureType
+    }
+
+    private String _describeLayer(server, layer) {
+        def requestUrl = server + "?request=DescribeLayer&service=WMS&version=1.1.1&layers=${layer}"
+        def outputStream = new ByteArrayOutputStream()
+        def request = new ExternalRequest(outputStream, requestUrl.toURL())
+
+        request.executeRequest()
+
+        return outputStream.toString("utf-8")
     }
 
     def _toFilterType(value) {

--- a/test/unit/au/org/emii/portal/wms/CoreGeoserverServerTests.groovy
+++ b/test/unit/au/org/emii/portal/wms/CoreGeoserverServerTests.groovy
@@ -9,6 +9,7 @@ class CoreGeoserverServerTests extends GrailsUnitTestCase {
     def filterValuesJson
     def emptyJson
     def groovyPageRenderer
+    def validDescribeLayerResponse
 
     protected void setUp() {
         super.setUp()
@@ -50,6 +51,15 @@ class CoreGeoserverServerTests extends GrailsUnitTestCase {
   "fieldName":"property_name",
   "size":0
 }'''
+        validDescribeLayerResponse =
+'''<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE WMS_DescribeLayerResponse SYSTEM "https://geoserver.aodn.org.au/geoserver/schemas/wms/1.1.1/WMS_DescribeLayerResponse.dtd">
+<WMS_DescribeLayerResponse version="1.1.1">
+  <LayerDescription name="imos:argo_profile_map" wfs="https://geoserver.aodn.org.au/geoserver/wfs?" owsURL="https://geoserver.aodn.org.au/geoserver/wfs?" owsType="WFS">
+    <Query typeName="imos:argo_profile_map"/>
+  </LayerDescription>
+</WMS_DescribeLayerResponse>
+'''
     }
 
     void testValidFilterValues() {
@@ -116,5 +126,20 @@ class CoreGeoserverServerTests extends GrailsUnitTestCase {
         def filtersJson = coreGeoserverServer.getFilters("http://server", "layer")
 
         assertEquals expected, filtersJson
+    }
+
+    void testLookup() {
+        def describeLayerCalledCount = 0
+
+        coreGeoserverServer.metaClass._describeLayer = { server, layer -> describeLayerCalledCount++ ; return validDescribeLayerResponse }
+
+        def result = coreGeoserverServer._lookupWfs("https://geoserver.aodn.org.au/geoserver/wms", "imos:argo_profile_map")
+
+        assertEquals(1, describeLayerCalledCount) // describeLayer called
+        assertEquals(["https://geoserver.aodn.org.au/geoserver/wfs?", "imos:argo_profile_map"], result)
+
+        result = coreGeoserverServer._lookupWfs("https://geoserver.aodn.org.au/geoserver/wms", "imos:argo_profile_map")
+        assertEquals(1, describeLayerCalledCount) // describeLayer not called - cache used
+        assertEquals(["https://geoserver.aodn.org.au/geoserver/wfs?", "imos:argo_profile_map"], result)
     }
 }


### PR DESCRIPTION
Geowebcache can't proxy WFS/WPS requests as they do not have an associated layer.   Workaround this by using the WMS DescribeLayer request (which Geowebcache does proxy) to source the backing wfs server.   Alternative to defining backing server details in knownhosts or in the metadata.