### PR TITLE
Test url for ALA autocomplete search

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -234,6 +234,11 @@ knownServers = [
         type: 'ALA'
     ],
     [
+        uri: 'https://biocache-test.ala.org.au/ws',
+        wmsVersion: '1.1.1',
+        type: 'ALA'
+    ],
+    [
         uri: 'http://data2.tpac.org.au/geoserver/ncwms',
         wmsVersion: '1.3.0',
         type: 'ncWMS'
@@ -410,7 +415,7 @@ portal {
 // Atlas of Australia
 ala {
     aodnAlaId = '2003'
-    url = "https://biocache.ala.org.au/ws/autocomplete/search"
+    url = "https://biocache-test.ala.org.au/ws/autocomplete/search"
     index = 'species_habitats:"Marine"'
     gfi_endpoint = "http://biocache.ala.org.au/ws/ogc/getFeatureInfo"
 }


### PR DESCRIPTION
More work on https://github.com/aodn/issues/issues/361

The autocomplete search is now coming from another places and works just fine, while leaving the WMS server to fall over all by itself