### PR TITLE
Use schema agnostic get.portal to update popularity

### DIFF
--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -320,7 +320,7 @@ Portal.search.FacetedSearchResultsDataView = Ext.extend(Ext.DataView, {
 
         // Updating the popularity counter of the metadata record at GeoNetwork
         Ext.ux.Ajax.proxyRequestXML({
-            url: Portal.app.appConfig.geonetwork.url + '/srv/eng/xml_iso19139.mcp?uuid=' + uuid + "&styleSheet=xml_iso19139.mcp.xsl"
+            url: Portal.app.appConfig.geonetwork.url + '/srv/eng/portal.get?uuid=' + uuid
         });
     },
 


### PR DESCRIPTION
instead of specific schema conversion service