### PR TITLE
[4003] Update config to allow new protocol

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -388,6 +388,7 @@ portal {
         wms = [
             "OGC:WMS-1.1.1-http-get-map",
             "OGC:WMS-1.3.0-http-get-map",
+            "OGC:WMS",
             "IMOS:NCWMS--proto"
         ]
 


### PR DESCRIPTION
You can test it by connect to https://catalogue-rc.aodn.org.au, this item have set to use OGC:WMS

https://catalogue-rc.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/34a628d2-ff7e-4362-85c0-72960c0056bd/formatters/xml_view_aodn?xsl=none

If you see it appear in the search list then it works