### PR TITLE
Remove AODN:WFS-EXTERNAL-1.0.0-http-get-capabilities from Config.groovy

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -372,8 +372,7 @@ portal {
         ]
 
         wfs = [
-            "OGC:WFS-1.0.0-http-get-capabilities",
-            "AODN:WFS-EXTERNAL-1.0.0-http-get-capabilities"
+            "OGC:WFS-1.0.0-http-get-capabilities"
         ]
 
         dataFile = [
@@ -401,7 +400,7 @@ portal {
         [ 'handler': 'GogoduckDownloadHandler',            'protocol': 'OGC:WPS--gogoduck'                   ],
         [ 'handler': 'DataTrawlerDownloadHandler',         'protocol': 'WWW:DOWNLOAD-1.0-http--csiro-oa-app' ],
         [ 'handler': 'PointCSVDownloadHandler',            'protocol': 'OGC:WPS--gogoduck'                   ],
-        [ 'handler': 'PythonDownloadHandler',              'protocol': 'AODN:WFS-EXTERNAL-1.0.0-http-get-capabilities' ],
+        [ 'handler': 'PythonDownloadHandler',              'protocol': 'OGC:WFS-1.0.0-http-get-capabilities' ],
         [ 'handler': 'BodaacDownloadHandler',              'protocol': 'IMOS:AGGREGATION--bodaac'            ],
         [ 'handler': 'FileListDownloadHandler',            'protocol': 'AODN:FILE-list'                      ],
         [ 'handler': 'ShapeFileDownloadHandler',           'protocol': 'OGC:WFS-1.0.0-http-get-feature--shapefile'],


### PR DESCRIPTION
Reverts https://github.com/aodn/aodn-portal/pull/2565

This is no longer required. Once merged, we can then revert the changes made in https://github.com/aodn/schema-plugins/pull/53 to add the new protocol.