### PR TITLE
Always return current year when no date given

### DIFF
--- a/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
+++ b/src/test/javascript/portal/search/FacetedSearchResultsDataViewSpec.js
@@ -54,9 +54,9 @@ describe("Portal.search.FacetedSearchResultsDataView", function() {
             facetedSearchDataView._formatTemporalExtentDateString(testString);
             expect(facetedSearchDataView._parseTemporalExtentDateString).toHaveBeenCalled();
         });
-        it('returns empty string if date is undefined', function() {
+        it('returns current year if date is undefined', function() {
             result = facetedSearchDataView._formatTemporalExtentDateString(undefined);
-            expect(result).toBe("");
+            expect(result).toBe(moment().format("YYYY"));
         });
     });
 

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -337,8 +337,8 @@ initComponent: function() {
     },
 
     _formatTemporalExtentDateString: function(dateString) {
-        var dateFormat = OpenLayers.i18n('temporalExtentDateFormat');
         if (dateString) {
+            var dateFormat = OpenLayers.i18n('temporalExtentDateFormat');
             return this._parseTemporalExtentDateString(dateString).format(dateFormat);
         } else {
             return moment().format("YYYY");

--- a/web-app/js/portal/search/FacetedSearchResultsDataView.js
+++ b/web-app/js/portal/search/FacetedSearchResultsDataView.js
@@ -337,11 +337,11 @@ initComponent: function() {
     },
 
     _formatTemporalExtentDateString: function(dateString) {
+        var dateFormat = OpenLayers.i18n('temporalExtentDateFormat');
         if (dateString) {
-            var dateFormat = OpenLayers.i18n('temporalExtentDateFormat');
             return this._parseTemporalExtentDateString(dateString).format(dateFormat);
         } else {
-            return "";
+            return moment().format("YYYY");
         }
     },
 


### PR DESCRIPTION
This fixes in GN3, collections without <tempExtentEnd> do not show end date as current date in portal (does with GN2)

GN2 search returns the current date when no date is present whereas GN3 does not so we let the Portal take care of it.