### PR TITLE
Makes the ALA autocomplete widget un-muntable

### DIFF
--- a/src/test/javascript/portal/filter/ui/AlaSpeciesFilterPanelSpec.js
+++ b/src/test/javascript/portal/filter/ui/AlaSpeciesFilterPanelSpec.js
@@ -1,4 +1,4 @@
-describe("Portal.filter.ui.AlaSpeciesFilterPanel", function() {
+    describe("Portal.filter.ui.AlaSpeciesFilterPanel", function() {
 
     var alaSpeciesFilterPanel;
 
@@ -37,6 +37,8 @@ describe("Portal.filter.ui.AlaSpeciesFilterPanel", function() {
                 })
             }
         });
+
+        alaSpeciesFilterPanel.cleanupSpeciesCombo = returns(true);
     });
 
     describe('_onSpeciesComboChange', function() {
@@ -49,7 +51,6 @@ describe("Portal.filter.ui.AlaSpeciesFilterPanel", function() {
                 getValue: noOp,
                 markInvalid: noOp
             };
-
             spyOn(alaSpeciesFilterPanel, '_createNewActiveFilterPanel');
         });
 

--- a/web-app/js/portal/filter/ui/AlaSpeciesFilterPanel.js
+++ b/web-app/js/portal/filter/ui/AlaSpeciesFilterPanel.js
@@ -64,6 +64,7 @@ Portal.filter.ui.AlaSpeciesFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterP
             typeAhead: false,
             forceSelection: true,
             width: this.MAX_COMPONENT_WIDTH,
+            validateOnBlur: false,
             queryParam: 'q',
             minChars: 2,
             lastQuery: '',
@@ -77,6 +78,18 @@ Portal.filter.ui.AlaSpeciesFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterP
                 select: this._onSpeciesComboChange,
                 change: this._onSpeciesComboChange,
                 blur: this._onBlur
+            },
+            assertValue: function () {
+                // https://stackoverflow.com/questions/26774545/how-to-clear-combo
+                var me = this,
+                    value = me.getRawValue();
+
+                if (me.forceSelection && me.allowBlank && Ext.isEmpty(value)) {
+                    me.setValue(value);
+                    me.collapse();
+                    return;
+                }
+                this.callParent(arguments);
             }
         });
 
@@ -176,9 +189,16 @@ Portal.filter.ui.AlaSpeciesFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterP
                 this.activeFiltersContainer.add(this._createNewActiveFilterPanel(record.data));
                 this.activeFiltersContainer.show();
                 this.activeFiltersContainer.doLayout();
-                this.speciesCombo.clearValue();
             }
         }
+        this.cleanupSpeciesCombo();
+    },
+
+    cleanupSpeciesCombo: function() {
+
+        this.speciesCombo.reset();
+        this.speciesCombo.blur();
+        this.speciesCombo.applyEmptyText();
     },
 
     handleRemoveFilter: function(targetedPanel) {
@@ -196,7 +216,6 @@ Portal.filter.ui.AlaSpeciesFilterPanel = Ext.extend(Portal.filter.ui.BaseFilterP
             }
 
         }, this);
-
 
         Ext.each(deadPanels, function(panel) {
             this._clearFilter(panel.activeFilterData);


### PR DESCRIPTION
If testing these changes note that by quickly interacting with it (therefore making map updates) you may cause both the ALA WMS and autocomplete endpoints to stop responding.

The way this component has broken in the past is:

1. The empty text should alway disappear on enter
1. The spinner below the input box should always show after typing at least three letters