### PR TITLE
Update "List of URLs" download option label to "List of HTTP URLs" to…

### DIFF
--- a/web-app/js/portal/cart/BodaacDownloadHandler.js
+++ b/web-app/js/portal/cart/BodaacDownloadHandler.js
@@ -31,7 +31,7 @@ Portal.cart.BodaacDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
                 handler: this._getUrlGeneratorFunction(),
                 handlerParams: {
                     downloadLabel: OpenLayers.i18n('downloadUrlListAction'),
-                    filenameFormat: '{0}_URLs.txt',
+                    filenameFormat: '{0}_HTTP_URLs.txt',
                     downloadControllerArgs: {
                         action: 'urlListForLayer',
                         urlFieldName: this._urlFieldName()

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -40,7 +40,7 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
     downloadAsPointTimeSeriesCsvLabel: 'CSV',
     downloadAsDataTrawlerCsvLabel: 'CSV - DataTrawler',
     downloadAsAllSourceNetCdfLabel: 'Un-subsetted NetCDFs',
-    downloadAsUrlsLabel: 'List of URLs',
+    downloadAsUrlsLabel: 'List of HTTP URLs',
     downloadAsPythonSnippetLabel: 'Python',
     parameterDateLabel: 'Date range',
     metadataLinkText: 'View metadata record',


### PR DESCRIPTION
… make the used protocol clearer and in preparation for a potential future support for a "List of OPeNDAP URLs". Also reflected this change in the retrieved file name.

Note that I didn't change the content of `downloadUrlListAction` in `web-app/js/portal/lang/en.js` since @jonescc believes this is used by google analytics and it would then be problematic.

Finally, not sure whether I should also update the "List of URLs" entries to "List of HTTP URLs" in `src/test/javascript/portal/cart/DownloadPanelSpec.js`.