### PR TITLE
DataLayers can be loaded from config. Chosen via the picker

### DIFF
--- a/grails-app/controllers/au/org/emii/portal/LayerController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/LayerController.groovy
@@ -12,16 +12,27 @@ class LayerController {
     def groovyPageRenderer
     def hostVerifier
 
-    def configuredBaselayers = {
-        def baseLayerConfig = grailsApplication.config.baselayers
+    def configuredLayers = {
 
+        def baseLayerConfig = grailsApplication.config.baselayers
         baseLayerConfig.each {
             it.isBaseLayer = true
             it.queryable = false
         }
 
-        render baseLayerConfig as JSON
+        def dataLayerConfig = grailsApplication.config.datalayers
+        dataLayerConfig.each {
+            it.isDataLayer = true
+            it.displayInLayerSwitcher = true
+            it.queryable = false
+            it.visibility = false
+        }
+
+        def layerConfig = [baseLayerConfig, dataLayerConfig].flatten().findAll{it}
+
+        render layerConfig as JSON
     }
+
 
     def _getServerClass(serverType) {
         if (serverType == 'ncwms') {

--- a/src/groovy/au/org/emii/portal/HostVerifier.groovy
+++ b/src/groovy/au/org/emii/portal/HostVerifier.groovy
@@ -49,6 +49,10 @@ class HostVerifier {
                 allowedHosts[extractHost(layer.server.uri)] = true
             }
 
+            appConfig.datalayers.each { layer ->
+                allowedHosts[extractHost(layer.server.uri)] = true
+            }
+
             appConfig.knownServers.each { server ->
                 allowedHosts[extractHost(server.uri)] = true
             }

--- a/test/unit/au/org/emii/portal/LayerControllerTests.groovy
+++ b/test/unit/au/org/emii/portal/LayerControllerTests.groovy
@@ -88,7 +88,7 @@ class LayerControllerTests extends ControllerUnitTestCase {
             ]
         ]
 
-        controller.configuredBaselayers()
+        controller.configuredLayers()
 
         assertEquals(String.valueOf(baselayerConfig as JSON), mockResponse.contentAsString)
     }

--- a/web-app/js/portal/ui/openlayers/LayerOptions.js
+++ b/web-app/js/portal/ui/openlayers/LayerOptions.js
@@ -16,10 +16,12 @@ Portal.ui.openlayers.LayerOptions = Ext.extend(Object, {
             version: layerDescriptor.server.wmsVersion,
             transitionEffect: 'resize',
             isBaseLayer: layerDescriptor.isBaseLayer,
+            isDataLayer: layerDescriptor.isDataLayer,
             buffer: 1,
             gutter: gutterSize,
             projection: new OpenLayers.Projection(layerDescriptor.projection),
-            displayInLayerSwitcher: (layerDescriptor.isBaseLayer === true)
+            displayInLayerSwitcher: (layerDescriptor.isBaseLayer === true || layerDescriptor.displayInLayerSwitcher === true),
+            visibility: (layerDescriptor.visibility === false) ? false : true
         };
 
         Ext.apply(this, defaultOptions);


### PR DESCRIPTION
For https://github.com/aodn/backlog/issues/919

Here is some example config to drive testing. 
```
// testing with aodn namespacing
datalayerServer = [
    uri: "http://geoserver-static.aodn.org.au/geoserver/aodn/wms",
    wmsVersion: '1.1.1'
]
datalayers = [
    [
            name: "aodn:sw_region_kefs_points",
            title: "sw_region_kefs_points",
            server: datalayerServer
    ],
    [
            name: "aodn:cs_kefs_2011",
            title: "cs_kefs_2011",
            server: datalayerServer
    ]
]
```