### PR TITLE
Handle ClientAbortExceptions

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -511,9 +511,7 @@ log4j.main = {
     debug   'grails.app.job',
         'grails.app.tagLib',
         'grails.app.controller.au.org.emii.portal.SystemController',
-        'grails.plugin.mail',
-        'grails.app.services.au.org.emii.portal.BulkDownloadService',
-        'grails.app.controllers.au.org.emii.portal.DownloadController'
+        'grails.plugin.mail'
 }
 
 /**

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -511,7 +511,9 @@ log4j.main = {
     debug   'grails.app.job',
         'grails.app.tagLib',
         'grails.app.controller.au.org.emii.portal.SystemController',
-        'grails.plugin.mail'
+        'grails.plugin.mail',
+        'grails.app.services.au.org.emii.portal.BulkDownloadService',
+        'grails.app.controllers.au.org.emii.portal.DownloadController'
 }
 
 /**

--- a/grails-app/controllers/au/org/emii/portal/DownloadController.groovy
+++ b/grails-app/controllers/au/org/emii/portal/DownloadController.groovy
@@ -78,15 +78,12 @@ class DownloadController extends RequestProxyingController {
 
         try {
             bulkDownloadService.generateArchiveOfFiles(urls, response.outputStream, request.locale)
-        }
-        catch (Exception e) {
-
-            if (e.cause.class == ClientAbortException) {
-                log.debug "ClientAbortException caught during bulk download.", e
-            }
-            else {
-                log.error "Unhandled exception during bulk download", e
-            }
+        } catch (ClientAbortException e) {
+            log.warn "Client aborted download"
+            log.debug "Caused by:", e
+        } catch (Exception e) {
+            log.error "Unhandled exception during bulk download"
+            log.debug "Caused by:", e
         }
     }
 

--- a/grails-app/services/au/org/emii/portal/BulkDownloadService.groovy
+++ b/grails-app/services/au/org/emii/portal/BulkDownloadService.groovy
@@ -1,6 +1,7 @@
 package au.org.emii.portal
 
 import groovy.time.TimeCategory
+import org.apache.catalina.connector.ClientAbortException
 
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
@@ -30,8 +31,10 @@ class BulkDownloadService {
         try {
             _createZipStream outputStream
             _writeFilesToStream urlList
-        }
-        finally {
+        } catch (ClientAbortException e) {
+            log.warn "Client aborted download"
+            log.debug "Caused by:", e
+        } finally {
 
             try {
                 _closeStream()
@@ -88,10 +91,12 @@ class BulkDownloadService {
             zipStream.putNextEntry new ZipEntry(filenameToUse)
 
             def bytesCopied = copy(streamFromUrl, zipStream, BUFFER_SIZE)
-
             log.debug "Added $bytesCopied Bytes"
-
-            if (!isReportFile) { report.addSuccessfulFileEntry url, filenameToUse, bytesCopied }
+            if (!isReportFile) {
+                report.addSuccessfulFileEntry url, filenameToUse, bytesCopied
+            }
+        } catch (ClientAbortException e) {
+            throw e
         } catch (Exception e) {
 
             log.warn "Error adding file to download archive. URL: '$url'"
@@ -99,7 +104,6 @@ class BulkDownloadService {
 
             if (!streamFromUrl) {
                 def filenameInArchive = filenameToUse + '.failed'
-
                 zipStream.putNextEntry new ZipEntry(filenameInArchive)
                 if (!isReportFile) {
                     report.addFailedFileEntry url, filenameInArchive, "Unable to download data from: '$url'"


### PR DESCRIPTION
Notes:  The changes in DownloadController.groovy correct some borken logic in the exception handling.  This is sufficient to fix things on a local Portal instance.

The additional changes in BulkDownloadService.groovy were necessary to catch the ClientAbortException when the application is deployed to aws.  The reason for this difference is unknown.

In BulkDownloadService we first catch the exception while copying bytes to the ZipStream so that it is not handled by the following ``catch (Exception e)``.  This immediately rethrows the exception to exit the loop writing files to the ZipStream so no further files are attempted. 

