### PR TITLE
Adjust spatial filter display on Step 3.  Fixes #2704

### DIFF
--- a/grails-app/views/_js_includes.gsp
+++ b/grails-app/views/_js_includes.gsp
@@ -99,6 +99,7 @@
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'GeometryFilter.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'NumberFilter.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'StringFilter.js')}"></script>
+    <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'StringDepthFilter.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'AlaSpeciesStringArrayFilter.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'PointFilter.js')}"></script>
     <script type="text/javascript" src="${resource(dir: 'js/portal/filter', file: 'FilterService.js')}"></script>

--- a/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
+++ b/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
@@ -58,7 +58,7 @@ describe('Portal.cart.NcWmsInjector', function() {
 
             var entry = injector._getDataFilterEntry(dataCollection);
             expect(entry).toContain(OpenLayers.i18n("spatialExtentHeading"));
-            expect(entry).toContain('0, 150 to Lat/Lon 40, 180');
+            expect(entry).toContain('0, -150 to Lat/Lon 40, 180');
         });
 
         it('indicates temporal range', function() {

--- a/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
+++ b/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
@@ -58,7 +58,7 @@ describe('Portal.cart.NcWmsInjector', function() {
 
             var entry = injector._getDataFilterEntry(dataCollection);
             expect(entry).toContain(OpenLayers.i18n("spatialExtentHeading"));
-            expect(entry).toContain('-150W 0S 180E 40N');
+            expect(entry).toContain('0, 150 to Lat/Lon 40, 180');
         });
 
         it('indicates temporal range', function() {

--- a/src/test/javascript/portal/filter/FilterSpec.js
+++ b/src/test/javascript/portal/filter/FilterSpec.js
@@ -14,6 +14,7 @@ describe("Portal.filter.Filter", function() {
             checkClassFor('geometrypropertytype', Portal.filter.GeometryFilter);
             checkClassFor('boolean', Portal.filter.BooleanFilter);
             checkClassFor('date', Portal.filter.DateFilter);
+            checkClassFor('depthstring', Portal.filter.StringDepthFilter);
             checkClassFor('unknown', null);
         });
 

--- a/src/test/javascript/portal/filter/GeometryFilterSpec.js
+++ b/src/test/javascript/portal/filter/GeometryFilterSpec.js
@@ -31,7 +31,7 @@ describe("Portal.filter.GeometryFilter", function() {
 
                 expect(humanReadableForm).toContain(OpenLayers.i18n("spatialExtentHeading"));
                 expect(humanReadableForm).toContain(OpenLayers.i18n("spatialExtentPolygonNote"));
-                expect(humanReadableForm).toBe(OpenLayers.i18n("spatialExtentHeading") + ': Polygon with max extent 1W 2S 3E 4N');
+                expect(humanReadableForm).toBe(OpenLayers.i18n("spatialExtentHeading") + ': Polygon with max extent From Lat/Lon 2, 1 to Lat/Lon 4, 3');
             });
         });
     });
@@ -64,7 +64,7 @@ describe("Portal.filter.GeometryFilter", function() {
                 var humanReadableForm = filter.getHumanReadableForm();
 
                 expect(humanReadableForm).toContain(OpenLayers.i18n("spatialExtentHeading"));
-                expect(humanReadableForm).toBe(OpenLayers.i18n("spatialExtentHeading") + ': 1W 2S 3E 4N');
+                expect(humanReadableForm).toBe(OpenLayers.i18n("spatialExtentHeading") + ': From Lat/Lon 2, 1 to Lat/Lon 4, 3');
             });
         });
     });

--- a/src/test/javascript/portal/prototypes/OpenLayersSpec.js
+++ b/src/test/javascript/portal/prototypes/OpenLayersSpec.js
@@ -176,7 +176,7 @@ describe('OpenLayers', function() {
 
         describe('getPrettyBounds', function() {
             it('returns pretty rounded bounds', function() {
-                expect(OpenLayers.Geometry.fromWKT('POLYGON((1 2,3 2,3.14159265 4,1 4,1 2))').getPrettyBounds()).toEqual('1W 2S 3.142E 4N');
+                expect(OpenLayers.Geometry.fromWKT('POLYGON((1 2,3 2,3.14159265 4,1 4,1 2))').getPrettyBounds()).toEqual('From Lat/Lon 2, 1 to Lat/Lon 4, 3.142');
             });
         });
     });

--- a/web-app/js/portal/details/NcWmsPanel.js
+++ b/web-app/js/portal/details/NcWmsPanel.js
@@ -631,12 +631,13 @@ Portal.details.NcWmsPanel = Ext.extend(Ext.Container, {
 
         if (zAxisValue) {
             filters.push(
-                new Portal.filter.StringFilter({
+                new Portal.filter.StringDepthFilter({
                     name: 'zaxis',
                     label: this.zAxisPickerContainer.zAxisPickerTitle,
                     isNcwmsParams: true,
                     visualised: true,
-                    value: zAxisValue
+                    value: zAxisValue,
+                    units: this.layer.extraLayerInfo.zaxis.units
                 })
             );
         }

--- a/web-app/js/portal/filter/Filter.js
+++ b/web-app/js/portal/filter/Filter.js
@@ -94,7 +94,8 @@ Portal.filter.Filter.classFor = function(filterConfig) {
         Portal.filter.GeometryFilter,
         Portal.filter.NumberFilter,
         Portal.filter.StringFilter,
-        Portal.filter.AlaSpeciesStringArrayFilter
+        Portal.filter.AlaSpeciesStringArrayFilter,
+        Portal.filter.StringDepthFilter
     ];
 
     var filterType = filterConfig.type;

--- a/web-app/js/portal/filter/StringDepthFilter.js
+++ b/web-app/js/portal/filter/StringDepthFilter.js
@@ -13,9 +13,7 @@ Portal.filter.StringDepthFilter = Ext.extend(Portal.filter.StringFilter, {
     },
 
     getHumanReadableForm: function() {
-
-        //  The format for a StringFilter is <Label>: <value>
-        //  In this case it will be something like 'Depth: 0,5000'
+        //  Desired format: 0m to 5000m
         if(this.getValue().length > 1) {
             zAxisMin = this.getValue()[0];
             zAxisMax = this.getValue()[1];

--- a/web-app/js/portal/filter/StringDepthFilter.js
+++ b/web-app/js/portal/filter/StringDepthFilter.js
@@ -1,0 +1,32 @@
+Ext.namespace('Portal.filter');
+
+Portal.filter.StringDepthFilter = Ext.extend(Portal.filter.StringFilter, {
+
+    setUnits: function(units) {
+
+        this.units = units;
+    },
+
+    getUnits: function() {
+
+        return this.units;
+    },
+
+    getHumanReadableForm: function() {
+
+        //  The format for a StringFilter is <Label>: <value>
+        //  In this case it will be something like 'Depth: 0,5000'
+        if(this.getValue().length > 1) {
+            zAxisMin = this.getValue()[0];
+            zAxisMax = this.getValue()[1];
+            zAxisString = zAxisMin + this.getUnits() + " to " + zAxisMax + this.getUnits();
+        }
+
+        return String.format(
+            '{0}: {1}',
+            this.getLabel(),
+            zAxisString
+        );
+    }
+
+});

--- a/web-app/js/portal/filter/StringDepthFilter.js
+++ b/web-app/js/portal/filter/StringDepthFilter.js
@@ -1,6 +1,10 @@
 Ext.namespace('Portal.filter');
 
-Portal.filter.StringDepthFilter = Ext.extend(Portal.filter.StringFilter, {
+Portal.filter.StringDepthFilter = Ext.extend(Portal.filter.Filter, {
+
+    getSupportedGeoserverTypes: function() {
+        return ['depthstring'];
+    },
 
     setUnits: function(units) {
 
@@ -10,6 +14,20 @@ Portal.filter.StringDepthFilter = Ext.extend(Portal.filter.StringFilter, {
     getUnits: function() {
 
         return this.units;
+    },
+
+    getUiComponentClass: function() {
+
+        return Portal.filter.ui.ComboFilterPanel;
+    },
+
+    getCql: function() {
+
+        return String.format(
+            "{0} LIKE '{1}'",
+            this.getName(),
+            this._escapeSingleQuotes(this.getValue())
+        );
     },
 
     getHumanReadableForm: function() {
@@ -25,6 +43,11 @@ Portal.filter.StringDepthFilter = Ext.extend(Portal.filter.StringFilter, {
             this.getLabel(),
             zAxisString
         );
+    },
+
+    _escapeSingleQuotes: function(text) {
+
+        return text.replace(/'/g, "''");
     }
 
 });

--- a/web-app/js/portal/filter/ui/GroupPanel.js
+++ b/web-app/js/portal/filter/ui/GroupPanel.js
@@ -170,7 +170,8 @@ Portal.filter.ui.GroupPanel = Ext.extend(Ext.Container, {
             Portal.filter.DateFilter,
             Portal.filter.BooleanFilter,
             Portal.filter.NumberFilter,
-            Portal.filter.StringFilter
+            Portal.filter.StringFilter,
+            Portal.filter.StringDepthFilter
         ];
 
         var typeOrder = function (filter) {

--- a/web-app/js/portal/prototypes/OpenLayers.js
+++ b/web-app/js/portal/prototypes/OpenLayers.js
@@ -221,11 +221,11 @@ OpenLayers.Geometry.prototype.getPrettyBounds = function() {
     var bounds = this.getBounds();
 
     return String.format(
-        '{0}W {1}S {2}E {3}N',
-        toNSigFigs(bounds['left'], 3),
+        'From Lat/Lon {0}, {1} to Lat/Lon {2}, {3}',
         toNSigFigs(bounds['bottom'], 3),
-        toNSigFigs(bounds['right'], 3),
-        toNSigFigs(bounds['top'], 3)
+        toNSigFigs(bounds['left'], 3),
+        toNSigFigs(bounds['top'], 3),
+        toNSigFigs(bounds['right'], 3)
     );
 };
 


### PR DESCRIPTION
Updated display of subset parameters selected on Step 3 to be the following format:

Spatial: From Lat/Lon -43.639, 132.715 to Lat/Lon -35.377, 136.582
Temporal: 2009-Jan-01-00:00-UTC to 2009-Jan-08-00:00-UTC
Depth: 0m to 5000m