### PR TITLE
Resize of large images now onRender of popup results

### DIFF
--- a/web-app/js/portal/ui/FeatureInfoPopup.js
+++ b/web-app/js/portal/ui/FeatureInfoPopup.js
@@ -160,7 +160,6 @@ Portal.ui.FeatureInfoPopup = Ext.extend(GeoExt.Popup, {
                     options.extraParams.name
                 );
                 this._featureInfoRequestCompleted();
-                Portal.utils.Image.resizeWhenLoadedAfterDelay('div > .featureinfocontent .feature img', 500);
             },
             failure: this._featureInfoRequestCompleted
         });
@@ -332,6 +331,8 @@ Portal.ui.FeatureInfoPopup = Ext.extend(GeoExt.Popup, {
                     var code = $('#' + this.getId() + ' script').text();
                     var codefunc = new Function(code);
                     codefunc();
+
+                    Portal.utils.Image.resizeWhenLoadedAfterDelay('div > .featureinfocontent .feature img', 500);
                 }
             }
         });


### PR DESCRIPTION
Spotted a trivial error when large images occur in GFI. They were not resizing because the popup tab container may not rendered yet if it is not the first tab.

Test this with `IMOS - AATAMS Facility - Satellite Relay Tagging Program - Near real-time CTD profile data` and some other layer