### PR TITLE
Register dialog: Update links and labels

### DIFF
--- a/grails-app/views/auth/_signUpModal.gsp
+++ b/grails-app/views/auth/_signUpModal.gsp
@@ -36,8 +36,8 @@
                     <g:render template="/auth/industryOptions"/>
                 </select>
             </div>
-            <input type="checkbox" checked id="signUpAgree" name="agree" onclick="document.getElementById('signUpButton').disabled = !event.target.checked">I Agree to the <a target="_blank" href="https://imos.org.au/imostermsofuse0">IMOS Terms & Privacy Conditions</a> and the <a target="_blank" href="https://help.aodn.org.au/user-guide-introduction/aodn-portal/data-use-acknowledgement/">Data Use Acknowledgement</a></input><br>
-            <input type="checkbox" checked id="signUpContact" name="contact">I agree to being contacted</input>
+            <input type="checkbox" checked id="signUpAgree" name="agree" onclick="document.getElementById('signUpButton').disabled = !event.target.checked">I Agree to the <a target="_blank" href="https://imos.org.au/imostermsofuse0">IMOS Terms & Privacy Conditions</a> and the <a target="_blank" href="https://imos.org.au/acknowledging-us">Data Use Acknowledgement</a></input><br>
+            <input type="checkbox" checked id="signUpContact" name="contact">I agree to be contacted for the purposes of providing feedback about user experience, <a target="_blank" href="https://imos.org.au/imostermsofuse0">see more information here.</a></input>
             <div style="margin-top: 15px"><button id="signUpButton" class="auth-submit-btn" type="submit">Register</button></div>
         </form>
     </div>


### PR DESCRIPTION
The "see more information here" link is pointing to the terms of use page until the new page is made available by IMOS Admin.