### PR TITLE
CheckFilters now uses WMS layer date fields

### DIFF
--- a/src/groovy/au/org/emii/portal/wms/WmsServer.groovy
+++ b/src/groovy/au/org/emii/portal/wms/WmsServer.groovy
@@ -47,11 +47,16 @@ abstract class WmsServer {
     }
 
     String _describeLayer(server, layer) {
+
         def requestUrl = server + "?request=DescribeLayer&service=WMS&version=1.1.1&layers=${layer}"
         def outputStream = new ByteArrayOutputStream()
-        def request = new ExternalRequest(outputStream, requestUrl.toURL())
-
-        request.executeRequest()
+        try {
+            def request = new ExternalRequest(outputStream, requestUrl.toURL())
+            request.executeRequest()
+        }
+        catch(e) {
+            log.error(e)
+        }
 
         return outputStream.toString("utf-8")
     }

--- a/web-app/js/portal/filter/ui/FilterGroupPanel.js
+++ b/web-app/js/portal/filter/ui/FilterGroupPanel.js
@@ -82,7 +82,7 @@ Portal.filter.ui.FilterGroupPanel = Ext.extend(Portal.filter.ui.GroupPanel, {
 
     _getFeatureParams: function() {
 
-        var builder = new Portal.filter.combiner.DataDownloadCqlBuilder({
+        var builder = new Portal.filter.combiner.FiltersWithValuesCqlBuilder({
             filters: this.dataCollection.getFilters()
         });
 


### PR DESCRIPTION
Changes to WmsServer.groovy stop errors being swallowed
Changes to FilterGroupPanel.js mean that the checkFilters request which checks the WMS layers WFS endpoint will use the temporal fields from the WMS layer not the 'TIME' field on the corresponding data layer