### PR TITLE
Fixes aodn/backlog#1780

### DIFF
--- a/src/test/javascript/portal/details/InfoPanelSpec.js
+++ b/src/test/javascript/portal/details/InfoPanelSpec.js
@@ -9,10 +9,16 @@ describe("Portal.details.InfoPanel", function() {
 
         var mockLinks = [{
             href: "http://www.google.com",
+            name: "",
             title: ""
         }, {
             href: "http://imos.aodn.org.au",
+            name: "",
             title: "Portal"
+        }, {
+            href: "http://example.com",
+            name: "example link",
+            title: ""
         }];
 
         panel = new Portal.details.InfoPanel({
@@ -45,6 +51,8 @@ describe("Portal.details.InfoPanel", function() {
             expect(output).toContain(unnamedResourceName);
             expect(output).toContain('href="http://imos.aodn.org.au"');
             expect(output).toContain('Portal');
+            expect(output).toContain('http://example.com');
+            expect(output).toContain('example link');
         });
     });
 

--- a/web-app/js/portal/details/InfoPanel.js
+++ b/web-app/js/portal/details/InfoPanel.js
@@ -40,11 +40,14 @@ Portal.details.InfoPanel = Ext.extend(Ext.Container, {
         Ext.each(links, function(link) {
             var linkText;
 
-            if (link.title == "") {
-                linkText = String.format('<i>({0})</i>', OpenLayers.i18n('unnamedResourceName'));
+            if (link.title != "") {
+                linkText = link.title;
+            }
+            else if (link.name != "") {
+                linkText = link.name;
             }
             else {
-                linkText = link.title;
+                linkText = String.format('<i>({0})</i>', OpenLayers.i18n('unnamedResourceName'));
             }
 
             linkHtml += String.format('<li><a class="external" href="{0}" target="_blank">{1}</a></li>\n', link.href, linkText);


### PR DESCRIPTION
Due to display issues in GeoNetwork 3, the description element (title)
was moved to the name element when the name element was empty
during the data migration.

To handle both GN2 and GN3 check the name element if the title element is empty
before using unnamed resource literal