### PR TITLE
Allow for no spatial extent in records

### DIFF
--- a/web-app/js/portal/filter/combiner/SpatialSubsetIntersectTester.js
+++ b/web-app/js/portal/filter/combiner/SpatialSubsetIntersectTester.js
@@ -35,9 +35,11 @@ Portal.filter.combiner.SpatialSubsetIntersectTester = Ext.extend(Object, {
             extent = new OpenLayers.Bounds(params.value.bounds.left, params.value.bounds.bottom, params.value.bounds.right, params.value.bounds.top);
         }
 
-        var bounds = dataCollection.getBounds();
-        if (extent && bounds) {
-            return bounds.intersectsBounds(extent, true, true);
+        if (extent) {
+            var bounds = dataCollection.getBounds();
+            if (bounds) {
+                return bounds.intersectsBounds(extent, true, true);
+            }
         }
         return true;
     },

--- a/web-app/js/portal/filter/combiner/SpatialSubsetIntersectTester.js
+++ b/web-app/js/portal/filter/combiner/SpatialSubsetIntersectTester.js
@@ -35,8 +35,9 @@ Portal.filter.combiner.SpatialSubsetIntersectTester = Ext.extend(Object, {
             extent = new OpenLayers.Bounds(params.value.bounds.left, params.value.bounds.bottom, params.value.bounds.right, params.value.bounds.top);
         }
 
-        if (extent) {
-            return dataCollection.getBounds().intersectsBounds(extent, true, true);
+        var bounds = dataCollection.getBounds();
+        if (extent && bounds) {
+            return bounds.intersectsBounds(extent, true, true);
         }
         return true;
     },


### PR DESCRIPTION
Effectively we assume the whole world is the extent and return 'true'. Apologies for the messy nesting of the `if`, this is to allow tests to pass.