### PR TITLE
ncWMS temporal selections must be valid

### DIFF
--- a/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
+++ b/src/test/javascript/portal/cart/NcWmsInjectorSpec.js
@@ -19,6 +19,7 @@ describe('Portal.cart.NcWmsInjector', function() {
                     isNcwmsParams: true,
                     dateRangeStart: startDate,
                     dateRangeEnd: endDate,
+                    errorMessage: "",
                     latitudeRangeStart: 0,
                     latitudeRangeEnd: 40,
                     longitudeRangeEnd: 180,
@@ -40,7 +41,8 @@ describe('Portal.cart.NcWmsInjector', function() {
 
         it('returns a message when no valid date', function() {
             dataCollection.getFilters = returns([{
-                isNcwmsParams: true
+                isNcwmsParams: true,
+                errorMessage: OpenLayers.i18n('unavailableTemporalExtent')
             }]);
             expect(injector._getDataFilterEntry(dataCollection)).toEqual(OpenLayers.i18n('unavailableTemporalExtent'));
         });

--- a/src/test/javascript/portal/details/NcWmsPanelSpec.js
+++ b/src/test/javascript/portal/details/NcWmsPanelSpec.js
@@ -225,7 +225,7 @@ describe('Portal.details.NcWmsPanel', function() {
             var testStartDate = moment();
             var testEndDate = moment();
 
-            var returnValue = ncwmsPanel._ncwmsParamsAsFilters(testStartDate, testEndDate, null, false, 0, 0);
+            var returnValue = ncwmsPanel._ncwmsParamsAsFilters("", testStartDate, testEndDate, null, false, 0, 0);
 
             expect(returnValue[0].getValue().fromDate).toEqual(testStartDate.toDate());
             expect(returnValue[1].dateRangeStart).toEqual(testStartDate);
@@ -235,7 +235,7 @@ describe('Portal.details.NcWmsPanel', function() {
 
             var testEndDate = moment();
 
-            var returnValue = ncwmsPanel._ncwmsParamsAsFilters(moment.invalid(), testEndDate, null, false, 0, 0);
+            var returnValue = ncwmsPanel._ncwmsParamsAsFilters("", moment.invalid(), testEndDate, null, false, 0, 0);
 
             expect(returnValue[0].getValue().toDate).toEqual(undefined);
             expect(returnValue[1].dateRangeEnd).toEqual(undefined);
@@ -243,7 +243,7 @@ describe('Portal.details.NcWmsPanel', function() {
 
         it('update geometry', function() {
 
-            var returnValue = ncwmsPanel._ncwmsParamsAsFilters(null, null, {
+            var returnValue = ncwmsPanel._ncwmsParamsAsFilters("",null, null, {
                 getBounds: returns({
                     bottom: 4,
                     left: 3,
@@ -263,7 +263,7 @@ describe('Portal.details.NcWmsPanel', function() {
                 latitude: -31.4,
                 longitude: 114.6
             };
-            var returnValue = ncwmsPanel._ncwmsParamsAsFilters(moment(), moment(), null, true, point);
+            var returnValue = ncwmsPanel._ncwmsParamsAsFilters("", moment(), moment(), null, true, point);
             var pointFilterValue = Portal.filter.FilterUtils.getFilter(returnValue, 'timeSeriesAtPoint').getValue();
             expect(pointFilterValue.latitude).toEqual(-31.4);
             expect(pointFilterValue.longitude).toEqual(114.6);

--- a/web-app/js/portal/cart/NcWmsInjector.js
+++ b/web-app/js/portal/cart/NcWmsInjector.js
@@ -39,16 +39,21 @@ Portal.cart.NcWmsInjector = Ext.extend(Portal.cart.BaseInjector, {
             timeSeriesAtString = pointFilter.getHumanReadableForm();
         }
 
-        if (params && params.dateRangeStart) {
-            var startDateString = this._formatDate(params.dateRangeStart);
-            var endDateString = this._formatDate(params.dateRangeEnd);
-            dateString = this._formatHumanDateInfo('temporalExtentHeading', startDateString, endDateString);
-        }
-        else if (!this.hasTemporalExtent(timeFilter, collection)) {
-            dateString = OpenLayers.i18n('unavailableTemporalExtent');
-        }
-        else {
-            dateString = OpenLayers.i18n('temporalExtentNotLoaded');
+        if (params) {
+            if (params.errorMessage && params.errorMessage.length > 0) {
+                dateString = params.errorMessage;
+            }
+            else if (params.dateRangeStart) {
+                var startDateString = this._formatDate(params.dateRangeStart);
+                var endDateString = this._formatDate(params.dateRangeEnd);
+                dateString = this._formatHumanDateInfo('temporalExtentHeading', startDateString, endDateString);
+            }
+            else if (!this.hasTemporalExtent(timeFilter, collection)) {
+                dateString = OpenLayers.i18n('unavailableTemporalExtent');
+            }
+            else {
+                dateString = OpenLayers.i18n('temporalExtentNotLoaded');
+            }
         }
 
         if (zAxisFilter && zAxisFilter.hasValue()) {
@@ -70,8 +75,12 @@ Portal.cart.NcWmsInjector = Ext.extend(Portal.cart.BaseInjector, {
         var injectionJson = Portal.cart.NcWmsInjector.superclass.getInjectionJson(collection);
 
         injectionJson.dataFilters = this._getDataFilterEntry(collection);
+
         if (injectionJson.dataFilters.contains(OpenLayers.i18n('temporalExtentNotLoaded'))) {
             injectionJson.errorMessage = OpenLayers.i18n('temporalExtentNotLoaded');
+        }
+        else if (injectionJson.dataFilters.contains(OpenLayers.i18n('invalidTemporalExtent'))) {
+            injectionJson.errorMessage = OpenLayers.i18n('subsetRestrictiveFiltersText');
         }
         injectionJson.isTemporalExtentSubsetted = collection.isTemporalExtentSubsetted;
 

--- a/web-app/js/portal/form/UtcExtentDateTime.js
+++ b/web-app/js/portal/form/UtcExtentDateTime.js
@@ -24,6 +24,10 @@ Portal.form.UtcExtentDateTime = Ext.extend(Ext.ux.form.DateTime, {
             this.onBlur(field);
         }, this);
 
+        this.df.on('invalid', function() {
+            this.fireEvent("invalid", this, undefined);
+        }, this);
+
         this.df.on('blur', function(field, e) {
             this.onBlur(field);
         }, this);
@@ -56,6 +60,10 @@ Portal.form.UtcExtentDateTime = Ext.extend(Ext.ux.form.DateTime, {
         // new Date(this.dateValue) used by superclass doesn't preserve milliseconds
         // on firefox
         return this.dateValue ? this.dateValue.clone() : '';
+    },
+
+    getErrors: function() {
+        return this.df.getErrors();
     },
 
     reset: function() {

--- a/web-app/js/portal/lang/en.js
+++ b/web-app/js/portal/lang/en.js
@@ -72,6 +72,7 @@ OpenLayers.Lang.en = OpenLayers.Util.extend(OpenLayers.Lang.en, {
     selectTimePeriod: 'Select ${direction} Time Period',
     selectMapTimePeriod: 'Move Time on Map',
     unavailableTemporalExtent: "The data collection has no temporal information",
+    invalidTemporalExtent: "Your date range selection has errors and cannot be applied",
 
     // tab titles
     subsetPanelTitle: 'Subset',


### PR DESCRIPTION
Fixes #2680
Fixes https://github.com/aodn/backlog/issues/901

The functionality:
1. `UtcExtentDateTime` datePicker errors now bubble up to `errorMessages` on the ncwmsDateParams filter
1. The error messages manifest differently in the Step 3 filter info and the disabled download button message. The `warningEmptyDownloadMessage` in Step 2 will be shown.
1. There is no longer defaulting to the data collections full extent.
1. The nearest neighbour behaviour remains. If the date component passes validation a download is possible
1. ncWMS filter handling remains as dangerous as ever