### PR TITLE
Let geoserver know what services we are talking to

### DIFF
--- a/src/groovy/au/org/emii/portal/wms/NcwmsServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/NcwmsServer.groovy
@@ -34,7 +34,7 @@ class NcwmsServer extends WmsServer {
         // Assume for NcWMS only date can be the filter request
         def date = filter
 
-        def urlFilterValues = String.format('%1$s?layerName=%2$s&REQUEST=GetMetadata&item=timesteps&day=%3$s',
+        def urlFilterValues = String.format('%1$s?layerName=%2$s&SERVICE=ncwms&REQUEST=GetMetadata&item=timesteps&day=%3$s',
             server,
             URLEncoder.encode(layer, "UTF-8"),
             date
@@ -78,7 +78,7 @@ class NcwmsServer extends WmsServer {
     }
 
     private String getMetadataUrl(server, layer) {
-        return String.format('%1$s?layerName=%2$s&REQUEST=GetMetadata&item=layerDetails',
+        return String.format('%1$s?layerName=%2$s&SERVICE=ncwms&REQUEST=GetMetadata&item=layerDetails',
             server,
             URLEncoder.encode(layer, "UTF-8")
         )

--- a/src/test/javascript/portal/details/StylePanelSpec.js
+++ b/src/test/javascript/portal/details/StylePanelSpec.js
@@ -84,7 +84,8 @@ describe("Portal.details.StylePanel", function() {
 
             var layer = {
                 params: {},
-                url: ""
+                url: "",
+                isNcwms: returns(false)
             };
             var urlString = stylePanel.buildGetLegend(layer, null, null, false);
             expect(getParameterByNameFromUrlString(urlString, "VERSION")).toEqual(null);
@@ -95,7 +96,8 @@ describe("Portal.details.StylePanel", function() {
             var layer = {
                 params: {},
                 url: "",
-                server: {wmsVersion: '1.1.0'}
+                server: {wmsVersion: '1.1.0'},
+                isNcwms: returns(false)
             };
             var urlString = stylePanel.buildGetLegend(layer, null, null, false);
             expect(getParameterByNameFromUrlString(urlString, "VERSION")).toEqual("1.1.0");
@@ -106,7 +108,8 @@ describe("Portal.details.StylePanel", function() {
             var layer = {
                 extraLayerInfo: {numColorBands: '24'},
                 url: "",
-                params: {}
+                params: {},
+                isNcwms: returns(false)
             };
             var urlString = stylePanel.buildGetLegend(layer, null, null, false);
             expect(getParameterByNameFromUrlString(urlString, 'NUMCOLORBANDS')).toEqual('24');
@@ -117,7 +120,8 @@ describe("Portal.details.StylePanel", function() {
             var layer = {
                 extraLayerInfo: {},
                 url: "",
-                params: {}
+                params: {},
+                isNcwms: returns(false)
             };
             var urlString = stylePanel.buildGetLegend(layer, null, null, false);
             expect(getParameterByNameFromUrlString(urlString, 'NUMCOLORBANDS')).toEqual(null);
@@ -127,7 +131,8 @@ describe("Portal.details.StylePanel", function() {
 
             var layer = {
                 url: "",
-                params: {}
+                params: {},
+                isNcwms: returns(false)
             };
             var urlString = stylePanel.buildGetLegend(layer, null, null, false);
             expect(getParameterByNameFromUrlString(urlString, 'NUMCOLORBANDS')).toEqual(null);
@@ -137,7 +142,8 @@ describe("Portal.details.StylePanel", function() {
 
             var layer = {
                 params: {},
-                url: ""
+                url: "",
+                isNcwms: returns(false)
             };
             var urlString = stylePanel.buildGetLegend(layer, 'style/palette', null, false);
             expect(getParameterByNameFromUrlString(urlString, "STYLE")).toEqual("style/palette");
@@ -147,7 +153,8 @@ describe("Portal.details.StylePanel", function() {
 
             var layer = {
                 params: {},
-                url: ""
+                url: "",
+                isNcwms: returns(false)
             };
             var urlString = stylePanel.buildGetLegend(layer, '', null, false);
             expect(getParameterByNameFromUrlString(urlString, "STYLE")).toEqual(null);
@@ -157,7 +164,8 @@ describe("Portal.details.StylePanel", function() {
 
             var layer = {
                 params: {},
-                url: ""
+                url: "",
+                isNcwms: returns(false)
             };
             var urlString = stylePanel.buildGetLegend(layer, '', 'palette', false);
             expect(getParameterByNameFromUrlString(urlString, "PALETTE")).toEqual("palette");
@@ -167,7 +175,8 @@ describe("Portal.details.StylePanel", function() {
 
             var layer = {
                 params: {},
-                url: ""
+                url: "",
+                isNcwms: returns(false)
             };
             var urlString = stylePanel.buildGetLegend(layer, null, null, false);
             expect(getParameterByNameFromUrlString(urlString, "PALETTE")).toEqual(null);

--- a/src/test/javascript/portal/ui/openlayers/layer/NcWmsSpec.js
+++ b/src/test/javascript/portal/ui/openlayers/layer/NcWmsSpec.js
@@ -396,7 +396,7 @@ describe("OpenLayers.Layer.NcWms", function() {
             var ncwmsLayer = mockNcwmsLayer();
 
             expect(ncwmsLayer._getExtraLayerInfoFromNcwms()).toEqual(
-                'http://ncwms.aodn.org.au/ncwms/wms?layerName=ncwmsLayerName&REQUEST=GetMetadata&item=layerDetails'
+                'http://ncwms.aodn.org.au/ncwms/wms?layerName=ncwmsLayerName&SERVICE=ncwms&REQUEST=GetMetadata&item=layerDetails'
             );
         });
 

--- a/web-app/js/portal/details/StylePanel.js
+++ b/web-app/js/portal/details/StylePanel.js
@@ -185,6 +185,12 @@ Portal.details.StylePanel = Ext.extend(Ext.Container, {
             url += "?";
         }
 
+        if (layer.isNcwms()) {
+            opts += "&SERVICE=ncwms"
+        } else {
+            opts += "&SERVICE=WMS"
+        }
+
         opts += "&REQUEST=GetLegendGraphic"
              +  "&LAYER=" + encodeURIComponent(layer.params.LAYERS)
              +  "&FORMAT=" + layer.params.FORMAT;

--- a/web-app/js/portal/ui/openlayers/layer/NcWms.js
+++ b/web-app/js/portal/ui/openlayers/layer/NcWms.js
@@ -301,7 +301,7 @@ OpenLayers.Layer.NcWms = OpenLayers.Class(OpenLayers.Layer.WMS, {
 
     _getExtraLayerInfoFromNcwms: function() {
         return String.format(
-            "{0}?layerName={1}&REQUEST=GetMetadata&item=layerDetails",
+            "{0}?layerName={1}&SERVICE=ncwms&REQUEST=GetMetadata&item=layerDetails",
             this.url,
             encodeURIComponent(this.params.LAYERS)
         );


### PR DESCRIPTION
Its used by geoserver to determine what parsers to use and its the only way we can tell geoserver to use different parsers for the WMS palette request parameter and the ncwms palette request parameter