### PR TITLE
Allow tailored response (error) handling for async downloads

### DIFF
--- a/grails-app/services/au/org/emii/portal/JsonService.groovy
+++ b/grails-app/services/au/org/emii/portal/JsonService.groovy
@@ -33,7 +33,6 @@ class JsonService extends AsyncDownloadService {
 
     def onResponseSuccess = { resp ->
         assert resp.statusLine.statusCode == 200
-        return "statusCode was ok"
+        return resp.entity.content.text
     }
-
 }

--- a/src/test/javascript/portal/cart/AsyncDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/cart/AsyncDownloadHandlerSpec.js
@@ -14,17 +14,26 @@ describe('Portal.cart.AsyncDownloadHandler', function () {
     describe('serviceResponseHandler', function() {
         it('invalid json', function() {
             var json = "HERE BE INAVLID JSON";
-            expect(handler.serviceResponseHandler(json)).toEqual("");
+            expect(handler.serviceResponseHandler(json)).toEqual({ userMsg : OpenLayers.i18n("unexpectedDownloadResponse"), status : 404 });
         });
 
         it('no url', function() {
             var json = "{}";
-            expect(handler.serviceResponseHandler(json)).toEqual("");
+            expect(handler.serviceResponseHandler(json)).toEqual({ userMsg : OpenLayers.i18n("unexpectedDownloadResponse"), status : 404 });
         });
 
         it('valid url', function() {
-            var json = '{ "url": "http://asyncdownloads.aodn.org.au" }';
-            expect(handler.serviceResponseHandler(json)).toMatch("href='http://asyncdownloads.aodn.org.au'");
+            var obj = {
+                responseText: JSON.stringify({
+                    url: "http://asyncdownloads.aodn.org.au"
+                })
+            };
+            var expected = {
+                responseText : '{"url":"http://asyncdownloads.aodn.org.au"}',
+                userMsg : "<a class='external' target='_blank' href='http://asyncdownloads.aodn.org.au'>Follow the progress of your job</a><br /><br />"
+            };
+
+            expect(handler.serviceResponseHandler(obj)).toMatch(expected);
         });
     });
 });

--- a/src/test/javascript/portal/cart/GaDownloadHandlerSpec.js
+++ b/src/test/javascript/portal/cart/GaDownloadHandlerSpec.js
@@ -1,0 +1,79 @@
+
+describe('Portal.cart.GaDownloadHandler', function () {
+
+    var handler;
+
+    beforeEach(function() {
+
+        handler = new Portal.cart.GaDownloadHandler({
+            href: 'ga_url',
+            name: 'layer_name'
+        });
+    });
+
+    describe('serviceResponseHandler', function() {
+/*        it('invalid json', function() {
+            var json = "HERE BE INAVLID JSON";
+            expect(handler.serviceResponseHandler(json)).toEqual({ userMsg : OpenLayers.i18n("unexpectedDownloadResponse"), status : "munt" });
+        });
+*/
+        it('no url', function() {
+            var json = "{}";
+            expect(handler.serviceResponseHandler(json)).toEqual({ userMsg : OpenLayers.i18n("unexpectedDownloadResponse"), status : 404 });
+        });
+
+
+        it('not valid', function() {
+            var typicalStatus = 200;
+            var obj = {
+                status: typicalStatus,
+                responseText: "some giberish"
+            };
+            expect(handler.parseResponse(obj).status).not.toEqual(typicalStatus);
+        });
+
+        it('not valid', function() {
+            var obj = {
+                status: 404,
+                responseText: JSON.stringify({
+                    url: "http://asyncdownloads.aodn.org.au"
+                })
+            };
+            expect(handler.parseResponse(obj)).toEqual(obj);
+        });
+
+
+        it('valid current response', function() {
+            var obj = {
+                status: 200,
+                responseText: JSON.stringify({
+                    status: "OK",
+                    reason: "Its not an error cause i say"
+                })
+            };
+            var expected = {
+                status: 200,
+                responseText: '{"status":"OK","reason":"Its not an error cause i say"}'
+            };
+
+            expect(handler.parseResponse(obj)).toEqual(expected);
+        });
+
+        it('not valid', function() {
+            var obj = {
+                status: 200,
+                responseText: JSON.stringify({
+                    status: "error",
+                    reason: "Its an error even though i send you 200"
+                })
+            };
+            var expected = {
+                status: 404,
+                responseText: '{"status":"error","reason":"Its an error even though i send you 200"}',
+                userMsg : '<p>Unable to create subsetting job. Please re-check the parameters you provided and try again.</p> <p><b>Download Server Message:</b>  &#39;<i>Its an error even though i send you 200</i>&#39;</p>'
+            };
+
+            expect(handler.parseResponse(obj)).toEqual(expected);
+        });
+    });
+});

--- a/web-app/css/AODNTheme.css
+++ b/web-app/css/AODNTheme.css
@@ -378,3 +378,8 @@ div.stringFilterResult {
     -moz-border-image: -moz-linear-gradient(left, #FFFFFF, #6c6b6b, #f0f0f0);
     border-image-slice: 1;
 }
+
+.x-window-dlg .x-window-header-text,
+.x-window-header-text {
+    font-size: larger;
+}

--- a/web-app/js/portal/cart/AsyncDownloadHandler.js
+++ b/web-app/js/portal/cart/AsyncDownloadHandler.js
@@ -15,21 +15,25 @@ Portal.cart.AsyncDownloadHandler = Ext.extend(Portal.cart.DownloadHandler, {
     },
 
     serviceResponseHandler: function(response) {
-        var msg = "";
 
+        var responseJson;
         if (response) {
             try {
-                var responseJson = JSON.parse(response);
+                responseJson = JSON.parse(response.responseText);
                 if (responseJson['url']) {
-                    msg = OpenLayers.i18n('asyncServiceMsg', {
+                    response.userMsg = OpenLayers.i18n('asyncServiceMsg', {
                         url: responseJson['url']
                     });
                 }
             }
             catch (e) {
-                log.error(String.format("Could not parse asynchronous response: '{0}'", response));
+                log.error(String.format("Could not parse asynchronous response: '{0}'", response.responseText));
+                response = {
+                    userMsg: (response.responseText) ? response.responseText : OpenLayers.i18n("unexpectedDownloadResponse"),
+                    status: 404
+                }
             }
         }
-        return msg;
+        return response;
     }
 });

--- a/web-app/js/portal/cart/GaDownloadHandler.js
+++ b/web-app/js/portal/cart/GaDownloadHandler.js
@@ -17,14 +17,39 @@ Portal.cart.GaDownloadHandler = Ext.extend(Portal.cart.AsyncDownloadHandler, {
         return downloadOptions;
     },
 
-    _buildHandlerParams: function(fileFormat, downloadLabel) {
+    _buildHandlerParams: function() {
         return {
             asyncDownload: true,
             collectEmailAddress: true,
             downloadControllerArgs: {
                 action: 'passThrough'
+            },
+            serviceResponseHandler: this.parseResponse
+        }
+    },
+
+    // should be JSON
+    parseResponse: function(response) {
+        var responseJson;
+        if (response) {
+
+            // GA response.status currently is always 200
+            if (response.responseText != "OK") {
+                try {
+                    responseJson = JSON.parse(response.responseText);
+                    if (responseJson['status'] == "error" || response.status != 200) {
+                        response.status = (response.status != 200) ? response.status : 404;
+                        response.userMsg = String.format("<p>{0}</p> <p><b>Download Server Message:</b>  &#39;<i>{1}</i>&#39;</p>", OpenLayers.i18n('asyncDownloadErrorMsg'), responseJson['reason'] );
+                        log.error(String.format("Download error. User was shown: '{0}'", response.userMsg));
+                    }
+                }
+                catch (e) {
+                    response.status = (response.status != 200) ? response.status : 404;
+                    log.error(String.format("Unexpected response from GA download service: '{0}'", response));
+                }
             }
         }
+        return response;
     },
 
     _showDownloadOptions: function() {

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -124,7 +124,7 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
     // Download View
     downloadConfirmationWindowTitle: 'Data Download',
     downloadConfirmationWindowContent: " \
-  <h3>Licence and use limitations</h3> \
+  <h2>Licence and use limitations</h2> \
     <p> \
       <tpl if=\"jurisdictionLink\"><a target=\"_blank\" href=\"{jurisdictionLink}\">Jurisdiction</a></tpl> \
       <tpl if=\"imageLink\"><img src=\"{imageLink}\" /></tpl> \
@@ -211,9 +211,10 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
     asyncDownloadPanelTitleLoading: 'Requesting subset ...',
     asyncDownloadPanelTitle: 'Subset job status',
     asyncDownloadSuccessPendingMsg: "Waiting for your job to register with our servers.....",
-    asyncDownloadSuccessMsg: 'Your subsetting job has been created. Processing commenced.<br /><br />When the job is complete we will send an email to <i>${email}</i> with download instructions.<br /><br />${serviceMessage}NB. Subsetting jobs can vary considerably in how long they take, from minutes to hours. Both the number of source files and the selected area can affect how long a job takes to run.',
+    asyncDownloadSuccessMsg: 'Your subsetting job has been created. Processing commenced.<br /><br />When the job is complete we will send an email to <i><b>${email}</b></i> with download instructions.<br /><br />${serviceMessage}<br /><b>Note:</b> Subsetting jobs can vary considerably in how long they take, from minutes to hours. Both the number of source files and the selected area can affect how long a job takes to run.',
     asyncDownloadErrorMsg: 'Unable to create subsetting job. Please re-check the parameters you provided and try again.',
-    asyncServiceMsg: "<a class='external' target='_blank' href='${url}'>Follow the progress of your job</a><br /><br />",
+    asyncServiceMsg: "<a class='external' target='_blank' href='${url}'>Follow the progress of your job</a><br />",
+    unexpectedDownloadResponse: "Error. Unexpected response from download server.",
 
     spatialExtentHeading: 'Spatial',
     timeSeriesAtHeading: 'Timeseries at Lat/Lon',


### PR DESCRIPTION
Fixes https://github.com/aodn/aodn-portal/issues/2762

downloadHandlers inherriting from AsyncDownloadHandler.js can now handle when the response is 200 but contains a known error message in the responseText