### PR TITLE
changes csiro type from 'dataTrawler' to 'GeoserverFilterConfig'

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -214,13 +214,8 @@ knownServers = [
     [
         uri: 'https://www.cmar.csiro.au/geoserver/wms',
         wmsVersion: '1.1.1',
-        type: 'CoreGeoServer'
-    ],
-
-    [
-        uri: 'http://www.cmar.csiro.au/geoserver/wms',
-        wmsVersion: '1.1.1',
-        type: 'datatrawlerserver',
+        type: 'GeoserverFilterConfig',
+        filtersDir: "csiro-datatrawler",
         wpsUrl: 'http://www.cmar.csiro.au/geoserver/wps'
     ],
     [


### PR DESCRIPTION
@pmbohm would you mind PRing this one? 

Now that the filters for the two collections are in the filter-config repo (test) branch you can test by pointing your local portal to catalogue-sandbox and searching for these two:
- CSIRO O&A CTD Data Overview (1982 - present) 
- CSIRO O&A Hydrology Data Overview (1942 - present)

With this change, the filters should appear and values are populated.

I looked at the download handler but I decided not to proceed with anything because I couldn't get a download to work in sandbox thus testing would be pretty useless.