### PR TITLE
Fix cookie not being cleared after account delete

### DIFF
--- a/web-app/js/aws-cognito/UserAuthentication.js
+++ b/web-app/js/aws-cognito/UserAuthentication.js
@@ -207,7 +207,7 @@ const UserAuthentication = function () {
       });
     },
     getDetails: function (callback) {
-      _cognitoUser.getUserAttributes((err, result) => {
+      _cognitoUser.getUserAttributes(function(err, result) {
         if (err) {
           callback(err, null);
         } else {
@@ -229,7 +229,7 @@ const UserAuthentication = function () {
       }
     },
     delete: function (callback) {
-      _cognitoUser.deleteUser(callback, function () {
+      _cognitoUser.deleteUser(function() {
         _clearCookies();
         callback();
       });


### PR DESCRIPTION
The `deleteUser` callback is incorrect meaning that the user cookie is never deleted after account deletion.