### PR TITLE
Proof of concept for retrieving filter config from a url

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -172,22 +172,27 @@ baselayerServer = [
 proxyConnectTimeout = 2000
 
 
+filtering {
+    baseUrl = "https://raw.githubusercontent.com/aodn/filter-config/test"
+}
+
 // This array should be populated from chef config
 knownServers = [
     [
         uri: 'http://geoserver-123.aodn.org.au/geoserver/wms',
         wmsVersion: '1.1.1',
-        type: 'GeoserverCore',
+        type: 'GeoServer',
         csvDownloadFormat: 'csv-with-metadata-header',
         urlListDownloadSubstitutions: [
             '^': 'http://data.aodn.org.au/'
-        ],
-        filterDir: 'imos-geoserver'
+        ]
     ],
     [
         uri: 'http://nonprod.marine.ga.gov.au/geoserver/wms',
         wmsVersion: '1.1.1',
-        type: 'GeoserverCore'
+        type: 'GeoserverFilterConfig',
+        filtersDir: "ga-geoserver",
+        wpsUrl: 'http://nonprod.marine.ga.gov.au/geoserver/wps'
     ],
     [
         uri: 'http://marine.ga.gov.au/geoserver/wms',
@@ -297,10 +302,6 @@ minimap {
         url = baselayerServer.uri
         params = [layers: 'default_bathy']
     }
-}
-
-filtering {
-    baseUrl = "https://raw.githubusercontent.com/aodn/filter-config/test"
 }
 
 portal {

--- a/grails-app/utils/au/org/emii/portal/UrlUtils.groovy
+++ b/grails-app/utils/au/org/emii/portal/UrlUtils.groovy
@@ -1,5 +1,7 @@
 package au.org.emii.portal
 
+import au.org.emii.portal.proxying.ExternalRequest
+
 final class UrlUtils {
 
     static String ensureTrailingSlash(url) {
@@ -29,4 +31,13 @@ final class UrlUtils {
 
         return urlWithQueryString(url, queryString)
     }
+
+    static String load(url) {
+        def outputStream = new ByteArrayOutputStream()
+        def request = new ExternalRequest(outputStream, url.toURL())
+
+        request.executeRequest()
+        return outputStream.toString("utf-8")
+    }
+
 }

--- a/src/groovy/au/org/emii/portal/wms/FilterConfigGeoserverServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/FilterConfigGeoserverServer.groovy
@@ -1,0 +1,67 @@
+package au.org.emii.portal.wms
+
+import au.org.emii.portal.UrlUtils
+
+class FilterConfigGeoserverServer extends WmsServer {
+
+    private def filterValuesService
+    private def filtersUrl
+
+    FilterConfigGeoserverServer(filtersUrl, filterValuesService) {
+        this.filtersUrl = filtersUrl
+        this.filterValuesService = filterValuesService
+    }
+
+    def getStyles(server, layer) {
+        return []
+    }
+
+    def getFilters(server, layer) {
+        def filters = []
+
+        try {
+            def url = _buildFilterConfigUrl(layer)
+            def xml = UrlUtils.load(url)
+            filters = _parseFilterConfigXml(xml)
+        } catch (e) {
+            log.error "Could not load filters for server '${server}', layer '${layer}'", e
+        }
+
+        return filters
+    }
+
+    def getFilterValues(server, layer, filter) {
+        return filterValuesService.getFilterValues(layer, filter)
+    }
+
+    def _buildFilterConfigUrl(layer) {
+        String fixedLayerName = layer.replace(':','/');
+        return filtersUrl +  "/" + fixedLayerName + '.xml'
+    }
+
+    def _parseFilterConfigXml(filterConfig) {
+        def filters = []
+
+        def xml = new XmlSlurper().parseText(filterConfig)
+
+        xml.filter.each { filter ->
+
+            def filterValue = [
+                label: filter.label.text(),
+                type: filter.type.text(),
+                name: filter.name.text(),
+                visualised: Boolean.valueOf(filter.visualised.text())
+            ]
+
+            if (!filter.wmsStartDateName.isEmpty() && !filter.wmsEndDateName.isEmpty()) {
+                filterValue.put('wmsStartDateName', filter.wmsStartDateName.text())
+                filterValue.put('wmsEndDateName', filter.wmsEndDateName.text())
+            }
+
+            filters.push(filterValue)
+        }
+
+        return filters
+    }
+
+}

--- a/src/groovy/au/org/emii/portal/wms/NcwmsServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/NcwmsServer.groovy
@@ -5,6 +5,7 @@ import java.text.DateFormat
 import java.text.SimpleDateFormat
 
 class NcwmsServer extends WmsServer {
+
     def getStyles(server, layer) {
         def json = JSON.parse(getUrlContent(getMetadataUrl(server, layer)))
 

--- a/src/groovy/au/org/emii/portal/wms/WpsUniqueValuesFilterService.groovy
+++ b/src/groovy/au/org/emii/portal/wms/WpsUniqueValuesFilterService.groovy
@@ -1,0 +1,51 @@
+package au.org.emii.portal.wms
+
+import groovy.json.JsonSlurper
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class WpsUniqueValuesFilterService {
+
+    static final Logger log = LoggerFactory.getLogger(this)
+
+    private def wpsUrl
+    private def requestRenderer
+
+    WpsUniqueValuesFilterService(wpsUrl, requestRenderer) {
+        this.wpsUrl = wpsUrl
+        this.requestRenderer = requestRenderer
+    }
+
+    def getFilterValues(layer, filter) {
+        def values = []
+
+        try {
+            def uniqueValuesResponse = _getPagedUniqueValues(layer, filter)
+            def json = new JsonSlurper().parseText(uniqueValuesResponse)
+
+            values = json.values
+        } catch (e) {
+            log.error "Unable to parse filters values for wps server '${wpsUrl}', layer '${layer}', filter '${filter}'", e
+        }
+
+        return values
+    }
+
+    def _getPagedUniqueValues(layer, filter) {
+        def params = [typeName: layer, propertyName: filter]
+        def body = requestRenderer.render(template: '/filters/pagedUniqueRequest.xml', model: params)
+        log.debug("Request body:\n\n${body}")
+
+        def connection = wpsUrl.toURL().openConnection()
+
+        connection.with {
+            doOutput = true
+            requestMethod = 'POST'
+            setRequestProperty("Content-Type", "application/xml; charset=utf-8")
+            outputStream.withWriter { writer ->
+                writer << body
+            }
+            content.text
+        }
+    }
+}

--- a/test/unit/au/org/emii/portal/wms/CoreGeoserverServerTests.groovy
+++ b/test/unit/au/org/emii/portal/wms/CoreGeoserverServerTests.groovy
@@ -6,9 +6,6 @@ class CoreGeoserverServerTests extends GrailsUnitTestCase {
 
     def coreGeoserverServer
     def validGeoserverResponse
-    def filterValuesJson
-    def emptyJson
-    def groovyPageRenderer
     def validDescribeLayerResponse
 
     protected void setUp() {
@@ -16,7 +13,7 @@ class CoreGeoserverServerTests extends GrailsUnitTestCase {
 
         mockLogging(CoreGeoserverServer)
 
-        coreGeoserverServer = new CoreGeoserverServer(groovyPageRenderer, null, null)
+        coreGeoserverServer = new CoreGeoserverServer(null)
 
         validGeoserverResponse =
 """<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:gml="http://www.opengis.net/gml" xmlns:imos="imos.mod" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="imos.mod">
@@ -36,21 +33,6 @@ class CoreGeoserverServerTests extends GrailsUnitTestCase {
   <xsd:element name="layer" substitutionGroup="gml:_Feature" type="imos:layerType"/>
 </xsd:schema>"""
 
-        filterValuesJson =
-'''{
-  "values":["ABFR","ADAB","ANHO","AUHO","BRER"],
-  "featureTypeName":"feature_type_name",
-  "fieldName":"property_name",
-  "size":5
-}'''
-
-        emptyJson =
-            '''{
-  "values":[],
-  "featureTypeName":"feature_type_name",
-  "fieldName":"property_name",
-  "size":0
-}'''
         validDescribeLayerResponse =
 '''<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE WMS_DescribeLayerResponse SYSTEM "https://geoserver.aodn.org.au/geoserver/schemas/wms/1.1.1/WMS_DescribeLayerResponse.dtd">
@@ -60,32 +42,6 @@ class CoreGeoserverServerTests extends GrailsUnitTestCase {
   </LayerDescription>
 </WMS_DescribeLayerResponse>
 '''
-    }
-
-    void testValidFilterValues() {
-        coreGeoserverServer.metaClass._getPagedUniqueValues = { server, layer, filter -> return filterValuesJson }
-
-        def expected = [
-            "ABFR",
-            "ADAB",
-            "ANHO",
-            "AUHO",
-            "BRER"
-        ]
-
-        def filterValues = coreGeoserverServer.getFilterValues("http://server", "layer", "some_filter")
-
-        assertEquals expected, filterValues
-    }
-
-    void testInvalidFilterValues() {
-        coreGeoserverServer.metaClass._getPagedUniqueValues = { server, layer, filter -> return "here be invalid json" }
-
-        def expected = []
-
-        def filterValues = coreGeoserverServer.getFilterValues("http://server", "layer", "some_filter")
-
-        assertEquals expected, filterValues
     }
 
     void testValidFilters() {

--- a/test/unit/au/org/emii/portal/wms/FilterConfigGeoserverServerTests.groovy
+++ b/test/unit/au/org/emii/portal/wms/FilterConfigGeoserverServerTests.groovy
@@ -1,0 +1,105 @@
+package au.org.emii.portal.wms
+
+import au.org.emii.portal.UrlUtils
+import grails.test.GrailsUnitTestCase
+
+class FilterConfigGeoserverServerTests  extends GrailsUnitTestCase {
+    def server
+    def validFilterConfig
+
+    protected void setUp() {
+        super.setUp()
+
+        mockLogging(FilterConfigGeoserverServer)
+
+        server = new FilterConfigGeoserverServer(null, null)
+
+        validFilterConfig =
+            """<?xml version="1.0"?>
+<filters>
+    <filter>
+        <name>data_centre_name</name>
+        <type>string</type>
+        <label>Data centre name</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+    <filter>
+        <name>platform_number</name>
+        <type>string</type>
+        <label>Platform Number</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+    <filter>
+        <name>juld</name>
+        <type>datetime</type>
+        <label>Time</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+    <filter>
+        <name>position</name>
+        <type>geometrypropertytype</type>
+        <label>Bounding Box</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+    <filter>
+        <name>profile_processing_type</name>
+        <type>string</type>
+        <label>Realtime/Delayed</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+</filters>"""
+
+    }
+
+    void testValidFilters() {
+
+        def expected = [[
+            label: 'Data centre name',
+            type: 'string',
+            name: 'data_centre_name',
+            visualised: true
+        ],[
+            label: 'Platform Number',
+            type: 'string',
+            name: 'platform_number',
+            visualised: true
+        ],[
+            label: 'Time',
+            type: 'datetime',
+            name: 'juld',
+            visualised: true
+        ],[
+            label: 'Bounding Box',
+            type: 'geometrypropertytype',
+            name: 'position',
+            visualised: true
+        ],[
+            label: 'Realtime/Delayed',
+            type: 'string',
+            name: 'profile_processing_type',
+            visualised: true
+        ]]
+
+        UrlUtils.metaClass.static.load = { url -> validFilterConfig}
+
+        def result = server.getFilters('http://server', 'dummy')
+
+        assertEquals expected, result
+    }
+
+    void testInvalidFilters() {
+        def expected = []
+
+        UrlUtils.metaClass.static.load = { url -> "here be invalid xml" }
+
+        def result = server.getFilters('dummy','filter')
+
+        assertEquals expected, result
+    }
+
+}

--- a/test/unit/au/org/emii/portal/wms/WpsUniqueValuesFilterServiceTests.groovy
+++ b/test/unit/au/org/emii/portal/wms/WpsUniqueValuesFilterServiceTests.groovy
@@ -1,0 +1,51 @@
+package au.org.emii.portal.wms
+
+import grails.test.GrailsUnitTestCase
+
+class WpsUniqueValuesFilterServiceTests extends GrailsUnitTestCase {
+    def filterValuesService
+    def filterValuesJson
+
+    protected void setUp() {
+        super.setUp()
+
+        mockLogging(CoreGeoserverServer)
+
+        filterValuesService = new WpsUniqueValuesFilterService(null, null)
+
+        filterValuesJson =
+            '''{
+  "values":["ABFR","ADAB","ANHO","AUHO","BRER"],
+  "featureTypeName":"feature_type_name",
+  "fieldName":"property_name",
+  "size":5
+}'''
+    }
+
+    void testValidFilterValues() {
+        filterValuesService.metaClass._getPagedUniqueValues = { layer, filter -> return filterValuesJson}
+
+        def expected = [
+            "ABFR",
+            "ADAB",
+            "ANHO",
+            "AUHO",
+            "BRER"
+        ]
+
+        def filterValues = filterValuesService.getFilterValues("layer", "some_filter")
+
+        assertEquals expected, filterValues
+    }
+
+    void testInvalidFilterValues() {
+        filterValuesService.metaClass._getPagedUniqueValues = { layer, filter -> return "here be invalid json" }
+
+        def expected = []
+
+        def filterValues = filterValuesService.getFilterValues("layer", "some_filter")
+
+        assertEquals expected, filterValues
+    }
+
+}


### PR DESCRIPTION
for https://github.com/aodn/backlog/issues/945#issuecomment-429200369

I haven't added tests for the new functionality yet since it's just proof of concept. I figure the functionality might change.

I've changed the config to show how it's supposed to be configured, but that probably shouldn't be merged into master, since geoserver-123 doesn't seem to work as coregeoserver for retrieving filter values (should we enable wps?)

I made sure to keep instances of CoreGeoserverServer generic (in the sense that each can accept requests for any server). But I wonder if we should actually just refactor to make each instance of a WmsServer attach to a specific server, rather than having server sent as a parameter to each function... cause the thing is, the way the code is currently set up,  a new WmsServer is created for each server, so a particular instance is never going to receive requests for more than one server...