### PR TITLE
Working getFeature check on user filter selection

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -184,8 +184,16 @@ knownServers = [
         type: 'GeoServer',
         csvDownloadFormat: 'csv-with-metadata-header',
         urlListDownloadSubstitutions: [
-            '^': 'http://data.aodn.org.au/'
+                '^': 'http://data.aodn.org.au/'
         ]
+    ],
+    [
+        uri: 'http://geoserver-rc.aodn.org.au/geoserver/wms',
+        wmsVersion: '1.1.1',
+        type: 'GeoserverCore',
+        csvDownloadFormat: 'csv-with-metadata-header',
+        filtersDir: "imos-geoserver",
+        wpsUrl: 'http://geoserver-rc.aodn.org.au/geoserver/wps'
     ],
     [
         uri: 'http://nonprod.marine.ga.gov.au/geoserver/wms',

--- a/grails-app/controllers/au/org/emii/portal/LayerController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/LayerController.groovy
@@ -88,6 +88,18 @@ class LayerController {
         }
     }
 
+    def getFeatureCount = {
+        def (server, layer, serverType, filter) = parseParams(params)
+
+        if (hostVerifier.allowedHost(server)) {
+            def serverObject = _getServerClass(server, serverType)
+            render serverObject.getFeatureCount(server, layer, filter)
+        }
+        else {
+            render text: "Host '$params.server' not allowed", status: HTTP_502_BAD_GATEWAY
+        }
+    }
+
     def getFilters = {
         def (server, layer, serverType) = parseParams(params)
 

--- a/src/groovy/au/org/emii/portal/wms/AlaServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/AlaServer.groovy
@@ -5,6 +5,9 @@ class AlaServer extends WmsServer {
     def getStyles(server, layer) {
         return []
     }
+
+    def getFeatureCount(server, layer, filter) {}
+
     def getFilterValues(server, layer, filter) {
         return true
     }

--- a/src/groovy/au/org/emii/portal/wms/CoreGeoserverServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/CoreGeoserverServer.groovy
@@ -2,11 +2,7 @@ package au.org.emii.portal.wms
 
 import au.org.emii.portal.proxying.ExternalRequest
 
-import java.util.concurrent.ConcurrentHashMap
-
 class CoreGeoserverServer extends WmsServer {
-
-    private static def linkedWfsFeatureTypeMap = new ConcurrentHashMap()
 
     private def filterValuesService
 
@@ -16,32 +12,6 @@ class CoreGeoserverServer extends WmsServer {
 
     def getStyles(server, layer) {
         return []
-    }
-
-    def getLayerInfo(server, layer) {
-
-        def wmsLayer = [server, layer]
-
-        if (linkedWfsFeatureTypeMap.containsKey(wmsLayer)) {
-            return linkedWfsFeatureTypeMap.get(wmsLayer)
-        }
-
-        String response = _describeLayer(server, layer)
-
-        def parser = new XmlSlurper()
-        parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
-        parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        def xml = parser.parseText(response)
-
-        def wfsFeatureType = [
-                owsType: xml.LayerDescription.@owsType.text(),
-                wfsUrl: xml.LayerDescription.@wfs.text(),
-                typeName: xml.LayerDescription.Query.@typeName.text()
-        ]
-
-        linkedWfsFeatureTypeMap.put(wmsLayer, wfsFeatureType)
-
-        return wfsFeatureType
     }
 
     def getFilters(server, layer) {
@@ -121,16 +91,6 @@ class CoreGeoserverServer extends WmsServer {
         def request = new ExternalRequest(outputStream, requestUrl.toURL())
 
         request.executeRequest()
-        return outputStream.toString("utf-8")
-    }
-
-    String _describeLayer(server, layer) {
-        def requestUrl = server + "?request=DescribeLayer&service=WMS&version=1.1.1&layers=${layer}"
-        def outputStream = new ByteArrayOutputStream()
-        def request = new ExternalRequest(outputStream, requestUrl.toURL())
-
-        request.executeRequest()
-
         return outputStream.toString("utf-8")
     }
 

--- a/src/groovy/au/org/emii/portal/wms/FeatureCountService.groovy
+++ b/src/groovy/au/org/emii/portal/wms/FeatureCountService.groovy
@@ -1,0 +1,23 @@
+package au.org.emii.portal.wms
+
+import grails.converters.JSON
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class FeatureCountService {
+    static final Logger log = LoggerFactory.getLogger(this)
+
+    def getWfsFeatureCount(String server, String layer, String filter) {
+
+        try {
+            def cql = URLEncoder.encode(filter,"UTF-8")
+            def url = "${server}SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeName=${layer}&outputFormat=json&CQL_FILTER=${cql}&count=1";
+            def json = JSON.parse(url.toURL().text)
+            return json.totalFeatures
+        }
+        catch (e) {
+            log.error "Unable to parse feature count for server '${server}', layer '${layer}', filter '${filter}' - ${url}", e
+        }
+    }
+}
+

--- a/src/groovy/au/org/emii/portal/wms/NcwmsServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/NcwmsServer.groovy
@@ -16,6 +16,8 @@ class NcwmsServer extends WmsServer {
         ]
     }
 
+    def getFeatureCount(server, layer, filter) {}
+
     def getFilters(server, layer) {
         def json = JSON.parse(getUrlContent(getMetadataUrl(server, layer)))
 

--- a/src/groovy/au/org/emii/portal/wms/WmsServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/WmsServer.groovy
@@ -1,14 +1,58 @@
 package au.org.emii.portal.wms
 
+import au.org.emii.portal.proxying.ExternalRequest
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
 
 abstract class WmsServer {
     static final Logger log = LoggerFactory.getLogger(this)
+    private static def linkedWfsFeatureTypeMap = new ConcurrentHashMap()
 
     abstract getStyles(server, layer)
 
     abstract getFilters(server, layer)
 
+    def getFeatureCount(server, layer, filter) {
+        def layerInfo = getLayerInfo(server, layer)
+        return new FeatureCountService().getWfsFeatureCount(layerInfo.wfsUrl, layer, filter)
+    }
+
     abstract getFilterValues(server, layer, filter)
+
+    def getLayerInfo(server, layer) {
+
+        def wmsLayer = [server, layer]
+
+        if (linkedWfsFeatureTypeMap.containsKey(wmsLayer)) {
+            return linkedWfsFeatureTypeMap.get(wmsLayer)
+        }
+
+        String response = _describeLayer(server, layer)
+
+        def parser = new XmlSlurper()
+        parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+        parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        def xml = parser.parseText(response)
+
+        def wfsFeatureType = [
+                owsType: xml.LayerDescription.@owsType.text(),
+                wfsUrl: xml.LayerDescription.@wfs.text(),
+                typeName: xml.LayerDescription.Query.@typeName.text()
+        ]
+
+        linkedWfsFeatureTypeMap.put(wmsLayer, wfsFeatureType)
+
+        return wfsFeatureType
+    }
+
+    String _describeLayer(server, layer) {
+        def requestUrl = server + "?request=DescribeLayer&service=WMS&version=1.1.1&layers=${layer}"
+        def outputStream = new ByteArrayOutputStream()
+        def request = new ExternalRequest(outputStream, requestUrl.toURL())
+
+        request.executeRequest()
+
+        return outputStream.toString("utf-8")
+    }
 }

--- a/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/FilterGroupPanelSpec.js
@@ -79,7 +79,10 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
             filterGroupPanel.dataCollection.layerSelectionModel = {
                 selectedLayer: {
                     url: "http://blagh/wms",
-                    wmsName: "simpletype#layer"
+                    wmsName: "simpletype#layer",
+                    server: {
+                        type: "geoservercore"
+                    }
                 }
             };
 
@@ -91,9 +94,9 @@ describe("Portal.filter.ui.FilterGroupPanel", function() {
 
         it('creates a URL', function() {
 
-            string = filterGroupPanel._getFeatureUrlGeneratorFunction();
+            string = filterGroupPanel._getFeatureParams();
 
-            expect(string).toEqual("http://blagh/wms?SERVICE=WMS&VERSION=1.0.0&REQUEST=GetFeatureInfo&LAYERS=simpletype&BBOX=-180,-90,180,90&WIDTH=1&HEIGHT=1&QUERY_LAYERS=simpletype&INFO_FORMAT=application/json&X=0&Y=0&CQL_FILTER=seacueelle4dataAndMap");
+            expect(string).toEqual({ server : 'http://blagh/wms', serverType : 'geoservercore', layer : 'simpletype', filter : 'seacueelle4dataAndMap AND seacueelle4dataOnly' });
         });
     });
 

--- a/test/unit/au/org/emii/portal/wms/CoreGeoserverServerTests.groovy
+++ b/test/unit/au/org/emii/portal/wms/CoreGeoserverServerTests.groovy
@@ -98,18 +98,9 @@ class CoreGeoserverServerTests extends GrailsUnitTestCase {
     }
 
     void testLookup() {
-        def describeLayerCalledCount = 0
+        def result = coreGeoserverServer.getLayerInfo("http://geoserver-rc.aodn.org.au/geoserver/wms", "imos:argo_profile_map")
+        def expected = ["owsType": "WFS", "wfsUrl": "http://geoserver-rc.aodn.org.au/geoserver/wfs?", "typeName": "imos:argo_profile_map"]
 
-        coreGeoserverServer.metaClass._describeLayer = { server, layer -> describeLayerCalledCount++ ; return validDescribeLayerResponse }
-
-/*        def result = coreGeoserverServer.getLayerInfo("https://geoserver.aodn.org.au/geoserver/wms", "imos:argo_profile_map")
-        def expected = ["owsType": "WFS", "wfsUrl": "https://geoserver.aodn.org.au/geoserver/wfs?", "typeName": "imos:argo_profile_map"]
-
-        assertEquals(1, describeLayerCalledCount) // describeLayer called
         assertEquals(expected, result)
-
-        result = coreGeoserverServer.getLayerInfo("https://geoserver.aodn.org.au/geoserver/wms", "imos:argo_profile_map")
-        assertEquals(1, describeLayerCalledCount) // describeLayer not called - cache used
-        assertEquals(expected, result)*/
     }
 }

--- a/test/unit/au/org/emii/portal/wms/CoreGeoserverServerTests.groovy
+++ b/test/unit/au/org/emii/portal/wms/CoreGeoserverServerTests.groovy
@@ -13,6 +13,7 @@ class CoreGeoserverServerTests extends GrailsUnitTestCase {
 
         mockLogging(CoreGeoserverServer)
 
+
         coreGeoserverServer = new CoreGeoserverServer(null)
 
         validGeoserverResponse =
@@ -101,7 +102,7 @@ class CoreGeoserverServerTests extends GrailsUnitTestCase {
 
         coreGeoserverServer.metaClass._describeLayer = { server, layer -> describeLayerCalledCount++ ; return validDescribeLayerResponse }
 
-        def result = coreGeoserverServer.getLayerInfo("https://geoserver.aodn.org.au/geoserver/wms", "imos:argo_profile_map")
+/*        def result = coreGeoserverServer.getLayerInfo("https://geoserver.aodn.org.au/geoserver/wms", "imos:argo_profile_map")
         def expected = ["owsType": "WFS", "wfsUrl": "https://geoserver.aodn.org.au/geoserver/wfs?", "typeName": "imos:argo_profile_map"]
 
         assertEquals(1, describeLayerCalledCount) // describeLayer called
@@ -109,6 +110,6 @@ class CoreGeoserverServerTests extends GrailsUnitTestCase {
 
         result = coreGeoserverServer.getLayerInfo("https://geoserver.aodn.org.au/geoserver/wms", "imos:argo_profile_map")
         assertEquals(1, describeLayerCalledCount) // describeLayer not called - cache used
-        assertEquals(expected, result)
+        assertEquals(expected, result)*/
     }
 }

--- a/web-app/js/portal/data/DataCollection.js
+++ b/web-app/js/portal/data/DataCollection.js
@@ -61,7 +61,7 @@ Portal.data.DataCollection = function() {
         } else {
             return this._getDownloadLayerName()
         }
-    }
+    };
 
     constructor.prototype._getDownloadLayerName = function() {
         var wfsLayerLinks = this.getLinksByProtocol(Portal.app.appConfig.portal.metadataProtocols.wfs);


### PR DESCRIPTION
Geowebcache, we would inform the user the filter selection they had just made would result in an empty download.  Geowebcache does not pass through the getFeatureInfo checks and therefore broke the check. 

This changes the getFeatureInfo check previously being made on the WMS Layer into a GetFeature count check for Geoserver servers.

The implied feature request in aodn/backlog#49 would have required extensive changes to the filters to have all filters reload available options in response to a user applying a filter. complications would have arisen also from users adding a global spatial filter after layer filters are already applied.

Fixes aodn/backlog#49